### PR TITLE
Improve loading progress

### DIFF
--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -71,7 +71,6 @@ export class ElmWorkspace {
 
   private async initWorkspace(x: WorkDoneProgress) {
     let progress = 0;
-    x.begin("Indexing", progress);
     let elmVersion;
     try {
       elmVersion = await utils.getElmVersion(
@@ -203,7 +202,6 @@ export class ElmWorkspace {
         this.imports.updateImports(item.uri, item.tree, this.forest);
       });
 
-      x.done();
       this.connection.console.info("Done parsing all files.");
     } catch (error) {
       this.connection.console.error(error.stack);

--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -185,17 +185,17 @@ export class ElmWorkspace {
       }
 
       const promiseList: Promise<void>[] = [];
-      const progressSteps = (elmFilePaths.length * 2) / 100;
+      const progressSteps = 100 / (elmFilePaths.length * 2);
       for (const filePath of elmFilePaths) {
         progress += progressSteps;
-        x.report(progressSteps);
+        x.report(progress);
         promiseList.push(this.readAndAddToForest(filePath));
       }
       await Promise.all(promiseList);
 
       this.forest.treeIndex.forEach(item => {
         progress += progressSteps;
-        x.report(progressSteps);
+        x.report(progress);
         this.connection.console.info(
           `Adding imports ${URI.parse(item.uri).fsPath}`,
         );

--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -83,9 +83,9 @@ export class ElmWorkspace {
         `Could not figure out elm version, this will impact how good the server works. \n ${e.stack}`,
       );
     }
+    const pathToElmJson = path.join(this.rootPath.fsPath, "elm.json");
+    this.connection.console.info(`Reading elm.json from ${pathToElmJson}`);
     try {
-      const pathToElmJson = path.join(this.rootPath.fsPath, "elm.json");
-      this.connection.console.info(`Reading elm.json from ${pathToElmJson}`);
       // Find elm files and feed them to tree sitter
       const elmJson = require(pathToElmJson);
       const type = elmJson.type;
@@ -202,9 +202,13 @@ export class ElmWorkspace {
         this.imports.updateImports(item.uri, item.tree, this.forest);
       });
 
-      this.connection.console.info("Done parsing all files.");
+      this.connection.console.info(
+        `Done parsing all files for ${pathToElmJson}`,
+      );
     } catch (error) {
-      this.connection.console.error(error.stack);
+      this.connection.console.error(
+        `Error parsing files for ${pathToElmJson}:\n${error.stack}`,
+      );
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,7 +109,7 @@ export class Server implements ILanguageServer {
   }
 
   public async init() {
-    this.elmWorkspaces.forEach(async it => await it.init(this.progress));
+    await Promise.all(this.elmWorkspaces.map(ws => ws.init(this.progress)));
   }
 
   public async registerInitializedProviders() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,7 +109,9 @@ export class Server implements ILanguageServer {
   }
 
   public async init() {
+    this.progress.begin("Indexing Elm", 0);
     await Promise.all(this.elmWorkspaces.map(ws => ws.init(this.progress)));
+    this.progress.done();
   }
 
   public async registerInitializedProviders() {


### PR DESCRIPTION
Fixes several problems with displaying loading progress, especially across multiple elm.json files.

Also resolves issue where the language server was attempting to process events before it had finished initialising, causing errors and failure to load features in files open during initialisation.

Caveat: In large projects there still seems to be a stall in loading at the point where a certain number of elm-tree-sitter processes have been spawned. This is not a new problem, but the visible loading progress makes it more visible, as the load percentage stalls. Would like to look into what's going on there in a later piece of work.