### PR TITLE
Fix for yarn global install

### DIFF
--- a/src/util/rebuilder.ts
+++ b/src/util/rebuilder.ts
@@ -31,9 +31,10 @@ function fetchPrebuild(
 ): Promise<void | Error> {
   // tslint:disable-next-line: no-console
   console.info(`Fetching ${name}`);
-  const pkgRoot: string = path.resolve(
-    path.join(__dirname, "../../node_modules", name),
-  );
+  // Using require.resolve so that this works for both npm and yarn global installs, with
+  // npm our node modules are in `<npm global dir/lib/elm-language-server/node_modules/`, but in yarn they
+  // can be in a different location, like `<yarn global dir>/node_modules/tree-sitter`
+  const pkgRoot: string = path.dirname(require.resolve(`${name}/package.json`));
   // tslint:disable-next-line non-literal-require
   const pkg: {
     name: string;


### PR DESCRIPTION
I was talking with @romariolopezc on slack and he found that the install worked with npm but not with yarn, I took a look and it was happening because with yarn's global installs the tree-sitter and tree-sitter-elm packages can be at the root of the global node_modules folder rather than inside the elm-language-server/node_modules/ folder.

I updated it to use `require.resolve` to find the tree-sitter and tree-sitter-elm package directories so that we can use node's module resolution to find it.

This should be the fix for the root cause of #58 