### PR TITLE
Fix crash with `UnnecessaryPortModule` diagnostic from elm-analyse

### DIFF
--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -263,12 +263,13 @@ export class ElmAnalyseDiagnostics extends EventEmitter {
       };
     }
 
-    const [
-      lineStart,
-      colStart,
-      lineEnd,
-      colEnd,
-    ] = message.data.properties.range;
+    const rangeDefaults = [1, 1, 2, 1];
+    const [lineStart, colStart, lineEnd, colEnd] =
+      (message.data &&
+        message.data.properties &&
+        message.data.properties.range) ||
+      rangeDefaults;
+
     const range = {
       end: { line: lineEnd - 1, character: colEnd - 1 },
       start: { line: lineStart - 1, character: colStart - 1 },


### PR DESCRIPTION
On the `UnnecessaryPortModule` error it doesn't include a range, but the code didn't guard against it being gone properly.

I checked the other messages that elm-analyse generates and we handle this is the only other one without a range that we don't handle already.