### PR TITLE
Consistent string concatenation, IFolder interface instead of inlined types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@ This is the language server implementation for the Elm programming language.
 
 You will need to install `elm`, `elm-test` and `elm-format`, to get all diagnostics.
 
-```shell
-npm install -g elm
-npm install -g elm-test
-npm install -g elm-format
+```sh
+npm install -g elm elm-test elm-format
 ```
 
 Or use them from your `node_modules`, if you want to do that you need to set the paths, via the settings.
 
 ## Features
 
-Supports elm 0.19
+Supports Elm 0.19
 
 | Feature          | Description                                                                                                                                         |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -24,7 +22,7 @@ Supports elm 0.19
 | completions      | Show completions for the current file and snippets                                                                                                  |
 | definitions      | Enables you to jump to the definition of a type alias, module, custom type or function                                                              |
 | documentSymbols  | Identifies all symbols in a document.                                                                                                               |
-| folding          | Let's you fold the code on certain elm constructs                                                                                                   |
+| folding          | Let's you fold the code on certain Elm constructs                                                                                                   |
 | hover            | Shows type annotations and documentation for a type alias, module, custom type or function                                                          |
 | references       | Lists all references to a type alias, module, custom type or function                                                                               |
 | rename           | Enables you to rename a type alias, module, custom type or function                                                                                 |
@@ -35,9 +33,9 @@ Supports elm 0.19
 This server contributes the following settings:
 
 - `elmLS.trace.server`: Enable/disable trace logging of client and server communication
-- `elmLS.elmPath`: The path to your elm executeable.
-- `elmLS.elmFormatPath`: The path to your elm-format executeable.
-- `elmLS.elmTestPath`: The path to your elm-test executeable.
+- `elmLS.elmPath`: The path to your `elm` executable.
+- `elmLS.elmFormatPath`: The path to your `elm-format` executable.
+- `elmLS.elmTestPath`: The path to your `elm-test` executable.
 
 ## Installation
 
@@ -67,7 +65,6 @@ npm run compile
 npm link
 ```
 
-
 ## Editor Support
 
 | Editor  | Setup Instructions                                                 | Source Code                                                       | Diagnostics        | Formatting         | CodeLenses         | Completions        | Definitions        | DocumentSymbols    | Folding            | Hover              | References         | Rename             | Workspace Symbols  |
