### PR TITLE
Avoid error when initializationOptions is not set

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -66,13 +66,16 @@ export class Server implements ILanguageServer {
     const elmWorkspaceFallback =
       // Add a trailing slash if not present
       this.params.rootUri && this.params.rootUri.replace(/\/?$/, "/");
+
+    const initializationOptions = this.params.initializationOptions || {};
+
     const elmWorkspace = URI.parse(
-      this.params.initializationOptions.elmWorkspace || elmWorkspaceFallback,
+      initializationOptions.elmWorkspace || elmWorkspaceFallback,
     );
 
     const settings = new Settings(
       this.params.capabilities,
-      this.params.initializationOptions,
+      initializationOptions,
     );
 
     connection.onInitialized(async () => {


### PR DESCRIPTION
[The spec](https://microsoft.github.io/language-server-protocol/specification#initialize) defines this as an optional field, so we shouldn't rely on it being set. This causes problems for https://github.com/autozimu/LanguageClient-neovim since it doesn't set the option by default. This PR changes it to default to an empty object when undefined to avoid this issue.

Possible fix for https://github.com/elm-tooling/elm-language-server/issues/119, this change was sufficient for me to get it working with the following config, but I didn't see the exact error described there.

```vim
let g:LanguageClient_serverCommands = {
      \ 'elm': [ 'elm-language-server', '--stdio' ],
\ }

```