### PR TITLE
Faster elm-analyse support

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -82,6 +82,30 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"accepts": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+			"requires": {
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+				},
+				"mime-types": {
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+					"requires": {
+						"mime-db": "1.40.0"
+					}
+				}
+			}
+		},
 		"after": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -129,6 +153,11 @@
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"array-index": {
 			"version": "1.0.0",
@@ -181,6 +210,15 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+		},
+		"babel-runtime": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
+			"integrity": "sha1-D0F3/9mEku8Tufgj6ZlKAlhMkHg=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.9.5"
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -236,6 +274,30 @@
 			"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
 			"dev": true
 		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.1",
+				"http-errors": "~1.6.2",
+				"iconv-lite": "0.4.19",
+				"on-finished": "~2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "~1.6.15"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				}
+			}
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -288,6 +350,11 @@
 			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
 			"dev": true
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"camelcase": {
 			"version": "2.1.1",
@@ -420,10 +487,70 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
+		"concat-stream": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+			"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+			"requires": {
+				"inherits": "~2.0.1",
+				"readable-stream": "~2.0.0",
+				"typedarray": "~0.0.5"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~1.0.6",
+						"string_decoder": "~0.10.x",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"core-js": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -451,7 +578,6 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -485,6 +611,16 @@
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -507,6 +643,68 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"elm-analyse": {
+			"version": "github:antew/elm-analyse#154736122631e10b36ea406b1442741b97d98b9e",
+			"from": "github:antew/elm-analyse#lsp-hooks-built",
+			"requires": {
+				"express": "4.16.3",
+				"express-ws": "2.0.0",
+				"find": "0.2.7",
+				"fs-extra": "2.0.0",
+				"lodash": "4.17.11",
+				"minimist": "1.2.0",
+				"node-watch": "0.5.5",
+				"opn": "5.4.0",
+				"os-homedir": "1.0.2",
+				"request": "2.88.0",
+				"sums": "0.2.4",
+				"ws": "3.3.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
+					"integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"ultron": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+					"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+				},
+				"ws": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.1.tgz",
+					"integrity": "sha512-8A/uRMnQy8KCQsmep1m7Bk+z/+LIkeF7w+TDMLtX1iZm5Hq9HsUDmgFGaW1ACW5Cj0b2Qo7wCvRhYN2ErUVp/A==",
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
+					}
+				}
+			}
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -548,6 +746,16 @@
 				"es5-ext": "~0.10.14"
 			}
 		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
 		"execspawn": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/execspawn/-/execspawn-1.0.1.tgz",
@@ -561,6 +769,74 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
 			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+		},
+		"express": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"requires": {
+				"accepts": "~1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "~1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "~1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "~1.4.0",
+				"type-is": "~1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				}
+			}
+		},
+		"express-ws": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/express-ws/-/express-ws-2.0.0.tgz",
+			"integrity": "sha1-ltE/pByN6Ppdy/otrKzm9ZQnKIg=",
+			"requires": {
+				"ws": "^1.0.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+					"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+					"requires": {
+						"options": ">=0.0.5",
+						"ultron": "1.0.x"
+					}
+				}
+			}
 		},
 		"extend": {
 			"version": "3.0.2",
@@ -587,6 +863,28 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
+		"finalhandler": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.4.0",
+				"unpipe": "~1.0.0"
+			}
+		},
+		"find": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/find/-/find-0.2.7.tgz",
+			"integrity": "sha1-evvQD48IxbYi+Xzab3FBc9VHuz8=",
+			"requires": {
+				"traverse-chain": "~0.1.0"
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -601,6 +899,16 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-constants": {
 			"version": "1.0.0",
@@ -714,8 +1022,7 @@
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
@@ -741,6 +1048,17 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -798,6 +1116,11 @@
 				}
 			}
 		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -824,6 +1147,11 @@
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
 		},
+		"ipaddr.js": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -838,10 +1166,20 @@
 			"integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
 			"dev": true
 		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -929,8 +1267,7 @@
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-			"dev": true
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"lodash.pad": {
 			"version": "4.5.1",
@@ -955,6 +1292,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"memory-stream": {
 			"version": "0.0.3",
@@ -990,6 +1332,21 @@
 					"dev": true
 				}
 			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
 			"version": "1.37.0",
@@ -1060,8 +1417,7 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"nan": {
 			"version": "2.13.2",
@@ -1072,6 +1428,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
 			"integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
+		},
+		"negotiator": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"next-tick": {
 			"version": "1.0.0",
@@ -1200,6 +1561,11 @@
 				}
 			}
 		},
