### PR TITLE
Add basic keyword completions

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -177,6 +177,7 @@ export class CompletionProvider {
       );
 
       completions.push(...this.createSnippets());
+      completions.push(...this.getKeywords());
 
       return completions;
     }
@@ -1198,6 +1199,32 @@ export class CompletionProvider {
         "Test block in Elm-test",
       ),
       this.createSnippet("todo", "-- TODO: ${0}", "TODO comment"),
+    ];
+  }
+
+  private createKeywordCompletion(
+    label: string
+  ): CompletionItem {
+    return {
+      label,
+      kind: CompletionItemKind.Keyword,
+      sortText: `a_${label}`
+    }
+  }
+
+  private getKeywords(): CompletionItem[] {
+    return [
+      this.createKeywordCompletion("if"),
+      this.createKeywordCompletion("then"),
+      this.createKeywordCompletion("else"),
+      this.createKeywordCompletion("let"),
+      this.createKeywordCompletion("in"),
+      this.createKeywordCompletion("case"),
+      this.createKeywordCompletion("of"),
+      this.createKeywordCompletion("type"),
+      this.createKeywordCompletion("alias"),
+      this.createKeywordCompletion("import"),
+      this.createKeywordCompletion("exposing")
     ];
   }
 }


### PR DESCRIPTION
Fixes #219. I wasn't sure about the sort order for keywords. I set the prefix to `a`, since it seems like in TypeScript the keywords are mostly towards the top, but it might not be correct. 