### PR TITLE
Default argument `--stdio` if nothing is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install -g @elm-tooling/elm-language-server
 Then, you should be able to run the language server with the following command:
 
 ```sh
-elm-language-server --stdio
+elm-language-server
 ```
 
 Follow the instructions below to integrate the language server into your editor.
@@ -104,7 +104,6 @@ If needed, you can set the paths to `elm`, `elm-test` and `elm-format` with the 
   "languageserver": {
     "elmLS": {
       "command": "elm-language-server",
-      "args": ["--stdio"],
       "filetypes": ["elm"],
       "rootPatterns": ["elm.json"],
       "initializationOptions": {
@@ -183,7 +182,6 @@ Then, assuming installation of `elm-language-server`, `elm-format`, and `elm-tes
 filetypes = ["elm"]
 roots = ["elm.json"]
 command = "elm-language-server"
-args = ["--stdio"]
 
 [language.elm.initialization_options]
 elmAnalyseTrigger = "change"
@@ -204,8 +202,7 @@ Add this to your LSP settings under the `clients` node:
 ```json
 "elm": {
     "command": [
-        "elm-language-server",
-        "--stdio"
+        "elm-language-server"
     ],
     "enabled": true,
     "languageId": "elm",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ import {
 import Parser from "web-tree-sitter";
 import { ILanguageServer } from "./server";
 
+// default setting `--stdio`
+if (process.argv.length === 2) {
+  process.argv.push("--stdio");
+}
+
 const connection: IConnection = createConnection(ProposedFeatures.all);
 let server: ILanguageServer;
 


### PR DESCRIPTION
To reduce configuration settings, it makes things easier, if there is a
default argument, if none is set. The result is that user configuration
can be simpler.

See vscode language server node implementation:

<https://github.com/microsoft/vscode-languageserver-node/blob/082631da44d6799358602a4abebadbf4fc47859b/server/src/main.ts#L1705>

Solves #147