### PR TITLE
Fix event listeners being overridden

### DIFF
--- a/server/src/providers/astProvider.ts
+++ b/server/src/providers/astProvider.ts
@@ -18,6 +18,7 @@ import {
 import URI from "vscode-uri";
 import { IForest } from "../forest";
 import { Position } from "../position";
+import { DocumentEvents } from '../util/documentEvents';
 import * as utils from "../util/elmUtils";
 
 export class ASTProvider {
@@ -26,7 +27,7 @@ export class ASTProvider {
   private parser: Parser;
   private elmWorkspace: URI;
 
-  constructor(connection: IConnection, forest: IForest, elmWorkspace: URI) {
+  constructor(connection: IConnection, forest: IForest, elmWorkspace: URI, events: DocumentEvents ) {
     this.connection = connection;
     this.forest = forest;
     this.elmWorkspace = elmWorkspace;
@@ -37,8 +38,8 @@ export class ASTProvider {
       this.connection.console.info(error.toString());
     }
 
-    this.connection.onDidChangeTextDocument(this.handleChangeTextDocument);
-    this.connection.onDidCloseTextDocument(this.handleCloseTextDocument);
+    events.on("change", this.handleChangeTextDocument);
+    events.on("close", this.handleCloseTextDocument)
 
     this.initializeWorkspace();
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,6 +2,7 @@ import {
   Connection,
   InitializeParams,
   InitializeResult,
+  TextDocuments,
 } from "vscode-languageserver";
 import URI from "vscode-uri";
 import { CapabilityCalculator } from "./capabilityCalculator";
@@ -18,6 +19,7 @@ import { HoverProvider } from "./providers/hoverProvider";
 import { ReferencesProvider } from "./providers/referencesProvider";
 import { RenameProvider } from "./providers/renameProvider";
 import { WorkspaceSymbolProvider } from "./providers/workspaceSymbolProvider";
+import { DocumentEvents } from './util/documentEvents';
 
 export interface ILanguageServer {
   readonly capabilities: InitializeResult;
@@ -56,12 +58,13 @@ export class Server implements ILanguageServer {
     forest: Forest,
     elmWorkspace: URI,
   ): void {
+    const documentEvents = new DocumentEvents(connection);
     // tslint:disable:no-unused-expression
-    new ASTProvider(connection, forest, elmWorkspace);
+    new ASTProvider(connection, forest, elmWorkspace, documentEvents);
     new FoldingRangeProvider(connection, forest);
     new CompletionProvider(connection, forest);
     new HoverProvider(connection, forest);
-    new DiagnosticsProvider(connection, elmWorkspace);
+    new DiagnosticsProvider(connection, elmWorkspace, documentEvents);
     new ElmFormatProvider(connection, elmWorkspace);
     new DefinitionProvider(connection, forest);
     new ReferencesProvider(connection, forest);

--- a/server/src/util/documentEvents.ts
+++ b/server/src/util/documentEvents.ts
@@ -1,0 +1,31 @@
+import { EventEmitter } from 'events';
+import {
+  Connection,
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveTextDocumentParams,
+} from 'vscode-languageserver';
+
+type DidChangeCallback = ((params: DidChangeTextDocumentParams) => void)
+type DidCloseCallback = ((params: DidCloseTextDocumentParams) => void)
+type DidOpenCallback = ((params: DidOpenTextDocumentParams) => void)
+type DidSaveCallback = ((params: DidSaveTextDocumentParams) => void)
+
+export interface IDocumentEvents{
+  on(event: 'change', listener: DidChangeCallback): this;
+  on(event: 'close', listener: DidCloseCallback): this;
+  on(event: 'open', listener: DidOpenCallback): this;
+  on(event: 'save', listener: DidSaveCallback): this;
+}
+
+export class DocumentEvents extends EventEmitter implements IDocumentEvents {
+  constructor(connection: Connection) {
+    super();
+
+    connection.onDidChangeTextDocument(event => this.emit("change", event))
+    connection.onDidCloseTextDocument(event => this.emit("close", event))
+    connection.onDidOpenTextDocument(event => this.emit("open", event))
+    connection.onDidSaveTextDocument(event => this.emit("save", event))
+  }
+}

--- a/server/src/util/textDocumentEvents.ts
+++ b/server/src/util/textDocumentEvents.ts
@@ -1,0 +1,83 @@
+import {
+	DidChangeTextDocumentParams,
+	DidOpenTextDocumentParams,
+	DidSaveTextDocumentParams,
+	TextDocument,
+	TextDocumentContentChangeEvent,
+	DidCloseTextDocumentParams,
+} from 'vscode-languageserver';
+import { EventEmitter } from 'ws';
+import { DocumentEvents } from './documentEvents';
+
+type DidChangeCallback = ((document: TextDocument) => void)
+type DidCloseCallback = ((document: TextDocument) => void)
+type DidOpenCallback = ((document: TextDocument) => void)
+type DidSaveCallback = ((document: TextDocument) => void)
+
+export interface ITextDocumentEvents {
+	on(event: 'change', listener: DidChangeCallback): this;
+	on(event: 'close', listener: DidCloseCallback): this;
+	on(event: 'open', listener: DidOpenCallback): this;
+	on(event: 'save', listener: DidSaveCallback): this;
+}
+
+interface IUpdateableDocument extends TextDocument {
+	update(event: TextDocumentContentChangeEvent, version: number): void;
+}
+
+// This is loosely based on https://github.com/Microsoft/vscode-languageserver-node/blob/73180893ca/server/src/main.ts#L124
+// With some simplifications and the ability to support multiple listeners
+export class TextDocumentEvents extends EventEmitter implements ITextDocumentEvents {
+	public static isUpdateableDocument(value: TextDocument): value is IUpdateableDocument {
+		return typeof (value as IUpdateableDocument).update === "function";
+	}
+
+	private documents: { [uri: string]: TextDocument };
+
+	constructor(events: DocumentEvents) {
+		super();
+		this.documents = {};
+
+		events.on('open', (event: DidOpenTextDocumentParams) => {
+			const td = event.textDocument;
+			const document = TextDocument.create(td.uri, td.languageId, td.version, td.text);
+			this.documents[event.textDocument.uri] = document;
+			const frozen = Object.freeze({ document });
+			this.emit('open', frozen.document);
+		});
+
+		events.on('change', (event: DidChangeTextDocumentParams) => {
+			const td = event.textDocument;
+			const changes = event.contentChanges;
+			const last: TextDocumentContentChangeEvent | undefined = changes.length > 0 ? changes[changes.length - 1] : undefined;
+			if (last) {
+				const document = this.documents[td.uri];
+				if (document && TextDocumentEvents.isUpdateableDocument(document)) {
+					if (td.version === null || td.version === void 0) {
+						throw new Error(`Received document change event for ${td.uri} without valid version identifier`);
+					}
+					document.update(last, td.version);
+					const frozen = Object.freeze({ document });
+					this.emit('change', frozen.document)
+				}
+			}
+
+		});
+		events.on('save', (event: DidSaveTextDocumentParams) => {
+			const document = this.documents[event.textDocument.uri];
+			if (document) {
+				const frozen = Object.freeze({ document });
+				this.emit('save', frozen.document);
+			}
+		});
+		events.on('close', (event: DidCloseTextDocumentParams) => {
+			const document = this.documents[event.textDocument.uri];
+			if (document) {
+				delete this.documents[event.textDocument.uri];
+				const frozen = Object.freeze({ document });
+				this.emit('close', frozen.document)
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
Allows multiple event listeners for notification events in the document (open, close, save, change).

In vscode-languageserver the built in events for open, close, change, etc, can only have one handler attached, adding a new one overwrites the old one.  For requests that require a response from the language server that is only reasonable, it avoids needing to merge responses from multiple listeners and whatnot, but for notification events that don't require a response it is not as nice to work with.

A second problem this solves is allowing partial updates in the astProvider.  The TextDocuments class from vscode-languageserver almost fits the bill, but when a document changes it applies the changes directly and wouldn't allow tree-sitter to incrementally parse.

You can now listen on low level events with the `DocumentEvents` class, which is useful for the astProvider, and higher-level TextDocument events with `TextDocumentEvents`