### PR TITLE
elm analyse configuration ("change" | "save" | "never").

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ This server contributes the following settings:
 - `elmLS.elmPath`: The path to your `elm` executable.
 - `elmLS.elmFormatPath`: The path to your `elm-format` executable.
 - `elmLS.elmTestPath`: The path to your `elm-test` executable.
-- `elmLS.diagnosticsOnSaveOnly`: Diagnostic updates triggered _only_ on save. `true/false` (default: `false`)
+- `elmLS.elmAnalyseTrigger`: `elm-analyse` executed on `'change'`, `'save'` or `'never'` (default: `'change'`)
+
+Settings may need a restart to be applied.
 
 ## Editor Support
 
@@ -109,7 +111,7 @@ If needed, you can set the paths to `elm`, `elm-test` and `elm-format` with the 
         "elmPath": "elm",
         "elmFormatPath": "elm-format",
         "elmTestPath": "elm-test",
-        "diagnosticsOnSaveOnly": false
+        "elmAnalyseTrigger": "change"
       }
     }
   },
@@ -190,7 +192,7 @@ args = ["--stdio"]
 elmPath = "elm"
 elmFormatPath = "elm-format"
 elmTestPath = "elm-test"
-diagnosticsOnSaveOnly = false
+elmAnalyseTrigger = "change"
 ```
 
 ### Emacs
@@ -225,7 +227,7 @@ Add this to your LSP settings under the `clients` node:
         "elmPath": "elm",
         "elmFormatPath": "elm-format",
         "elmTestPath": "elm-test",
-        "diagnosticsOnSaveOnly": false
+        "elmAnalyseTrigger": "change"
     }
 }
 ```

