### PR TITLE
Add fallbacks for workspace/configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,21 @@ This extension contributes the following settings:
 
 To enable support with [coc.nvim](https://github.com/neoclide/coc.nvim), run `:CocConfig` and add the language server config below.
 
+If needed, you can set the paths to `elm` and `elm-format` with the `elmPath` and `elmFormatPath` variables.
+
 ```
 {
   "languageserver": {
-    "elm-ls": {
+    "elmLS": {
       "command": "elm-ls",
       "args": ["--stdio"],
       "filetypes": ["elm"],
       "rootPatterns": ["elm.json"],
       "initializationOptions": {
-        "runtime": "node"
-      },
-      "settings": {}
+        "runtime": "node",
+        "elmPath": "elm",
+        "elmFormatPath": "elm-format"
+      }
     }
   }
 }
@@ -49,3 +52,9 @@ For [ALE](https://github.com/w0rp/ale) support.
 | [Vim-Plug](https://github.com/junegunn/vim-plug)  | `Plug 'antew/vim-elm-language-server'`                                                        |
 | [Vundle](https://github.com/VundleVim/Vundle.vim) | `Plugin 'antew/vim-elm-language-server'`                                                      |
 | [Pathogen](https://github.com/tpope/vim-pathogen) | <pre>cd ~/.vim/bundle<br>git clone https://github.com/antew/vim-elm-language-server.git</pre> |
+
+If needed, you can set the paths to `elm` and `elm-format` with these variables:
+```
+let g:ale_elm_ls_elm_format_path = "/path/to/elm-format"
+let g:ale_elm_ls_elm_path = "/path/to/elm"
+```

--- a/server/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/server/src/providers/diagnostics/diagnosticsProvider.ts
@@ -7,6 +7,7 @@ import {
 } from "vscode-languageserver";
 import URI from "vscode-uri";
 import { DocumentEvents } from "../../util/documentEvents";
+import { Settings } from "../../util/settings";
 import { TextDocumentEvents } from "../../util/textDocumentEvents";
 import { ElmAnalyseDiagnostics } from "./elmAnalyseDiagnostics";
 import { ElmMakeDiagnostics } from "./elmMakeDiagnostics";
@@ -34,11 +35,13 @@ export class DiagnosticsProvider {
     elmMake: Map<string, Diagnostic[]>;
     elmAnalyse: Map<string, Diagnostic[]>;
   };
+  private settings: Settings;
 
   constructor(
     private connection: IConnection,
     private elmWorkspaceFolder: URI,
     documentEvents: DocumentEvents,
+    settings: Settings
   ) {
     this.getDiagnostics = this.getDiagnostics.bind(this);
     this.newElmAnalyseDiagnostics = this.newElmAnalyseDiagnostics.bind(this);
@@ -46,10 +49,12 @@ export class DiagnosticsProvider {
     this.events = new TextDocumentEvents(documentEvents);
 
     this.connection = connection;
+    this.settings = settings;
     this.elmWorkspaceFolder = elmWorkspaceFolder;
     this.elmMakeDiagnostics = new ElmMakeDiagnostics(
       connection,
       elmWorkspaceFolder,
+      settings
     );
 
     this.elmAnalyseDiagnostics = new ElmAnalyseDiagnostics(

--- a/server/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/server/src/providers/diagnostics/diagnosticsProvider.ts
@@ -41,7 +41,7 @@ export class DiagnosticsProvider {
     private connection: IConnection,
     private elmWorkspaceFolder: URI,
     documentEvents: DocumentEvents,
-    settings: Settings
+    settings: Settings,
   ) {
     this.getDiagnostics = this.getDiagnostics.bind(this);
     this.newElmAnalyseDiagnostics = this.newElmAnalyseDiagnostics.bind(this);
@@ -54,7 +54,7 @@ export class DiagnosticsProvider {
     this.elmMakeDiagnostics = new ElmMakeDiagnostics(
       connection,
       elmWorkspaceFolder,
-      settings
+      settings,
     );
 
     this.elmAnalyseDiagnostics = new ElmAnalyseDiagnostics(

--- a/server/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/server/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -15,9 +15,11 @@ export class ElmMakeDiagnostics {
   constructor(
     private connection: IConnection,
     private elmWorkspaceFolder: URI,
+    private settings: Settings,
   ) {
     this.connection = connection;
     this.elmWorkspaceFolder = elmWorkspaceFolder;
+    this.settings = settings;
   }
 
   public createDiagnostics = async (filePath: URI): Promise<IElmIssue[]> => {
@@ -33,7 +35,7 @@ export class ElmMakeDiagnostics {
     rootPath: string,
     filename: string,
   ): Promise<IElmIssue[]> {
-    const settings = await Settings.getSettings(connection);
+    const settings = await this.settings.getSettings(connection);
 
     return new Promise((resolve, reject) => {
       const makeCommand: string = settings.elmPath;

--- a/server/src/providers/documentFormatingProvider.ts
+++ b/server/src/providers/documentFormatingProvider.ts
@@ -13,15 +13,18 @@ import { TextDocumentEvents } from "../util/textDocumentEvents";
 
 export class DocumentFormattingProvider {
   private events: TextDocumentEvents;
+  private settings: Settings;
 
   constructor(
     private connection: IConnection,
     private elmWorkspaceFolder: URI,
     documentEvents: DocumentEvents,
+    settings: Settings,
   ) {
     this.connection = connection;
     this.elmWorkspaceFolder = elmWorkspaceFolder;
     this.events = new TextDocumentEvents(documentEvents);
+    this.settings = settings;
 
     this.connection.onDocumentFormatting(this.handleFormattingRequest);
   }
@@ -30,7 +33,7 @@ export class DocumentFormattingProvider {
     params: DocumentFormattingParams,
   ) => {
     try {
-      const settings = await Settings.getSettings(this.connection);
+      const settings = await this.settings.getSettings(this.connection);
       const text = this.events.get(params.textDocument.uri);
       if (!text) {
         this.connection.console.error("Can't find file for formatting.");

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -42,11 +42,20 @@ export class Server implements ILanguageServer {
       params.initializationOptions.elmWorkspace || elmWorkspaceFallback,
     );
 
-    const settings = new Settings(params.capabilities, params.initializationOptions);
+    const settings = new Settings(
+      params.capabilities,
+      params.initializationOptions,
+    );
 
     if (elmWorkspace) {
       connection.console.info(`initializing - folder: "${elmWorkspace}"`);
-      this.registerProviders(connection, forest, elmWorkspace, imports, settings);
+      this.registerProviders(
+        connection,
+        forest,
+        elmWorkspace,
+        imports,
+        settings,
+      );
     } else {
       connection.console.info(`No workspace.`);
     }
@@ -63,7 +72,7 @@ export class Server implements ILanguageServer {
     forest: Forest,
     elmWorkspace: URI,
     imports: Imports,
-    settings: Settings
+    settings: Settings,
   ): void {
     const documentEvents = new DocumentEvents(connection);
     // tslint:disable:no-unused-expression
@@ -72,7 +81,12 @@ export class Server implements ILanguageServer {
     new CompletionProvider(connection, forest, imports);
     new HoverProvider(connection, forest, imports);
     new DiagnosticsProvider(connection, elmWorkspace, documentEvents, settings);
-    new DocumentFormattingProvider(connection, elmWorkspace, documentEvents, settings);
+    new DocumentFormattingProvider(
+      connection,
+      elmWorkspace,
+      documentEvents,
+      settings,
+    );
     new DefinitionProvider(connection, forest, imports);
     new ReferencesProvider(connection, forest, imports);
     new DocumentSymbolProvider(connection, forest);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -21,6 +21,7 @@ import { ReferencesProvider } from "./providers/referencesProvider";
 import { RenameProvider } from "./providers/renameProvider";
 import { WorkspaceSymbolProvider } from "./providers/workspaceSymbolProvider";
 import { DocumentEvents } from "./util/documentEvents";
+import { Settings } from "./util/settings";
 
 export interface ILanguageServer {
   readonly capabilities: InitializeResult;
@@ -41,9 +42,11 @@ export class Server implements ILanguageServer {
       params.initializationOptions.elmWorkspace || elmWorkspaceFallback,
     );
 
+    const settings = new Settings(params.capabilities, params.initializationOptions);
+
     if (elmWorkspace) {
       connection.console.info(`initializing - folder: "${elmWorkspace}"`);
-      this.registerProviders(connection, forest, elmWorkspace, imports);
+      this.registerProviders(connection, forest, elmWorkspace, imports, settings);
     } else {
       connection.console.info(`No workspace.`);
     }
@@ -60,6 +63,7 @@ export class Server implements ILanguageServer {
     forest: Forest,
     elmWorkspace: URI,
     imports: Imports,
+    settings: Settings
   ): void {
     const documentEvents = new DocumentEvents(connection);
     // tslint:disable:no-unused-expression
@@ -67,8 +71,8 @@ export class Server implements ILanguageServer {
     new FoldingRangeProvider(connection, forest);
     new CompletionProvider(connection, forest, imports);
     new HoverProvider(connection, forest, imports);
-    new DiagnosticsProvider(connection, elmWorkspace, documentEvents);
-    new DocumentFormattingProvider(connection, elmWorkspace, documentEvents);
+    new DiagnosticsProvider(connection, elmWorkspace, documentEvents, settings);
+    new DocumentFormattingProvider(connection, elmWorkspace, documentEvents, settings);
     new DefinitionProvider(connection, forest, imports);
     new ReferencesProvider(connection, forest, imports);
     new DocumentSymbolProvider(connection, forest);

--- a/server/src/util/settings.ts
+++ b/server/src/util/settings.ts
@@ -1,4 +1,4 @@
-import { IConnection } from "vscode-languageserver";
+import { ClientCapabilities, IConnection } from "vscode-languageserver";
 
 export interface IClientSettings {
   elmPath: string;
@@ -6,12 +6,28 @@ export interface IClientSettings {
 }
 
 export class Settings {
-  public static getSettings(
-    connection: IConnection,
-  ): Thenable<IClientSettings> {
-    const result = connection.workspace.getConfiguration({
-      section: "elmLS",
-    });
-    return result;
+  private params: IClientSettings;
+  private capabilities: ClientCapabilities;
+  constructor(capabilities: ClientCapabilities, params: IClientSettings) {
+    this.capabilities = capabilities;
+    this.params = params;
+  }
+
+  public getSettings(connection: IConnection): Thenable<IClientSettings> {
+    const supportsConfig = this.capabilities &&
+      this.capabilities.workspace &&
+      this.capabilities.workspace.configuration;
+
+    if (!supportsConfig) {
+      return Promise.resolve(this.params);
+    }
+
+    return connection.workspace
+      .getConfiguration({
+        section: "elmLS",
+      }).then(settings => 
+        // Allow falling back to the preset params if we cant get the 
+        // settings from the workspace
+        Object.assign({}, this.params, settings));
   }
 }

--- a/server/src/util/settings.ts
+++ b/server/src/util/settings.ts
@@ -14,7 +14,8 @@ export class Settings {
   }
 
   public getSettings(connection: IConnection): Thenable<IClientSettings> {
-    const supportsConfig = this.capabilities &&
+    const supportsConfig =
+      this.capabilities &&
       this.capabilities.workspace &&
       this.capabilities.workspace.configuration;
 
@@ -25,9 +26,11 @@ export class Settings {
     return connection.workspace
       .getConfiguration({
         section: "elmLS",
-      }).then(settings => 
-        // Allow falling back to the preset params if we cant get the 
+      })
+      .then(settings =>
+        // Allow falling back to the preset params if we cant get the
         // settings from the workspace
-        Object.assign({}, this.params, settings));
+        Object.assign({}, this.params, settings),
+      );
   }
 }


### PR DESCRIPTION
This allows falling back to getting the `elmPath` and `elmFormatPath` from the `initializationOptions` so that support for coc.vim and ALE is seamless.

I updated the readme with new instructions for coc.vim, and pushed a new version of https://github.com/antew/vim-elm-language-server that allows configuring the paths with ALE.

I had to add a capability check on `workspace/configuration` for ALE, the promise would never resolve or reject with clients that didn't respond to the message, so there is a short-circuit for that case.
