### PR TITLE
Setting: `diagnosticsOnSaveOnly` (bool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This server contributes the following settings:
 - `elmLS.elmPath`: The path to your `elm` executable.
 - `elmLS.elmFormatPath`: The path to your `elm-format` executable.
 - `elmLS.elmTestPath`: The path to your `elm-test` executable.
+- `elmLS.diagnosticsOnSaveOnly`: Diagnostic updates triggered _only_ on save. `true/false` (default: `false`)
 
 ## Installation
 
@@ -103,12 +104,13 @@ If needed, you can set the paths to `elm`, `elm-test` and `elm-format` with the 
       "initializationOptions": {
         "elmPath": "elm",
         "elmFormatPath": "elm-format",
-        "elmTestPath": "elm-test"
+        "elmTestPath": "elm-test",
+        "diagnosticsOnSaveOnly": false
       }
     }
   },
   // If you use neovim you can enable codelenses with this
-  "codeLens.enable": true,
+  "codeLens.enable": true
 }
 ```
 
@@ -184,6 +186,7 @@ args = ["--stdio"]
 elmPath = "elm"
 elmFormatPath = "elm-format"
 elmTestPath = "elm-test"
+diagnosticsOnSaveOnly = false
 ```
 
 ### Emacs
@@ -217,7 +220,8 @@ Add this to your LSP settings under the `clients` node:
     "initializationOptions": {
         "elmPath": "elm",
         "elmFormatPath": "elm-format",
-        "elmTestPath": "elm-test"
+        "elmTestPath": "elm-test",
+        "diagnosticsOnSaveOnly": false
     }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elm-tooling/elm-language-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -32,6 +32,7 @@ export class DiagnosticsProvider {
   constructor(
     private connection: IConnection,
     private elmWorkspaceFolder: URI,
+    private settings: Settings,
     private events: TextDocumentEvents,
     elmAnalyse: ElmAnalyseDiagnostics,
     elmMake: ElmMakeDiagnostics,
@@ -51,12 +52,18 @@ export class DiagnosticsProvider {
     };
 
     this.events.on("open", this.getDiagnosticsOnSaveOrOpen);
-    this.events.on("change", this.getDiagnosticsOnChange);
     this.events.on("save", this.getDiagnosticsOnSaveOrOpen);
     this.elmAnalyseDiagnostics.on(
       "new-diagnostics",
       this.newElmAnalyseDiagnostics,
     );
+
+    // register onChange listener if settings are not on-save only
+    this.settings.getClientSettings().then(({ diagnosticsOnSaveOnly }) => {
+      if (!diagnosticsOnSaveOnly) {
+        this.events.on("change", this.getDiagnosticsOnChange);
+      }
+    });
   }
 
   private newElmAnalyseDiagnostics(diagnostics: Map<string, Diagnostic[]>) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,6 +126,7 @@ export class Server implements ILanguageServer {
     new DiagnosticsProvider(
       this.connection,
       this.elmWorkspace,
+      this.settings,
       textDocumentEvents,
       elmAnalyse,
       elmMake,

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -1,6 +1,7 @@
 import { ClientCapabilities, IConnection } from "vscode-languageserver";
 
 export interface IClientSettings {
+  diagnosticsOnSaveOnly: boolean;
   elmFormatPath: string;
   elmPath: string;
   elmTestPath: string;
@@ -9,6 +10,7 @@ export interface IClientSettings {
 
 export class Settings {
   private fallbackClientSettings: IClientSettings = {
+    diagnosticsOnSaveOnly: false,
     elmFormatPath: "elm-format",
     elmPath: "elm",
     elmTestPath: "elm-test",
@@ -16,6 +18,7 @@ export class Settings {
   };
 
   private clientSettings: IClientSettings = {
+    diagnosticsOnSaveOnly: false,
     elmFormatPath: "elm-format",
     elmPath: "elm",
     elmTestPath: "elm-test",


### PR DESCRIPTION
If enabled, diagnostics are only triggered on save, and not on change.
The default value is `false`, which means diagnostics are updated on change and on save.

Relates to #67 