### PR TITLE
Generate unique IDs for each fixer so that they can be spawned multiple times

### DIFF
--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import { ElmApp, FixedFile, Message, Report } from "elm-analyse/ts/domain";
 import { EventEmitter } from "events";
 import * as fs from "fs";
@@ -33,8 +34,9 @@ const fixableErrors = [
   "DuplicateImport",
 ];
 const ELM_ANALYSE = "elm-analyse";
-export const CODE_ACTION_ELM_ANALYSE = "elmLS.elmAnalyseFixer";
-export const CODE_ACTION_ELM_ANALYSE_FIX_ALL = "elmLS.elmAnalyseFixer.fixAll";
+const RANDOM_ID = crypto.randomBytes(16).toString("hex");
+export const CODE_ACTION_ELM_ANALYSE = `elmLS.elmAnalyseFixer-${RANDOM_ID}`;
+export const CODE_ACTION_ELM_ANALYSE_FIX_ALL = `elmLS.elmAnalyseFixer.fixAll-${RANDOM_ID}`;
 
 export interface IElmAnalyseEvents {
   on(event: "new-report", diagnostics: Map<string, Diagnostic[]>): this;


### PR DESCRIPTION
This should be the fix for that 7hoenix was seeing on Slack, with a message like

```
[Info  - 8:47:19 AM] Done parsing all files.
[Error - 8:47:19 AM] Server initialization failed.
Error: command 'elmLS.elmAnalyseFixer' already exists
    at d.registerCommand (/Applications/Visual Studio Code 2.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:497:447)
    at Object.registerCommand (/Applications/Visual Studio Code 2.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:716:422)
```

I didn't realize that they had to be unique per instance! https://github.com/Microsoft/vscode-languageserver-node/issues/333