### PR TITLE
Clear make diagnostics on file when no errors are left (#29)

### DIFF
--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -99,27 +99,7 @@ export class DiagnosticsProvider {
 
     this.elmAnalyseDiagnostics.updateFile(uri, text);
 
-    const compilerErrors: IElmIssue[] = [];
-    compilerErrors.push(
-      ...(await this.elmMakeDiagnostics.createDiagnostics(uri)),
-    );
-
-    const diagnostics: Map<string, Diagnostic[]> = compilerErrors.reduce(
-      (acc, issue) => {
-        // If provided path is relative, make it absolute
-        if (issue.file.startsWith(".")) {
-          issue.file = this.elmWorkspaceFolder + issue.file.slice(1);
-        }
-        const issueUri = URI.file(issue.file).toString();
-        const arr = acc.get(issueUri) || [];
-        arr.push(this.elmMakeIssueToDiagnostic(issue));
-        acc.set(issueUri, arr);
-        return acc;
-      },
-      new Map(),
-    );
-
-    this.currentDiagnostics.elmMake = diagnostics;
+    this.currentDiagnostics.elmMake = await this.elmMakeDiagnostics.createDiagnostics(uri);
     this.sendDiagnostics();
   }
 

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -22,12 +22,22 @@ export class ElmMakeDiagnostics {
     this.settings = settings;
   }
 
-  public createDiagnostics = async (filePath: URI): Promise<IElmIssue[]> => {
+  public createDiagnostics = async (filePath: URI): Promise<Map<string, Diagnostic[]>> => {
     return await this.checkForErrors(
       this.connection,
       this.elmWorkspaceFolder.fsPath,
       filePath.fsPath,
-    );
+    ).then(issues =>
+      {
+        if (issues.length > 0){
+          return this.issuesToDiagnosticMap(issues);
+        } else {
+          return new Map([
+            [filePath.toString(), []]
+          ]);
+        }
+      }
+      )
   };
 
   private async checkForErrors(
@@ -148,6 +158,29 @@ export class ElmMakeDiagnostics {
         return DiagnosticSeverity.Error;
     }
   }
+
+  private issuesToDiagnosticMap(issues: IElmIssue[]): Map<string, Diagnostic[]> {
+    return issues.reduce(
+      (acc, issue) =>
+      {
+        const uri = this.getUriFromIssue(issue);
+        const diagnostic = this.elmMakeIssueToDiagnostic(issue);
+        const arr = acc.get(uri) || [];
+        arr.push(diagnostic);
+        acc.set(uri, diagnostic);
+        return acc;
+      }, new Map()
+    );
+  }
+  
+
+  private getUriFromIssue(issue: IElmIssue): string {
+    if (issue.file.startsWith(".")) {
+      issue.file = this.elmWorkspaceFolder + issue.file.slice(1);
+    }
+    return URI.file(issue.file).toString();
+  }
+
 
   private elmMakeIssueToDiagnostic(issue: IElmIssue): Diagnostic {
     const lineRange: Range = Range.create(

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -22,22 +22,20 @@ export class ElmMakeDiagnostics {
     this.settings = settings;
   }
 
-  public createDiagnostics = async (filePath: URI): Promise<Map<string, Diagnostic[]>> => {
+  public createDiagnostics = async (
+    filePath: URI,
+  ): Promise<Map<string, Diagnostic[]>> => {
     return await this.checkForErrors(
       this.connection,
       this.elmWorkspaceFolder.fsPath,
       filePath.fsPath,
-    ).then(issues =>
-      {
-        if (issues.length > 0){
-          return this.issuesToDiagnosticMap(issues);
-        } else {
-          return new Map([
-            [filePath.toString(), []]
-          ]);
-        }
+    ).then(issues => {
+      if (issues.length > 0) {
+        return this.issuesToDiagnosticMap(issues);
+      } else {
+        return new Map([[filePath.toString(), []]]);
       }
-      )
+    });
   };
 
   private async checkForErrors(
@@ -159,20 +157,18 @@ export class ElmMakeDiagnostics {
     }
   }
 
-  private issuesToDiagnosticMap(issues: IElmIssue[]): Map<string, Diagnostic[]> {
-    return issues.reduce(
-      (acc, issue) =>
-      {
-        const uri = this.getUriFromIssue(issue);
-        const diagnostic = this.elmMakeIssueToDiagnostic(issue);
-        const arr = acc.get(uri) || [];
-        arr.push(diagnostic);
-        acc.set(uri, diagnostic);
-        return acc;
-      }, new Map()
-    );
+  private issuesToDiagnosticMap(
+    issues: IElmIssue[],
+  ): Map<string, Diagnostic[]> {
+    return issues.reduce((acc, issue) => {
+      const uri = this.getUriFromIssue(issue);
+      const diagnostic = this.elmMakeIssueToDiagnostic(issue);
+      const arr = acc.get(uri) || [];
+      arr.push(diagnostic);
+      acc.set(uri, arr);
+      return acc;
+    }, new Map());
   }
-  
 
   private getUriFromIssue(issue: IElmIssue): string {
     if (issue.file.startsWith(".")) {
@@ -180,7 +176,6 @@ export class ElmMakeDiagnostics {
     }
     return URI.file(issue.file).toString();
   }
-
 
   private elmMakeIssueToDiagnostic(issue: IElmIssue): Diagnostic {
     const lineRange: Range = Range.create(


### PR DESCRIPTION
This should fix issue #29. I don't think there are any other consequences to doing this, although it might change if we start running `elm-make` on unsaved buffers.