### PR TITLE
Fix glob to match `elm.json` in directory

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ export class Server implements ILanguageServer {
     if (uri) {
       const elmJsonGlob = `${uri.fsPath}/**/elm.json`;
 
+      connection.console.info(elmJsonGlob);
       const elmJsons = globby.sync([elmJsonGlob, "**/node_modules/**"]);
       if (elmJsons.length > 0) {
         connection.console.info(

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ export class Server implements ILanguageServer {
     const uri = this.getWorkspaceUri(params);
 
     if (uri) {
-      const elmJsonGlob = `${uri.fsPath}/**/elm.json`;
+      const elmJsonGlob = `${uri.fsPath}/**elm.json`;
 
       connection.console.info(elmJsonGlob);
       const elmJsons = globby.sync([elmJsonGlob, "**/node_modules/**"]);


### PR DESCRIPTION
Still matching all subdirectories (dependencies) but will match `elm.json` in root, too.