### PR TITLE
ASTProvider - Use normal file path rather than file:// protocol when reading a file

### DIFF
--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -5,6 +5,7 @@ import {
   IConnection,
   VersionedTextDocumentIdentifier,
 } from "vscode-languageserver";
+import { URI } from "vscode-uri";
 import Parser, { Point, SyntaxNode, Tree } from "web-tree-sitter";
 import { IForest } from "../forest";
 import { IImports } from "../imports";
@@ -31,7 +32,10 @@ export class ASTProvider {
     const document: VersionedTextDocumentIdentifier = params.textDocument;
     let tree: Tree | undefined = this.forest.getTree(document.uri);
     if (tree === undefined) {
-      const fileContent: string = readFileSync(document.uri, "utf8");
+      const fileContent: string = readFileSync(
+        URI.parse(document.uri).fsPath,
+        "utf8",
+      );
       tree = this.parser.parse(fileContent);
     }
 


### PR DESCRIPTION
nonpop on Slack shared this stack trace
```
{ Error: ENOENT: no such file or directory, open 'file:///THE_FILE_IM_EDITING'
    at Object.openSync (fs.js:436:3)
    at Object.module.(anonymous function) [as openSync] (ELECTRON_ASAR.js:160:31)
    at Object.readFileSync (fs.js:341:35)
    at Object.fs.readFileSync (ELECTRON_ASAR.js:580:40)
    at ASTProvider.<anonymous> (/home/nonpop/.vscode/extensions/elmtooling.elm-ls-vscode-0.4.1/server/out/providers/astProvider.js:24:42)
    at Generator.next (<anonymous>)
    at /home/nonpop/.vscode/extensions/elmtooling.elm-ls-vscode-0.4.1/server/out/providers/astProvider.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/home/nonpop/.vscode/extensions/elmtooling.elm-ls-vscode-0.4.1/server/out/providers/astProvider.js:3:12)
    at DocumentEvents.ASTProvider.handleChangeTextDocument (/home/nonpop/.vscode/extensions/elmtooling.elm-ls-vscode-0.4.1/server/out/providers/astProvider.js:19:53)
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path:
   'file:///THE_FILE_IM_EDITING' }
```

They said the file does exist at that path, so the only thing I can think of is that node says support for the `file://` protocol is experimental, so we may have better luck using the `fsPath` instead.

```
    /**
     * Synchronously reads the entire contents of a file.
     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
     * URL support is _experimental_.
     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
     * If a flag is not provided, it defaults to `'r'`.
     */
    function readFileSync(path: PathLike | number, options: { encoding: string; flag?: string; } | string): string;
```
From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/fs.d.ts#L1299