@@ -89,7 +86,7 @@ To enable support with [coc.nvim](https://github.com/neoclide/coc.nvim), run `:C
 
 If needed, you can set the paths to `elm`, `elm-test` and `elm-format` with the `elmPath`, `elmTestPath` and `elmFormatPath` variables.
 
-```
+```json
 {
   "languageserver": {
     "elmLS": {
@@ -126,14 +123,14 @@ If needed, you can set the paths to `elm`, `elm-test` and `elm-format`. The conf
 
 First install [kak-lsp](https://github.com/ul/kak-lsp), and enable it in the kakrc. One way would be to add these lines to your .config/kak/kakrc file:
 
-```
+```sh
 eval %sh{kak-lsp --kakoune -s $kak_session}
 lsp-enable
 ```
 
-Then, assuming installation of elm-language-server, elm-format, and elm-test, add this section to your .config/kak-lsp/kak-lsp.toml file:
+Then, assuming installation of `elm-language-server`, `elm-format`, and `elm-test`, add this section to your `.config/kak-lsp/kak-lsp.toml` file:
 
-```
+```toml
 [language.elm]
 filetypes = ["elm"]
 roots = ["elm.json"]

--- a/src/imports.ts
+++ b/src/imports.ts
@@ -190,7 +190,7 @@ export class Imports implements IImports {
         case "TypeAlias":
         case "Type":
           result.push({
-            alias: importPrefix + "." + element.name,
+            alias: `${importPrefix}.${element.name}`,
             fromModuleName: moduleNameNode.text,
             fromUri: uri,
             node: element.syntaxNode,

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -306,7 +306,7 @@ export class CompletionProvider {
                     result.push(
                       this.createFunctionParameterCompletion(
                         hint,
-                        child.text + "." + element.field,
+                        `${child.text}.${element.field}`,
                       ),
                     );
                   });

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -122,7 +122,7 @@ export class DiagnosticsProvider {
     );
     return Diagnostic.create(
       lineRange,
-      issue.overview + " - " + issue.details.replace(/\[\d+m/g, ""),
+      `${issue.overview} - ${issue.details.replace(/\[\d+m/g, "")}`,
       this.severityStringToDiagnosticSeverity(issue.type),
       undefined,
       "Elm",

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -134,10 +134,9 @@ export class ElmAnalyseDiagnostics {
       code: message.id,
       // Clean up the error message a bit, removing the end of the line, e.g.
       // "Record has only one field. Use the field's type or introduce a Type. At ((14,5),(14,20))"
-      message:
-        message.data.description.split(/at .+$/i)[0] +
-        "\n" +
-        `See https://stil4m.github.io/elm-analyse/#/messages/${message.type}`,
+      message: `${
+        message.data.description.split(/at .+$/i)[0]
+      }\nSee https://stil4m.github.io/elm-analyse/#/messages/${message.type}`,
       range,
       severity: DiagnosticSeverity.Warning,
       source: "elm-analyse",

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -52,7 +52,7 @@ export class ElmMakeDiagnostics {
       const cwd: string = rootPath;
       let make: cp.ChildProcess;
       if (utils.isWindows) {
-        filename = '"' + filename + '"';
+        filename = `"${filename}"`;
       }
       const args = [
         "make",
@@ -64,7 +64,7 @@ export class ElmMakeDiagnostics {
       ];
       const testOrMakeCommand = isTestFile ? testCommand : makeCommand;
       if (utils.isWindows) {
-        make = cp.exec(testOrMakeCommand + " " + args.join(" "), { cwd });
+        make = cp.exec(`${testOrMakeCommand} ${args.join(" ")}`, { cwd });
       } else {
         make = cp.spawn(testOrMakeCommand, args, { cwd });
       }
@@ -86,9 +86,7 @@ export class ElmMakeDiagnostics {
             const problems = error.problems.map((problem: any) => ({
               details: problem.message
                 .map((message: any) =>
-                  typeof message === "string"
-                    ? message
-                    : "#" + message.string + "#",
+                  typeof message === "string" ? message : `#${message.string}#`,
                 )
                 .join(""),
               file: error.path,
@@ -195,7 +193,7 @@ export class ElmMakeDiagnostics {
     );
     return Diagnostic.create(
       lineRange,
-      issue.overview + " - " + issue.details.replace(/\[\d+m/g, ""),
+      `${issue.overview} - ${issue.details.replace(/\[\d+m/g, "")}`,
       this.severityStringToDiagnosticSeverity(issue.type),
       undefined,
       "Elm",

--- a/src/util/elmUtils.ts
+++ b/src/util/elmUtils.ts
@@ -52,7 +52,7 @@ export function execCmd(
   const executingCmd: any = new Promise((resolve, reject) => {
     const cmdArguments = options ? options.cmdArguments : [];
 
-    const fullCommand = cmd + " " + (cmdArguments || []).join(" ");
+    const fullCommand = `${cmd} ${(cmdArguments || []).join(" ")}`;
     childProcess = cp.exec(
       fullCommand,
       { cwd: elmRootPath.fsPath },
@@ -108,7 +108,7 @@ export function execCmd(
             if (cmdWasNotFound) {
               const notFoundText = options ? options.notFoundText : "";
               connection.window.showErrorMessage(
-                `${cmdName} is not available in your path. ` + notFoundText,
+                `${cmdName} is not available in your path. ${notFoundText}`,
               );
             } else {
               connection.window.showErrorMessage(error.message);

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -83,7 +83,7 @@ export class References {
                         a =>
                           a.fromModuleName === moduleNameNode.text &&
                           a.type === "Function" &&
-                          (a.alias.endsWith("." + functionNameNode.text) ||
+                          (a.alias.endsWith(`.${functionNameNode.text}`) ||
                             a.alias === functionNameNode.text),
                       );
                       if (needsToBeChecked.length > 0) {
@@ -188,7 +188,7 @@ export class References {
                           a.fromModuleName === moduleNameNode.text &&
                           (a.type === "Type" || a.type === "TypeAlias") &&
                           (a.alias.endsWith(
-                            "." + typeOrTypeAliasNameNode.text,
+                            `.${typeOrTypeAliasNameNode.text}`,
                           ) ||
                             a.alias === typeOrTypeAliasNameNode.text),
                       );

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,8 @@
   "rules": {
     "prettier": [true, ".prettierrc.yaml"],
     "cognitive-complexity": false,
-    "no-big-function": false
+    "no-big-function": false,
+    "prefer-template": true
   },
   "rulesDirectory": ["tslint-plugin-prettier"]
 }


### PR DESCRIPTION
- Added missing syntax highlighting in README
- Consistent string concatenation with TSLint rule for it
- Added `IFolder` interface to extract repeated type.

This addresses #69 and #70 