### PR TITLE
README: Duplicate configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,4 @@ For [ALE](https://github.com/w0rp/ale) support.
 | [Vundle](https://github.com/VundleVim/Vundle.vim) | `Plugin 'antew/vim-elm-language-server'`                                                      |
 | [Pathogen](https://github.com/tpope/vim-pathogen) | <pre>cd ~/.vim/bundle<br>git clone https://github.com/antew/vim-elm-language-server.git</pre> |
 
-If needed, you can set the paths to `elm` and `elm-format` with these variables:
-
-```
-let g:ale_elm_ls_elm_format_path = "/path/to/elm-format"
-let g:ale_elm_ls_elm_path = "/path/to/elm"
-```
+If needed, you can set the paths to `elm` and `elm-format`. The configuration can be [found here](https://github.com/antew/vim-elm-language-server#configuration)


### PR DESCRIPTION
I'd link to the configuration of `vim-elm-language-server` to avoid multiple places and potentially outdated documentation. This will hopefully be merged into ale itself in the next future.