### PR TITLE
Check if workspace/configuration is available before calling it

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,11 @@ export class Server implements ILanguageServer {
     this.calculator = new CapabilityCalculator(params.capabilities);
 
     const initializationOptions = this.params.initializationOptions || {};
-    this.settings = new Settings(this.connection, initializationOptions);
+    this.settings = new Settings(
+      this.connection,
+      initializationOptions,
+      params.capabilities,
+    );
 
     const uri = this.getWorkspaceUri(params);
 

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -1,4 +1,4 @@
-import { IConnection } from "vscode-languageserver";
+import { ClientCapabilities, IConnection } from "vscode-languageserver";
 
 export interface IClientSettings {
   elmFormatPath: string;
@@ -21,7 +21,11 @@ export class Settings {
 
   private initDone = false;
 
-  constructor(private connection: IConnection, config: any) {
+  constructor(
+    private connection: IConnection,
+    config: any,
+    private clientCapabilities: ClientCapabilities,
+  ) {
     this.updateSettings(config);
   }
 
@@ -30,7 +34,11 @@ export class Settings {
   }
 
   public async getClientSettings(): Promise<IClientSettings> {
-    if (this.initDone) {
+    if (
+      this.initDone &&
+      this.clientCapabilities.workspace &&
+      this.clientCapabilities.workspace.configuration
+    ) {
       this.updateSettings(
         await this.connection.workspace.getConfiguration("elmLS"),
       );


### PR DESCRIPTION
@andys8 I'm actually not sure if this will not screw with the reworked startup in some way.
We should look for settings being not what they should be on clients that don't implement `workspace/configuration`