### PR TITLE
Cleaned up forest.ts, fixed typo

### DIFF
--- a/src/forest.ts
+++ b/src/forest.ts
@@ -29,53 +29,29 @@ export interface IForest {
 export class Forest implements IForest {
   public treeIndex: ITreeContainer[] = [];
 
-  constructor() {
-    this.treeIndex = new Array();
-  }
-
   public getTree(uri: string): Tree | undefined {
     const result = this.treeIndex.find(tree => tree.uri === uri);
-    if (result) {
-      return result.tree;
-    } else {
-      return undefined;
-    }
+
+    return result && result.tree;
   }
 
   public getExposingByModuleName(moduleName: string): Exposing | undefined {
     const result = this.treeIndex.find(tree => tree.moduleName === moduleName);
-    if (result) {
-      return result.exposing;
-    } else {
-      return undefined;
-    }
+    return result && result.exposing;
   }
 
   public getTreeByModuleName(moduleName: string): Tree | undefined {
     const result = this.treeIndex.find(tree => tree.moduleName === moduleName);
-    if (result) {
-      return result.tree;
-    } else {
-      return undefined;
-    }
+
+    return result && result.tree;
   }
 
   public getByModuleName(moduleName: string): ITreeContainer | undefined {
-    const result = this.treeIndex.find(tree => tree.moduleName === moduleName);
-    if (result) {
-      return result;
-    } else {
-      return undefined;
-    }
+    return this.treeIndex.find(tree => tree.moduleName === moduleName);
   }
 
   public getByUri(uri: string): ITreeContainer | undefined {
-    const result = this.treeIndex.find(tree => tree.uri === uri);
-    if (result) {
-      return result;
-    } else {
-      return undefined;
-    }
+    return this.treeIndex.find(tree => tree.uri === uri);
   }
 
   public setTree(
@@ -90,24 +66,19 @@ export class Forest implements IForest {
 
       const existingTree = this.treeIndex.findIndex(a => a.uri === uri);
 
+      const treeContainer = {
+        exposing,
+        moduleName,
+        referenced,
+        tree,
+        uri,
+        writable,
+      };
+
       if (existingTree === -1) {
-        this.treeIndex.push({
-          exposing,
-          moduleName,
-          referenced,
-          tree,
-          uri,
-          writable,
-        });
+        this.treeIndex.push(treeContainer);
       } else {
-        this.treeIndex[existingTree] = {
-          exposing,
-          moduleName,
-          referenced,
-          tree,
-          uri,
-          writable,
-        };
+        this.treeIndex[existingTree] = treeContainer;
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@
 import * as Path from "path";
 import {
   createConnection,
-  DidChangeConfigurationParams,
   IConnection,
   InitializeParams,
   InitializeResult,
@@ -15,9 +14,7 @@ import { ILanguageServer } from "./server";
 export type Runtime = "node" | "electron";
 const connection: IConnection = createConnection(ProposedFeatures.all);
 
-connection.onDidChangeConfiguration((params: DidChangeConfigurationParams) => {
-  return undefined;
-});
+connection.onDidChangeConfiguration(params => undefined);
 
 connection.onInitialize(
   async (params: InitializeParams): Promise<InitializeResult> => {

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -238,7 +238,7 @@ export class CompletionProvider {
     return {
       documentation: {
         kind: MarkupKind.Markdown,
-        value: markdownDocumentation ? markdownDocumentation : "",
+        value: markdownDocumentation || "",
       },
       kind,
       label,
@@ -252,7 +252,7 @@ export class CompletionProvider {
     return {
       documentation: {
         kind: MarkupKind.Markdown,
-        value: markdownDocumentation ? markdownDocumentation : "",
+        value: markdownDocumentation || "",
       },
       kind,
       label,
@@ -378,10 +378,11 @@ export class CompletionProvider {
     return {
       documentation: {
         kind: MarkupKind.Markdown,
-        value: markdownDocumentation ? markdownDocumentation : "",
+        value: markdownDocumentation || "",
       },
-      insertText:
-        snippetText instanceof Array ? snippetText.join("\n") : snippetText,
+      insertText: Array.isArray(snippetText)
+        ? snippetText.join("\n")
+        : snippetText,
       insertTextFormat: InsertTextFormat.Snippet,
       kind: CompletionItemKind.Snippet,
       label,

--- a/src/providers/diagnostics/elmAnalyseDiagnostics.ts
+++ b/src/providers/diagnostics/elmAnalyseDiagnostics.ts
@@ -145,7 +145,7 @@ export class ElmAnalyseDiagnostics extends EventEmitter {
 
         if (code === -1) {
           this.connection.console.warn(
-            "Unable to apply elm-analyse fix, unknown diagnotic code",
+            "Unable to apply elm-analyse fix, unknown diagnostic code",
           );
           return;
         }

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -39,14 +39,12 @@ export class ElmMakeDiagnostics {
       this.elmWorkspaceFolder.fsPath,
       filePath.fsPath,
     ).then(issues => {
-      if (issues.length > 0) {
-        return ElmDiagnosticsHelper.issuesToDiagnosticMap(
-          issues,
-          this.elmWorkspaceFolder,
-        );
-      } else {
-        return new Map([[filePath.toString(), []]]);
-      }
+      return issues.length === 0
+        ? new Map([[filePath.toString(), []]])
+        : ElmDiagnosticsHelper.issuesToDiagnosticMap(
+            issues,
+            this.elmWorkspaceFolder,
+          );
     });
   };
 
@@ -55,12 +53,8 @@ export class ElmMakeDiagnostics {
     const elmMakeDiagnostics: Diagnostic[] = this.filterElmMakeDiagnostics(
       params.context.diagnostics,
     );
-    const elmMakeCodeActions = this.convertDiagnosticsToCodeActions(
-      elmMakeDiagnostics,
-      uri,
-    );
 
-    return elmMakeCodeActions.length > 0 ? elmMakeCodeActions : [];
+    return this.convertDiagnosticsToCodeActions(elmMakeDiagnostics, uri);
   }
 
   private convertDiagnosticsToCodeActions(

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -255,14 +255,11 @@ export class TreeUtils {
     type: string | string[],
     node: SyntaxNode,
   ): SyntaxNode[] | undefined {
-    const result =
-      type instanceof Array
-        ? node.children.filter(child => type.includes(child.type))
-        : node.children.filter(child => child.type === type);
-    if (result.length === 0) {
-      return undefined;
-    }
-    return result;
+    const result = Array.isArray(type)
+      ? node.children.filter(child => type.includes(child.type))
+      : node.children.filter(child => child.type === type);
+
+    return result.length === 0 ? undefined : result;
   }
 
   public static findExposedFunctionNode(
@@ -505,7 +502,7 @@ export class TreeUtils {
       });
     }
 
-    return result.length > 0 ? result : undefined;
+    return result.length === 0 ? undefined : result;
   }
 
   public static findAllFunctionCallsAndParameters(
@@ -581,7 +578,7 @@ export class TreeUtils {
         return a.text === typeOrTypeAliasName;
       });
 
-      return result.length > 0 ? result : undefined;
+      return result.length === 0 ? undefined : result;
     }
   }
 
@@ -959,11 +956,8 @@ export class TreeUtils {
     const result = tree.rootNode.children.filter(
       a => a.type === "import_clause",
     );
-    if (result.length > 0) {
-      return result;
-    } else {
-      return undefined;
-    }
+
+    return result.length === 0 ? undefined : result;
   }
 
   public static findImportClauseByName(
@@ -1050,6 +1044,6 @@ export class TreeUtils {
         });
       }
     }
-    return result.length > 0 ? result : undefined;
+    return result.length === 0 ? undefined : result;
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
     "prettier": [true, ".prettierrc.yaml"],
     "cognitive-complexity": false,
     "no-big-function": false,
+    "prefer-const": true,
     "prefer-template": true
   },
   "rulesDirectory": ["tslint-plugin-prettier"]


### PR DESCRIPTION
Getting myself more familiar with the code by doing minor tweaks.

Here conditionals weren't really needed for `find` statements because they already bring back `T | undefined`, so they can be brought back directly.

Removed redundant array initialization from constructor, because it already has default value assigned.

Fixed typo.

Using built in method to check if object is array, rather than using `instanceof`.

Recreating this in favor for #115 