### PR TITLE
Diagnostics provider will prefer elm make errors

### DIFF
--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -74,15 +74,16 @@ export class DiagnosticsProvider {
 
   private sendDiagnostics() {
     const allDiagnostics: Map<string, Diagnostic[]> = new Map();
-    for (const [uri, diagnostics] of this.currentDiagnostics.elmAnalyse) {
+
+    for (const [uri, diagnostics] of this.currentDiagnostics.elmMake) {
       allDiagnostics.set(uri, diagnostics);
     }
 
-    for (const [uri, diagnostics] of this.currentDiagnostics.elmMake) {
-      allDiagnostics.set(
-        uri,
-        (allDiagnostics.get(uri) || []).concat(diagnostics),
-      );
+    for (const [uri, diagnostics] of this.currentDiagnostics.elmAnalyse) {
+      const currentDiagnostics = allDiagnostics.get(uri) || [];
+      if (currentDiagnostics.length === 0) {
+        allDiagnostics.set(uri, diagnostics);
+      }
     }
 
     for (const [uri, diagnostics] of allDiagnostics) {
@@ -94,11 +95,14 @@ export class DiagnosticsProvider {
     const uri = URI.parse(document.uri);
     const text = document.getText();
 
-    this.elmAnalyseDiagnostics.updateFile(uri, text);
-
     this.currentDiagnostics.elmMake = await this.elmMakeDiagnostics.createDiagnostics(
       uri,
     );
+
+    if (this.currentDiagnostics.elmMake.get(uri.toString()) === []) {
+      this.elmAnalyseDiagnostics.updateFile(uri, text);
+    }
+
     this.sendDiagnostics();
   }
 


### PR DESCRIPTION
There is elm make and elm-analyse. When there compile errors, most elm analyse warnings don't make a lot of sense. The user has to fix the compile error first. That's why this optimization will trigger and show elm-analyse only when there are no compile error for a file.