### PR TITLE
Add trigger characters to completion provider capabilities

### DIFF
--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -26,7 +26,9 @@ export class CapabilityCalculator {
       codeLensProvider: {
         resolveProvider: true,
       },
-      completionProvider: {},
+      completionProvider: {
+        triggerCharacters: ["."],
+      },
       definitionProvider: true,
       documentFormattingProvider: true,
       documentSymbolProvider: true,


### PR DESCRIPTION
Send trigger characters. It's optional but helps some integrations like lsp-mode and company-lsp (Emacs). By default it using only trigger characters provided by server. So it will result in easier setup.