### PR TITLE
Define "bin" for "npm link" to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If needed, you can set the paths to `elm` and `elm-format` with the `elmPath` an
 {
   "languageserver": {
     "elmLS": {
-      "command": "elm-ls",
+      "command": "elm-language-server",
       "args": ["--stdio"],
       "filetypes": ["elm"],
       "rootPatterns": ["elm.json"],

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "watch": "tsc -b -w",
     "lint": "tslint -p tsconfig.json",
     "tslint-check": "tslint-config-prettier-check ./tslint.json"
+  },
+  "bin": {
+    "elm-language-server": "./out/index.js"
   }
 }


### PR DESCRIPTION
The user still needs to execute the compile step before. `npm link` will link the output and make it executable under the given name.

Note: This will/would use the name `elm-language-server`. The plugins are using `elm-lsp` and the `README.md` has `elm-ls` in it. We choose a name and fix it. Your choice @Razzeee  ;)