### PR TITLE
[Bugfix] execa stripping new lines resulted wrong elm-format diff

### DIFF
--- a/src/util/elmUtils.ts
+++ b/src/util/elmUtils.ts
@@ -36,6 +36,7 @@ export async function execCmd(
       cwd,
       input,
       preferLocal,
+      stripFinalNewline: false,
     });
   } catch (error) {
     if (error.errno === "ENOENT") {
@@ -97,7 +98,8 @@ export async function getElmVersion(
     connection,
   );
 
-  const version = result.stdout;
+  const version = result.stdout.trim();
+
   connection.console.info(`Elm version ${version} detected.`);
 
   return Promise.resolve(version);


### PR DESCRIPTION
* Changing the last line duplicated the last line
* Changing the first line duplicated the whole file

<https://github.com/sindresorhus/execa#stripfinalnewline>

![vokoscreen-2019-08-29_21-04-06](https://user-images.githubusercontent.com/13085980/63971576-1a3c0100-caa7-11e9-88ee-2898b0283e36.gif)