+		"node-watch": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.5.5.tgz",
+			"integrity": "sha512-z9xN2ibI6P0UylFadN7oMcIMsoTeCENC0rZyRM5MVK9AqzSPx+uGqKG6KMPeC/laOV4wOGZq/GH0PTstRNSqOA=="
+		},
 		"noop-logger": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
@@ -1314,6 +1680,14 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1321,6 +1695,19 @@
 			"requires": {
 				"wrappy": "1"
 			}
+		},
+		"opn": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+			"requires": {
+				"is-wsl": "^1.1.0"
+			}
+		},
+		"options": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+			"integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
@@ -1339,8 +1726,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -1351,6 +1737,11 @@
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
 			}
+		},
+		"parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"path-array": {
 			"version": "1.0.1",
@@ -1366,6 +1757,11 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -1437,6 +1833,15 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
+		"proxy-addr": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+			"requires": {
+				"forwarded": "~0.1.2",
+				"ipaddr.js": "1.9.0"
+			}
+		},
 		"psl": {
 			"version": "1.1.31",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -1460,6 +1865,45 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"depd": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": ">= 1.3.1 < 2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+				}
+			}
 		},
 		"rc": {
 			"version": "1.2.8",
@@ -1485,6 +1929,11 @@
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.9.6",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+			"integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
 		},
 		"request": {
 			"version": "2.88.0",
@@ -1559,6 +2008,37 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.4.0"
+			}
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
+				"send": "0.16.2"
+			}
+		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -1569,6 +2049,11 @@
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
 			"dev": true
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -1636,6 +2121,11 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1666,6 +2156,52 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"sums": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/sums/-/sums-0.2.4.tgz",
+			"integrity": "sha1-14wUOYKX1gT+ZYjcOwPeynuRupM=",
+			"requires": {
+				"babel-runtime": "6.18.0",
+				"concat-stream": "1.5.2",
+				"is-stream": "1.1.0",
+				"through2": "2.0.1",
+				"tmp": "0.0.31"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~1.0.6",
+						"string_decoder": "~0.10.x",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"through2": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+					"integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+					"requires": {
+						"readable-stream": "~2.0.0",
+						"xtend": "~4.0.0"
+					}
+				}
+			}
 		},
 		"tar": {
 			"version": "3.2.1",
@@ -1752,6 +2288,14 @@
 				}
 			}
 		},
+		"tmp": {
+			"version": "0.0.31",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+			"requires": {
+				"os-tmpdir": "~1.0.1"
+			}
+		},
 		"to-buffer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
@@ -1800,6 +2344,11 @@
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
 			"dev": true
 		},
+		"traverse-chain": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+			"integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE="
+		},
 		"tree-sitter": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.14.0.tgz",
