### PR TITLE
Add record completion items

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -450,12 +450,21 @@ export class CompletionProvider {
     uri: string,
   ): CompletionItem[] {
     const result: CompletionItem[] = [];
-    const typeDeclarationNode = TreeUtils.getTypeAliasOfRecord(
+    let typeDeclarationNode = TreeUtils.getTypeAliasOfRecord(
       node,
       tree,
       imports,
       uri
     );
+
+    if (!typeDeclarationNode && node.parent?.parent) {
+      typeDeclarationNode = TreeUtils.getTypeAliasOfRecordField(
+        node.parent.parent,
+        tree,
+        imports,
+        uri
+      );
+    }
 
     if (typeDeclarationNode) {
       const fields = TreeUtils.getAllFieldsFromTypeAlias(

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -162,7 +162,7 @@ export class CompletionProvider {
       } else if (
         nodeAtPosition.parent?.parent?.type == "record_expr"
       ) {
-        return this.getRecordCompetions(nodeAtPosition, tree, replaceRange, elmWorkspace.getImports(), params.textDocument.uri);
+        return this.getRecordCompletions(nodeAtPosition, tree, replaceRange, elmWorkspace.getImports(), params.textDocument.uri);
       }
 
       completions.push(
@@ -442,7 +442,7 @@ export class CompletionProvider {
     return completions;
   }
 
-  private getRecordCompetions(
+  private getRecordCompletions(
     node: SyntaxNode,
     tree: Tree,
     range: Range,
@@ -465,7 +465,7 @@ export class CompletionProvider {
       const typeName = TreeUtils.findFirstNamedChildOfType(
         "upper_case_identifier",
         typeDeclarationNode
-      )?.text || "";
+      )?.text ?? "";
 
       fields?.forEach(element => {
         const hint = HintHelper.createHintForTypeAliasReference(
@@ -474,7 +474,7 @@ export class CompletionProvider {
           typeName,
         );
         result.push(
-          this.createFunctionParameterCompletion(
+          this.createFieldOrParameterCompletion(
             hint,
             element.field,
             range,
@@ -501,7 +501,7 @@ export class CompletionProvider {
     );
   }
 
-  private createFunctionParameterCompletion(
+  private createFieldOrParameterCompletion(
     markdownDocumentation: string | undefined,
     label: string,
     range: Range,
@@ -697,7 +697,7 @@ export class CompletionProvider {
               child,
             );
             result.push(
-              this.createFunctionParameterCompletion(
+              this.createFieldOrParameterCompletion(
                 markdownDocumentation,
                 child.text,
                 range,
@@ -724,7 +724,7 @@ export class CompletionProvider {
                       child.text,
                     );
                     result.push(
-                      this.createFunctionParameterCompletion(
+                      this.createFieldOrParameterCompletion(
                         hint,
                         `${child.text}.${element.field}`,
                         range,

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -466,6 +466,14 @@ export class CompletionProvider {
       );
     }
 
+    if (!typeDeclarationNode && node.parent?.parent) {
+      typeDeclarationNode = TreeUtils.getTypeOrTypeAliasOfFunctionRecordParameter(
+        node.parent.parent,
+        tree,
+        imports,
+        uri);
+    }
+
     if (typeDeclarationNode) {
       const fields = TreeUtils.getAllFieldsFromTypeAlias(
         typeDeclarationNode,

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -1177,6 +1177,32 @@ export class TreeUtils {
     }
   }
 
+  public static getTypeAliasOfRecordField(
+    node: SyntaxNode | undefined,
+    tree: Tree,
+    imports: IImports,
+    uri: string
+  ): SyntaxNode | undefined {
+    const fieldName = node?.parent?.firstNamedChild?.text;
+
+    const children = node?.parent?.parent?.namedChildren.map(n => n.text + " " + n.type);
+    const recordType = TreeUtils.getTypeAliasOfRecord(
+      node,
+      tree,
+      imports,
+      uri
+    );
+
+    const fields = TreeUtils.getAllFieldsFromTypeAlias(
+      recordType,
+    );
+
+    const fieldType = fields?.find(field => field.field === fieldName)?.type ?? "";
+
+    const type = TreeUtils.findTypeAliasDeclaration(tree, fieldType);
+    return type;
+  }
+
   public static getTypeAliasOfRecord(
     node: SyntaxNode | undefined,
     tree: Tree,

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -1172,7 +1172,7 @@ export class TreeUtils {
       );
       if (typeAnnotationNodes) {
         const type = typeAnnotationNodes[typeAnnotationNodes.length - 1];
-        return type.firstNamedChild?.firstNamedChild || type;
+        return type.firstNamedChild?.firstNamedChild ?? type;
       }
     }
   }
@@ -1187,7 +1187,7 @@ export class TreeUtils {
       const type = TreeUtils.findFirstNamedChildOfType(
         "record_base_identifier",
         node.parent.parent,
-      ) || TreeUtils.findFirstNamedChildOfType(
+      ) ?? TreeUtils.findFirstNamedChildOfType(
         "record_base_identifier",
         node.parent,
       );


### PR DESCRIPTION
Fixes #218. Adds record completion items for that type when updating a record. Also works for imported records.

![record-completion-items](https://user-images.githubusercontent.com/44308390/76899558-c982ce80-6865-11ea-8556-a0fff6ed2e0b.gif)
