### PR TITLE
Ignore globby errors when looking for elm.json

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,9 @@ export class Server implements ILanguageServer {
         elmJsonGlob,
         "!**/node_modules/**",
         "!**/elm-stuff/**",
-      ]);
+      ], {
+        suppressErrors: true
+      });
       if (elmJsons.length > 0) {
         connection.console.info(
           `Found ${elmJsons.length} elm.json files for workspace ${globUri}`,


### PR DESCRIPTION
I am currently getting the following error when opening one of my projects, where some of my files are not directly accessible by my user:
```
[Info  - 10:37:42 PM] Loading Elm tree-sitter syntax from ../../.vscode/extensions/elmtooling.elm-ls-vscode-0.7.1/server/out/tree-sitter-elm.wasm
[Trace - 10:37:42 PM] Received response 'initialize - (0)' in 309ms. Request failed: Request initialize failed with message: EACCES: permission denied, scandir '/home/mktange/code/matter/var/data/postgres/base' (-32603).
[Error - 10:37:42 PM] Server initialization failed.
  Message: Request initialize failed with message: EACCES: permission denied, scandir '/[path-to-repo]/var/data/postgres/base'
  Code: -32603 
[Trace - 10:37:42 PM] Sending request 'shutdown - (1)'.
[Trace - 10:37:42 PM] Received response 'shutdown - (1)' in 0ms.
```

This happens when `globby` is trying to find the `elm.json`s in the project. 
Adding `suppressErrors: true` tells globby to ignore all errors (and not just ENOENT), which should be fine for this globby call.

On another note: Is it possible to restart the language server in VS Code without restarting the application?