### PR TITLE
elm-analyse: Fix cache directory location

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -650,7 +650,7 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"elm-analyse": {
-			"version": "github:antew/elm-analyse#154736122631e10b36ea406b1442741b97d98b9e",
+			"version": "github:antew/elm-analyse#c922cedb673af8332f3fd00f64fbd23b471b060c",
 			"from": "github:antew/elm-analyse#lsp-hooks-built",
 			"requires": {
 				"express": "4.16.3",


### PR DESCRIPTION
Previously it based the cache path off of the current working directory, which may not always be the same as the project root, it now uses the folder where elm.json is as the base for the cache path.

I updated the PR over in https://github.com/stil4m/elm-analyse/pull/201 as well.

Closes #22