### PR TITLE
Fix global elm analyse result being replaced by the result of a singl…

### DIFF
--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -65,7 +65,6 @@ export class DiagnosticsProvider {
 
     this.currentDiagnostics = { elmMake: new Map(), elmAnalyse: new Map() };
 
-    this.events.on("open", this.getDiagnostics);
     this.events.on("change", this.getDiagnostics);
     this.events.on("save", this.getDiagnostics);
   }


### PR DESCRIPTION
…e file

Before this, if you initialize your workspace you will only get elm-analyse results for the current file, as the result the server pushes will get overwritten.

@antew 
not sure this is the ideal fix, but the problem seems to be gone afterwards.