### PR TITLE
Configurable if diagnostics run on change

### DIFF
--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -66,8 +66,13 @@ export class DiagnosticsProvider {
     this.currentDiagnostics = { elmMake: new Map(), elmAnalyse: new Map() };
 
     this.events.on("open", this.getDiagnostics);
-    this.events.on("change", this.getDiagnostics);
     this.events.on("save", this.getDiagnostics);
+
+    settings.getSettings(connection).then(({ diagnosticsOn }) => {
+      if (diagnosticsOn === "change") {
+        this.events.on("change", document => this.getDiagnostics(document));
+      }
+    });
   }
 
   private newElmAnalyseDiagnostics(diagnostics: Map<string, Diagnostic[]>) {


### PR DESCRIPTION
Settings `diagnosticsOn` is set to "change" by default. Otherwise it will not register the change handler for diagnostics. I'm open for a different name or type. I went with string as a value, because I'm not sure about types in vim or other editor configurations.