--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -78,24 +78,32 @@ export class ElmWorkspace {
   }
 
   public async init() {
+    const settings = await this.settings.getClientSettings();
+
     const documentFormatingProvider = new DocumentFormattingProvider(
       this.connection,
       this.elmWorkspace,
       this.textDocumentEvents,
       this.settings,
     );
-    const elmAnalyse = new ElmAnalyseDiagnostics(
-      this.connection,
-      this.elmWorkspace,
-      this.textDocumentEvents,
-      this.settings,
-      documentFormatingProvider,
-    );
+
+    const elmAnalyse =
+      settings.elmAnalyseTrigger !== "never"
+        ? new ElmAnalyseDiagnostics(
+            this.connection,
+            this.elmWorkspace,
+            this.textDocumentEvents,
+            this.settings,
+            documentFormatingProvider,
+          )
+        : null;
+
     const elmMake = new ElmMakeDiagnostics(
       this.connection,
       this.elmWorkspace,
       this.settings,
     );
+
     // tslint:disable:no-unused-expression
     new DiagnosticsProvider(
       this.connection,
@@ -105,6 +113,7 @@ export class ElmWorkspace {
       elmAnalyse,
       elmMake,
     );
+
     new CodeActionProvider(this.connection, elmAnalyse, elmMake);
 
     await this.initWorkspace();

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -9,12 +9,12 @@ import { ElmMakeDiagnostics } from "./diagnostics/elmMakeDiagnostics";
 
 export class CodeActionProvider {
   private connection: IConnection;
-  private elmAnalyse: ElmAnalyseDiagnostics;
+  private elmAnalyse: ElmAnalyseDiagnostics | null;
   private elmMake: ElmMakeDiagnostics;
 
   constructor(
     connection: IConnection,
-    elmAnalyse: ElmAnalyseDiagnostics,
+    elmAnalyse: ElmAnalyseDiagnostics | null,
     elmMake: ElmMakeDiagnostics,
   ) {
     this.connection = connection;
@@ -28,13 +28,14 @@ export class CodeActionProvider {
 
   private onCodeAction(params: CodeActionParams): CodeAction[] {
     this.connection.console.info("A code action was requested");
-    return this.elmAnalyse
-      .onCodeAction(params)
-      .concat(this.elmMake.onCodeAction(params));
+    const analyse =
+      (this.elmAnalyse && this.elmAnalyse.onCodeAction(params)) || [];
+    const make = this.elmMake.onCodeAction(params);
+    return [...analyse, ...make];
   }
 
   private async onExecuteCommand(params: ExecuteCommandParams) {
     this.connection.console.info("A command execution was requested");
-    return this.elmAnalyse.onExecuteCommand(params);
+    return this.elmAnalyse && this.elmAnalyse.onExecuteCommand(params);
   }
 }

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -22,7 +22,7 @@ export interface IElmIssue {
 
 export class DiagnosticsProvider {
   private elmMakeDiagnostics: ElmMakeDiagnostics;
-  private elmAnalyseDiagnostics: ElmAnalyseDiagnostics;
+  private elmAnalyseDiagnostics: ElmAnalyseDiagnostics | null;
   private currentDiagnostics: {
     elmMake: Map<string, Diagnostic[]>;
     elmAnalyse: Map<string, Diagnostic[]>;
@@ -34,7 +34,7 @@ export class DiagnosticsProvider {
     private elmWorkspaceFolder: URI,
     private settings: Settings,
     private events: TextDocumentEvents,
-    elmAnalyse: ElmAnalyseDiagnostics,
+    elmAnalyse: ElmAnalyseDiagnostics | null,
     elmMake: ElmMakeDiagnostics,
   ) {
     this.newElmAnalyseDiagnostics = this.newElmAnalyseDiagnostics.bind(this);
@@ -55,10 +55,12 @@ export class DiagnosticsProvider {
       this.events.on("save", d =>
         this.getDiagnostics(d, true, elmAnalyseTrigger),
       );
-      this.elmAnalyseDiagnostics.on(
-        "new-diagnostics",
-        this.newElmAnalyseDiagnostics,
-      );
+      if (this.elmAnalyseDiagnostics) {
+        this.elmAnalyseDiagnostics.on(
+          "new-diagnostics",
+          this.newElmAnalyseDiagnostics,
+        );
+      }
       if (elmAnalyseTrigger === "change") {
         this.events.on("change", d =>
           this.getDiagnostics(d, false, elmAnalyseTrigger),
@@ -124,6 +126,7 @@ export class DiagnosticsProvider {
       );
 
       if (
+        this.elmAnalyseDiagnostics &&
         elmAnalyseTrigger !== "never" &&
         elmMakeDiagnosticsForCurrentFile &&
         elmMakeDiagnosticsForCurrentFile.length === 0

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -1,6 +1,6 @@
 import { Diagnostic, IConnection, TextDocument } from "vscode-languageserver";
 import { URI } from "vscode-uri";
-import { Settings } from "../../util/settings";
+import { ElmAnalyseTrigger, Settings } from "../../util/settings";
 import { TextDocumentEvents } from "../../util/textDocumentEvents";
 import { ElmAnalyseDiagnostics } from "./elmAnalyseDiagnostics";
 import { ElmMakeDiagnostics } from "./elmMakeDiagnostics";
@@ -37,10 +37,6 @@ export class DiagnosticsProvider {
     elmAnalyse: ElmAnalyseDiagnostics,
     elmMake: ElmMakeDiagnostics,
   ) {
-    this.getDiagnosticsOnSaveOrOpen = this.getDiagnosticsOnSaveOrOpen.bind(
-      this,
-    );
-    this.getDiagnosticsOnChange = this.getDiagnosticsOnChange.bind(this);
     this.newElmAnalyseDiagnostics = this.newElmAnalyseDiagnostics.bind(this);
     this.elmMakeDiagnostics = elmMake;
     this.elmAnalyseDiagnostics = elmAnalyse;
@@ -51,17 +47,22 @@ export class DiagnosticsProvider {
       elmTest: new Map(),
     };
 
-    this.events.on("open", this.getDiagnosticsOnSaveOrOpen);
-    this.events.on("save", this.getDiagnosticsOnSaveOrOpen);
-    this.elmAnalyseDiagnostics.on(
-      "new-diagnostics",
-      this.newElmAnalyseDiagnostics,
-    );
-
     // register onChange listener if settings are not on-save only
-    this.settings.getClientSettings().then(({ diagnosticsOnSaveOnly }) => {
-      if (!diagnosticsOnSaveOnly) {
-        this.events.on("change", this.getDiagnosticsOnChange);
+    this.settings.getClientSettings().then(({ elmAnalyseTrigger }) => {
+      this.events.on("open", d =>
+        this.getDiagnostics(d, true, elmAnalyseTrigger),
+      );
+      this.events.on("save", d =>
+        this.getDiagnostics(d, true, elmAnalyseTrigger),
+      );
+      this.elmAnalyseDiagnostics.on(
+        "new-diagnostics",
+        this.newElmAnalyseDiagnostics,
+      );
+      if (elmAnalyseTrigger === "change") {
+        this.events.on("change", d =>
+          this.getDiagnostics(d, false, elmAnalyseTrigger),
+        );
       }
     });
   }
@@ -97,26 +98,17 @@ export class DiagnosticsProvider {
     }
   }
 
-  private async getDiagnosticsOnChange(document: TextDocument): Promise<void> {
-    this.connection.console.info(
-      "Diagnostics were requested due to a file change",
-    );
-    this.getDiagnostics(document, false);
-  }
-
-  private async getDiagnosticsOnSaveOrOpen(
-    document: TextDocument,
-  ): Promise<void> {
-    this.connection.console.info(
-      "Diagnostics were requested due to a file open or save",
-    );
-    this.getDiagnostics(document, true);
-  }
-
   private async getDiagnostics(
     document: TextDocument,
     isSaveOrOpen: boolean,
+    elmAnalyseTrigger: ElmAnalyseTrigger,
   ): Promise<void> {
+    this.connection.console.info(
+      `Diagnostics were requested due to a file ${
+        isSaveOrOpen ? "open or save" : "change"
+      }`,
+    );
+
     const uri = URI.parse(document.uri);
     if (uri.toString().startsWith(this.elmWorkspaceFolder.toString())) {
       const text = document.getText();
@@ -130,7 +122,9 @@ export class DiagnosticsProvider {
       const elmMakeDiagnosticsForCurrentFile = this.currentDiagnostics.elmMake.get(
         uri.toString(),
       );
+
       if (
+        elmAnalyseTrigger !== "never" &&
         elmMakeDiagnosticsForCurrentFile &&
         elmMakeDiagnosticsForCurrentFile.length === 0
       ) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,9 +81,7 @@ export class Server implements ILanguageServer {
   }
 
   public async init() {
-    this.elmWorkspaceMap.forEach(it => {
-      return it.init();
-    });
+    this.elmWorkspaceMap.forEach(it => it.init());
   }
 
   public async registerInitializedProviders() {

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -1,16 +1,18 @@
 import { IConnection } from "vscode-languageserver";
 
 export interface IClientSettings {
-  diagnosticsOnSaveOnly: boolean;
   elmFormatPath: string;
   elmPath: string;
   elmTestPath: string;
+  elmAnalyseTrigger: ElmAnalyseTrigger;
   trace: { server: string };
 }
 
+export type ElmAnalyseTrigger = "change" | "save" | "never";
+
 export class Settings {
   private clientSettings: IClientSettings = {
-    diagnosticsOnSaveOnly: false,
+    elmAnalyseTrigger: "change",
     elmFormatPath: "elm-format",
     elmPath: "elm",
     elmTestPath: "elm-test",


### PR DESCRIPTION
Adds configuration: `elmAnalyseTrigger` ("change" | "save" | "never"). Will not initialize `elm-analyse` if the setting is `never`. 

Solves #133 