### PR TITLE
Elm-analyse code actions

### DIFF
--- a/server/src/providers/codeActionProvider.ts
+++ b/server/src/providers/codeActionProvider.ts
@@ -1,0 +1,27 @@
+import {
+  CodeAction,
+  CodeActionParams,
+  ExecuteCommandParams,
+  IConnection,
+} from "vscode-languageserver";
+import { ElmAnalyseDiagnostics } from "./diagnostics/elmAnalyseDiagnostics";
+
+export class CodeActionProvider {
+  private connection: IConnection;
+  private elmAnalyse: ElmAnalyseDiagnostics;
+
+  constructor(connection: IConnection, elmAnalyse: ElmAnalyseDiagnostics) {
+    this.connection = connection;
+    this.elmAnalyse = elmAnalyse;
+    this.connection.onCodeAction(this.onCodeAction);
+    this.connection.onExecuteCommand(this.onExecuteCommand);
+  }
+
+  private onCodeAction(params: CodeActionParams): CodeAction[] {
+    return this.elmAnalyse.onCodeAction(params);
+  }
+
+  private async onExecuteCommand(params: ExecuteCommandParams) {
+    return this.elmAnalyse.onExecuteCommand(params);
+  }
+}

--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -20,6 +20,7 @@ export class CapabilityCalculator {
       // Incremental sync is disabled for now due to not being able to get the
       // old text in ASTProvider
       // textDocumentSync: TextDocumentSyncKind.Incremental,
+      codeActionProvider: true,
       codeLensProvider: {
         resolveProvider: true,
       },
@@ -28,6 +29,9 @@ export class CapabilityCalculator {
       documentFormattingProvider: true,
       documentRangeFormattingProvider: true,
       documentSymbolProvider: true,
+      executeCommandProvider: {
+          commands: ["elm-analyse-fixer"]
+      },
       foldingRangeProvider: true,
       hoverProvider: true,
       referencesProvider: true,

--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -3,6 +3,7 @@ import {
   ServerCapabilities,
   TextDocumentSyncKind,
 } from "vscode-languageserver";
+import * as ElmAnalyseDiagnostics from "./providers/diagnostics/elmAnalyseDiagnostics";
 
 export class CapabilityCalculator {
   private clientCapabilities: ClientCapabilities;
@@ -30,7 +31,7 @@ export class CapabilityCalculator {
       documentRangeFormattingProvider: true,
       documentSymbolProvider: true,
       executeCommandProvider: {
-          commands: ["elm-analyse-fixer"]
+        commands: [ElmAnalyseDiagnostics.CODE_ACTION_ELM_ANALYSE],
       },
       foldingRangeProvider: true,
       hoverProvider: true,

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -13,6 +13,8 @@ export class CodeActionProvider {
   constructor(connection: IConnection, elmAnalyse: ElmAnalyseDiagnostics) {
     this.connection = connection;
     this.elmAnalyse = elmAnalyse;
+    this.onCodeAction = this.onCodeAction.bind(this);
+    this.onExecuteCommand = this.onExecuteCommand.bind(this);
     this.connection.onCodeAction(this.onCodeAction);
     this.connection.onExecuteCommand(this.onExecuteCommand);
   }

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -5,8 +5,7 @@ import {
   Range,
   TextDocument,
 } from "vscode-languageserver";
-import { URI } from "vscode-uri";
-import { DocumentEvents } from "../../util/documentEvents";
+import URI from "vscode-uri";
 import { Settings } from "../../util/settings";
 import { TextDocumentEvents } from "../../util/textDocumentEvents";
 import { ElmAnalyseDiagnostics } from "./elmAnalyseDiagnostics";
@@ -40,14 +39,14 @@ export class DiagnosticsProvider {
   constructor(
     private connection: IConnection,
     private elmWorkspaceFolder: URI,
-    documentEvents: DocumentEvents,
+    events: TextDocumentEvents,
     settings: Settings,
     elmAnalyse: ElmAnalyseDiagnostics,
   ) {
     this.getDiagnostics = this.getDiagnostics.bind(this);
     this.newElmAnalyseDiagnostics = this.newElmAnalyseDiagnostics.bind(this);
     this.elmMakeIssueToDiagnostic = this.elmMakeIssueToDiagnostic.bind(this);
-    this.events = new TextDocumentEvents(documentEvents);
+    this.events = events;
     this.elmAnalyseDiagnostics = elmAnalyse;
 
     this.connection = connection;

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -42,11 +42,13 @@ export class DiagnosticsProvider {
     private elmWorkspaceFolder: URI,
     documentEvents: DocumentEvents,
     settings: Settings,
+    elmAnalyse: ElmAnalyseDiagnostics,
   ) {
     this.getDiagnostics = this.getDiagnostics.bind(this);
     this.newElmAnalyseDiagnostics = this.newElmAnalyseDiagnostics.bind(this);
     this.elmMakeIssueToDiagnostic = this.elmMakeIssueToDiagnostic.bind(this);
     this.events = new TextDocumentEvents(documentEvents);
+    this.elmAnalyseDiagnostics = elmAnalyse;
 
     this.connection = connection;
     this.settings = settings;
@@ -57,17 +59,15 @@ export class DiagnosticsProvider {
       settings,
     );
 
-    this.elmAnalyseDiagnostics = new ElmAnalyseDiagnostics(
-      connection,
-      elmWorkspaceFolder,
-      this.newElmAnalyseDiagnostics,
-    );
-
     this.currentDiagnostics = { elmMake: new Map(), elmAnalyse: new Map() };
 
     this.events.on("open", this.getDiagnostics);
     this.events.on("change", this.getDiagnostics);
     this.events.on("save", this.getDiagnostics);
+    this.elmAnalyseDiagnostics.on(
+      "new-diagnostics",
+      this.newElmAnalyseDiagnostics,
+    );
   }
 
   private newElmAnalyseDiagnostics(diagnostics: Map<string, Diagnostic[]>) {

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -5,7 +5,7 @@ import {
   Range,
   TextDocument,
 } from "vscode-languageserver";
-import URI from "vscode-uri";
+import { URI } from "vscode-uri";
 import { Settings } from "../../util/settings";
 import { TextDocumentEvents } from "../../util/textDocumentEvents";
 import { ElmAnalyseDiagnostics } from "./elmAnalyseDiagnostics";
@@ -27,6 +27,7 @@ export interface IElmIssue {
 }
 
 export class DiagnosticsProvider {
+  private connection: IConnection;
   private events: TextDocumentEvents;
   private elmMakeDiagnostics: ElmMakeDiagnostics;
   private elmAnalyseDiagnostics: ElmAnalyseDiagnostics;
@@ -34,11 +35,10 @@ export class DiagnosticsProvider {
     elmMake: Map<string, Diagnostic[]>;
     elmAnalyse: Map<string, Diagnostic[]>;
   };
-  private settings: Settings;
 
   constructor(
-    private connection: IConnection,
-    private elmWorkspaceFolder: URI,
+    connection: IConnection,
+    elmWorkspaceFolder: URI,
     events: TextDocumentEvents,
     settings: Settings,
     elmAnalyse: ElmAnalyseDiagnostics,
@@ -50,8 +50,6 @@ export class DiagnosticsProvider {
     this.elmAnalyseDiagnostics = elmAnalyse;
 
     this.connection = connection;
-    this.settings = settings;
-    this.elmWorkspaceFolder = elmWorkspaceFolder;
     this.elmMakeDiagnostics = new ElmMakeDiagnostics(
       connection,
       elmWorkspaceFolder,

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -33,7 +33,7 @@ const fixableErrors = [
   "DuplicateImport",
 ];
 const ELM_ANALYSE = "elm-analyse";
-export const CODE_ACTION_ELM_ANALYSE = "elmLanguageServer.elmAnalyseFixer";
+export const CODE_ACTION_ELM_ANALYSE = "elmLS.elmAnalyseFixer";
 
 export interface IElmAnalyseEvents {
   on(event: "new-report", diagnostics: Map<string, Diagnostic[]>): this;

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -14,7 +14,7 @@ import {
   TextDocument,
   TextEdit,
 } from "vscode-languageserver";
-import URI from "vscode-uri";
+import { URI } from "vscode-uri";
 import * as Diff from "../../util/diff";
 import { IClientSettings, Settings } from "../../util/settings";
 import { TextDocumentEvents } from "../../util/textDocumentEvents";

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -174,8 +174,8 @@ export class ElmAnalyseDiagnostics extends EventEmitter {
         );
       };
 
-      elmAnalyse.ports.onFixQuick.send(code);
       elmAnalyse.ports.sendFixedFile.subscribe(fixedFileCallback);
+      elmAnalyse.ports.onFixQuick.send(code);
     });
   }
 

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -33,7 +33,7 @@ const fixableErrors = [
   "DuplicateImport",
 ];
 const ELM_ANALYSE = "elm-analyse";
-export const CODE_ACTION_ELM_ANALYSE = "elm-analyse-fixer";
+export const CODE_ACTION_ELM_ANALYSE = "elmLanguageServer.elmAnalyseFixer";
 
 export interface IElmAnalyseEvents {
   on(event: "new-report", diagnostics: Map<string, Diagnostic[]>): this;

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -1,32 +1,49 @@
 import { ElmApp, Message, Report } from "elm-analyse/ts/domain";
+import { EventEmitter } from "events";
 import * as fs from "fs";
 import * as path from "path";
 import util from "util";
 import {
+  CodeAction,
+  CodeActionKind,
+  CodeActionParams,
   Diagnostic,
   DiagnosticSeverity,
+  ExecuteCommandParams,
   IConnection,
+  WorkspaceEdit,
 } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 
 const readFile = util.promisify(fs.readFile);
-type INewDiagnosticsCallback = (diagnostics: Map<string, Diagnostic[]>) => void;
+const fixableErrors = [
+  "UnnecessaryParens",
+  "UnusedImport",
+  "UnusedImportedVariable",
+  "UnusedImportAlias",
+  "UnusedPatternVariable",
+  "UnusedTypeAlias",
+  "MultiLineRecordFormatting",
+  "DropConsOfItemAndList",
+  "DuplicateImport",
+];
 
-export class ElmAnalyseDiagnostics {
+export interface IElmAnalyseEvents {
+  on(event: "new-report", diagnostics: Map<string, Diagnostic[]>): this;
+}
+
+export class ElmAnalyseDiagnostics extends EventEmitter {
   private connection: IConnection;
   private elmWorkspace: URI;
   private elmAnalyse: Promise<ElmApp>;
   private filesWithDiagnostics: Set<string> = new Set();
-  private onNewDiagnostics: INewDiagnosticsCallback;
 
-  constructor(
-    connection: IConnection,
-    elmWorkspace: URI,
-    onNewDiagnostics: INewDiagnosticsCallback,
-  ) {
+  constructor(connection: IConnection, elmWorkspace: URI) {
+    super();
     this.connection = connection;
     this.elmWorkspace = elmWorkspace;
-    this.onNewDiagnostics = onNewDiagnostics;
+    this.onExecuteCommand = this.onExecuteCommand.bind(this);
+    this.onCodeAction = this.onCodeAction.bind(this);
 
     this.elmAnalyse = this.setupElmAnalyse();
   }
@@ -41,6 +58,68 @@ export class ElmAnalyseDiagnostics {
     });
   }
 
+  public onCodeAction(params: CodeActionParams): CodeAction[] {
+    const { uri } = params.textDocument;
+    if (params.context.diagnostics && params.context.diagnostics.length) {
+      return params.context.diagnostics
+        .filter(d => d.source === "elm-analyse" && this.isFixable(d))
+        .map(d => {
+          const command = {
+            arguments: [uri, d],
+            command: "elm-analyse-fixer",
+            title: d.message.split("\n")[0],
+          };
+          const action: CodeAction = {
+            command,
+            diagnostics: [d],
+            kind: CodeActionKind.QuickFix,
+            title: d.message.split("\n")[0],
+          };
+          return action;
+        });
+    }
+    return [];
+  }
+
+  public async onExecuteCommand(params: ExecuteCommandParams) {
+    try {
+      if (params.command === "elm-analyse-fixer") {
+        const elmAnalyse = await this.elmAnalyse;
+        if (params.arguments && params.arguments.length === 2) {
+          const uri: URI = params.arguments[0];
+          const diagnostic: Diagnostic = params.arguments[1];
+          const code: number =
+            typeof diagnostic.code === "number" ? diagnostic.code : -1;
+          if (code !== -1) {
+            return new Promise(resolve => {
+              elmAnalyse.ports.onFixQuick.send(code);
+              elmAnalyse.ports.sendFixedFile.subscribe(fixedFile => {
+                const edit: WorkspaceEdit = {
+                  changes: {
+                    [uri.toString()]: [
+                      {
+                        newText: fixedFile.content,
+                        range: {
+                          end: { line: 9999999, character: 0 },
+                          start: { line: 0, character: 0 },
+                        },
+                      },
+                    ],
+                  },
+                };
+
+                return this.connection.workspace.applyEdit(edit);
+              });
+            });
+          }
+        }
+      }
+    } catch (e) {
+      this.connection.console.error(
+        `Error executing codeAction. ${e.message} ${e.stack}`,
+      );
+    }
+  }
   private async setupElmAnalyse(): Promise<ElmApp> {
     const fsPath = this.elmWorkspace.fsPath;
     const elmJson = await readFile(path.join(fsPath, "elm.json"), {
@@ -76,6 +155,7 @@ export class ElmAnalyseDiagnostics {
     this.connection.console.log(
       `Received new elm-analyse report with ${report.messages.length} messages`,
     );
+
     // When publishing diagnostics it looks like you have to publish
     // for one URI at a time, so this groups all of the messages for
     // each file and sends them as a batch
@@ -103,8 +183,12 @@ export class ElmAnalyseDiagnostics {
     // When you fix the last error in a file it no longer shows up in the report, but
     // we still need to clear the error marker for it
     filesThatAreNowFixed.forEach(file => diagnostics.set(file, []));
-    this.onNewDiagnostics(diagnostics);
+    this.emit("new-diagnostics", diagnostics);
   };
+
+  private isFixable(diagnostic: Diagnostic): boolean {
+    return fixableErrors.some(e => diagnostic.message.indexOf(e) > -1);
+  }
 
   private messageToDiagnostic(message: Message): Diagnostic {
     if (message.type === "FileLoadFailed") {

--- a/src/providers/documentFormatingProvider.ts
+++ b/src/providers/documentFormatingProvider.ts
@@ -3,7 +3,7 @@ import {
   IConnection,
   TextEdit,
 } from "vscode-languageserver";
-import URI from "vscode-uri";
+import { URI } from "vscode-uri";
 import * as Diff from "../util/diff";
 import { execCmd } from "../util/elmUtils";
 import { Settings } from "../util/settings";

--- a/src/server.ts
+++ b/src/server.ts
@@ -230,8 +230,20 @@ export class Server implements ILanguageServer {
   ): void {
     this.initialize(connection, forest, elmWorkspace, imports, parser);
     const documentEvents = new DocumentEvents(connection);
-    const textDocumentEvents = new TextDocumentEvents(documentEvents)
-    const elmAnalyse = new ElmAnalyseDiagnostics(connection, elmWorkspace, textDocumentEvents);
+    const textDocumentEvents = new TextDocumentEvents(documentEvents);
+    const documentFormatingProvider = new DocumentFormattingProvider(
+      connection,
+      elmWorkspace,
+      textDocumentEvents,
+      settings,
+    );
+    const elmAnalyse = new ElmAnalyseDiagnostics(
+      connection,
+      elmWorkspace,
+      textDocumentEvents,
+      settings,
+      documentFormatingProvider,
+    );
     // tslint:disable:no-unused-expression
     new ASTProvider(connection, forest, documentEvents, imports, parser);
     new FoldingRangeProvider(connection, forest);
@@ -243,12 +255,6 @@ export class Server implements ILanguageServer {
       textDocumentEvents,
       settings,
       elmAnalyse,
-    );
-    new DocumentFormattingProvider(
-      connection,
-      elmWorkspace,
-      textDocumentEvents,
-      settings,
     );
     new DefinitionProvider(connection, forest, imports);
     new ReferencesProvider(connection, forest, imports);

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { CodeLensProvider } from "./providers/codeLensProvider";
 import { CompletionProvider } from "./providers/completionProvider";
 import { DefinitionProvider } from "./providers/definitionProvider";
 import { DiagnosticsProvider } from "./providers/diagnostics/diagnosticsProvider";
+import { ElmAnalyseDiagnostics } from "./providers/diagnostics/elmAnalyseDiagnostics"
 import { DocumentFormattingProvider } from "./providers/documentFormatingProvider";
 import { DocumentSymbolProvider } from "./providers/documentSymbolProvider";
 import { FoldingRangeProvider } from "./providers/foldingProvider";
@@ -227,12 +228,13 @@ export class Server implements ILanguageServer {
   ): void {
     this.initialize(connection, forest, elmWorkspace, imports, parser);
     const documentEvents = new DocumentEvents(connection);
+    const elmAnalyse = new ElmAnalyseDiagnostics(connection, elmWorkspace)
     // tslint:disable:no-unused-expression
     new ASTProvider(connection, forest, documentEvents, imports, parser);
     new FoldingRangeProvider(connection, forest);
     new CompletionProvider(connection, forest, imports);
     new HoverProvider(connection, forest, imports);
-    new DiagnosticsProvider(connection, elmWorkspace, documentEvents, settings);
+    new DiagnosticsProvider(connection, elmWorkspace, documentEvents, settings, elmAnalyse);
     new DocumentFormattingProvider(
       connection,
       elmWorkspace,

--- a/src/util/diff.ts
+++ b/src/util/diff.ts
@@ -1,0 +1,54 @@
+import diff from "fast-diff";
+import { Range, TextEdit } from "vscode-languageserver";
+// Given two strings (`before`, `after`), return a list of all substrings
+// that appear in `after` but not in `before`, and the positions of each
+// of the substrings within `after`.
+export function getTextRangeChanges(before: string, after: string): TextEdit[] {
+  const newRanges: TextEdit[] = [];
+  let lineNumber = 0;
+  let column = 0;
+
+  const parts = diff(before, after);
+
+  // Loop over every part, keeping track of:
+  // 1. The current line no. and column in the `after` string
+  // 2. Character ranges for all "added" parts in the `after` string
+  parts.forEach(part => {
+    const startLineNumber = lineNumber;
+    const startColumn = column;
+    if (part[0] === 0 || part[0] === -1) {
+      // Split the part into lines. Loop through these lines to find
+      // the line no. and column at the end of this part.
+      const substring = part[1];
+      const lines = substring.split("\n");
+      lines.forEach((line, lineIndex) => {
+        // The first `line` is actually just a continuation of the last line
+        if (lineIndex === 0) {
+          column += line.length;
+          // All other lines come after a line break.
+        } else if (lineIndex > 0) {
+          lineNumber += 1;
+          column = line.length;
+        }
+      });
+    }
+
+    if (part[0] === 1) {
+      newRanges.push({
+        newText: part[1],
+        range: Range.create(
+          startLineNumber,
+          startColumn,
+          startLineNumber,
+          startColumn,
+        ),
+      });
+    } else if (part[0] === -1) {
+      newRanges.push({
+        newText: "",
+        range: Range.create(startLineNumber, startColumn, lineNumber, column),
+      });
+    }
+  });
+  return newRanges;
+}

--- a/src/util/textDocumentEvents.ts
+++ b/src/util/textDocumentEvents.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 import {
   DidChangeTextDocumentParams,
   DidCloseTextDocumentParams,
@@ -6,7 +7,6 @@ import {
   TextDocument,
   TextDocumentContentChangeEvent,
 } from "vscode-languageserver";
-import { EventEmitter } from "ws";
 import { DocumentEvents } from "./documentEvents";
 
 type DidChangeCallback = (document: TextDocument) => void;


### PR DESCRIPTION
I think this is about ready now, it adds in a code action provider that supports elm-analyse.  
The upstream set of changes for `elm-analyse` is https://github.com/stil4m/elm-analyse/pull/209.

![fixer](https://user-images.githubusercontent.com/1693421/59164627-65b0c580-8add-11e9-9265-b8b462607364.gif)

Features:
- `elm-analyse` messages that can be fixed now show up as code actions in the editor!
- `elm-format` is run on the fixed text

Changes:
- Moved common diffing code into `src/util/diff.ts`, it's now used by the `documentFormattingProvder` and `elmAnalyseDiagnostics` to generate changelists for the document so I moved it over there and have both importing it.
- Moved `elmAnalyseDiagnostics` up a level in the code so that it can be given to the `diagnosticsProvider` and the `codeActionProvider`.
- Broke out a block of code in the `documentFormattingProvider` into a public function for formatting some text, this way elm-analyse can make use of `elm-format` as well and we can apply the already formatted fix to the document.


Misc:
- I noticed that the `TextDocumentEvents` was importing `EventEmitter` from `ws`, so I switched it to use it from `events` like the other files.