### PR TITLE
Readme: Explaining vim filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Just install the [`elm-tooling/elm-language-client-vscode`](https://github.com/e
 
 ### Vim
 
-[General Elm Vim tooling](https://github.com/elm-tooling/elm-vim)
+There are [general setup instructions for vim](https://github.com/elm-tooling/elm-vim). It's recommended to install [syntax highlighting](https://github.com/andys8/vim-elm-syntax), which also adds the required [detection of elm as `filetype`](https://github.com/andys8/vim-elm-syntax/blob/d614325a037982489574012e4db04d7f8f134c17/ftdetect/elm.vim#L3).
 
 #### coc.nvim
 


### PR DESCRIPTION
It turned out to be necessary, that elm files are recognized as elm files. Most people install syntax highlighting anyway. But if not, elm-language-server wouldn't work.