@@ -1831,11 +2380,50 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
+		"type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+				},
+				"mime-types": {
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+					"requires": {
+						"mime-db": "1.40.0"
+					}
+				}
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"ultron": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+			"integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unzipper": {
 			"version": "0.8.14",
@@ -1920,10 +2508,20 @@
 			"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
 			"dev": true
 		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/razzeee/elm-language-server"
   },
   "dependencies": {
+    "elm-analyse": "github:antew/elm-analyse#lsp-hooks-built",
     "fast-diff": "^1.2.0",
     "prebuild-install": "^5.2.5",
     "request": "^2.88.0",

--- a/server/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/server/src/providers/diagnostics/diagnosticsProvider.ts
@@ -2,9 +2,9 @@ import {
   Diagnostic,
   DiagnosticSeverity,
   IConnection,
-  TextDocuments,
-  TextDocumentChangeEvent,
   Range,
+  TextDocumentChangeEvent,
+  TextDocuments,
 } from "vscode-languageserver";
 import URI from "vscode-uri";
 import { ElmAnalyseDiagnostics } from "./elmAnalyseDiagnostics";
@@ -70,17 +70,18 @@ export class DiagnosticsProvider {
 
   private sendDiagnostics() {
     const allDiagnostics: Map<string, Diagnostic[]> = new Map();
-    for (let [uri, diagnostics] of this.currentDiagnostics.elmAnalyse) {
+    for (const [uri, diagnostics] of this.currentDiagnostics.elmAnalyse) {
       allDiagnostics.set(uri, diagnostics);
     }
-    for (let [uri, diagnostics] of this.currentDiagnostics.elmMake) {
+
+    for (const [uri, diagnostics] of this.currentDiagnostics.elmMake) {
       allDiagnostics.set(
         uri,
         (allDiagnostics.get(uri) || []).concat(diagnostics),
       );
     }
 
-    for (let [uri, diagnostics] of allDiagnostics) {
+    for (const [uri, diagnostics] of allDiagnostics) {
       this.connection.sendDiagnostics({ uri, diagnostics });
     }
   }
@@ -102,10 +103,10 @@ export class DiagnosticsProvider {
         if (issue.file.startsWith(".")) {
           issue.file = this.elmWorkspaceFolder + issue.file.slice(1);
         }
-        const uri = URI.file(issue.file).toString();
-        const arr = acc.get(uri) || [];
+        const issueUri = URI.file(issue.file).toString();
+        const arr = acc.get(issueUri) || [];
         arr.push(this.elmMakeIssueToDiagnostic(issue));
-        acc.set(uri, arr);
+        acc.set(issueUri, arr);
         return acc;
       },
       new Map(),

--- a/server/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/server/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -24,6 +24,7 @@ export class ElmAnalyseDiagnostics {
     elmWorkspace: URI,
     onNewDiagnostics: INewDiagnosticsCallback,
   ) {
+    this.connection = connection;
     this.elmWorkspace = elmWorkspace;
     this.onNewDiagnostics = onNewDiagnostics;
 

--- a/server/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/server/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -87,7 +87,7 @@ export class ElmAnalyseDiagnostics {
 
     this.filesWithDiagnostics = filesInReport;
 
-    // We you fix the last error in a file it no longer shows up in the report, but
+    // When you fix the last error in a file it no longer shows up in the report, but
     // we still need to clear the error marker for it
     filesThatAreNowFixed.forEach(file => diagnostics.set(file, []));
     this.onNewDiagnostics(diagnostics);

--- a/server/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/server/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -58,7 +58,7 @@ export class ElmAnalyseDiagnostics {
 
     // elm-analyse breaks if there is a trailing slash on the path, it tries to
     // read <dir>//elm.json instead of <div>/elm.json
-    fileLoadingPorts.setup(elmAnalyse, {}, fsPath.replace(/\/?$/, ""));
+    fileLoadingPorts.setup(elmAnalyse, {}, fsPath.replace(/[\\/]?$/, ""));
     elmAnalyse.ports.sendReportValue.subscribe(this.onNewReport);
 
     return elmAnalyse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"sourceMap": true
 	},
 	"include": [
-		"**/src"
+		"src"
 	],
 	"exclude": [
 		"node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"sourceMap": true
 	},
 	"include": [
-		"src"
+		"**/src"
 	],
 	"exclude": [
 		"node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
   "extends": ["tslint:recommended", "tslint-config-prettier"],
   "jsRules": {},
   "rules": {
-    "prettier": true
+    "prettier": [true, ".prettierrc.yaml"]
   },
   "rulesDirectory": ["tslint-plugin-prettier"]
 }


### PR DESCRIPTION
Updates how the diagnostics are run so that `elm-analyse` and `elm make` can run concurrently and report back with diagnostics when they finish, I saw your comment on #13 and I totally agree Rx could make for a nice API for subscribing to these.  I also plan to update elm-analyse to allow requesting a fix from the server as well as batch applying fixes on a file so it would be nice for that too!

This currently relies on a fork I have of elm-analyse that allows passing in the file content on changes rather than needing to read from disk, which allows linting as you type with it.  [elm-analyse#201](https://github.com/stil4m/elm-analyse/pull/201).

![lint-as-you-type](https://user-images.githubusercontent.com/1693421/56874602-ed001900-6a08-11e9-928b-2840386f55a3.gif)

