### PR TITLE
Merge pull request #206 from sentience/fix-ancestor-relative-source-directories

### DIFF
--- a/src/providers/diagnostics/elmDiagnosticsHelper.ts
+++ b/src/providers/diagnostics/elmDiagnosticsHelper.ts
@@ -35,11 +35,6 @@ export class ElmDiagnosticsHelper {
     issue: IElmIssue,
     elmWorkspaceFolder: URI,
   ): string {
-    if (issue.file.startsWith(".")) {
-      return URI.file(
-        path.join(elmWorkspaceFolder.fsPath, issue.file.slice(1)),
-      ).toString();
-    }
     return URI.file(
       path.join(elmWorkspaceFolder.fsPath, issue.file),
     ).toString();


### PR DESCRIPTION
When elm.json `"source-directories"` start with `..` (e.g. `"../lib"`), the language server would misinterpret the leading `.` as the current directory and strip it off, leaving a path that starts with `./` (which is wrong).

In short, `../lib` is interpreted as `./lib`, causing diagnostics to be attributed to a non-existent file path.

This fix simply removes the offending branch, which seems no longer to be needed. The [original implementation][original] assembled the path through string concatenation, but this is no longer the case. In the current interpretation, `path.join` handles the relative paths correctly on its own, so we can just remove this special case.

Sample project that demonstrates this issue: https://github.com/sentience/elm-language-server-bug-demo

Screenshot showing the issue:

![Code - Insiders 2020-01-16 at 19 00 52@2x](https://user-images.githubusercontent.com/89772/72506711-8bcded80-3896-11ea-8c2a-40e30e82bc29.png)

[original]: https://github.com/elm-tooling/elm-language-server/blob/85aa6a4613bd5c5adf78eb9163efb5eab93ca1b1/src/providers/diagnostics/elmMakeDiagnostics.ts#L178-L180