### PR TITLE
Fix hovers for custom types

### DIFF
--- a/src/util/hintHelper.ts
+++ b/src/util/hintHelper.ts
@@ -60,11 +60,22 @@ export class HintHelper {
       let code: string | undefined;
       let comment: string = "";
       let annotation: string = "";
-      if (declaration.type === "type_declaration") {
+      if (declaration.type === "type_declaration" || declaration.type === "type_alias_declaration") {
         code = declaration.text;
       }
       if (declaration.type === "union_variant") {
-        declaration = declaration.parent ? declaration.parent : declaration;
+        if (declaration.parent?.previousNamedSibling?.type !== "block_comment") {
+          code = declaration.text;
+
+          if (declaration.parent) {
+            const typeName = TreeUtils.findFirstNamedChildOfType(
+              "upper_case_identifier",
+              declaration.parent)?.text;
+            comment = `A variant on the union type \`${typeName}\`` || "";
+          }
+        } else {
+          declaration = declaration.parent ? declaration.parent : declaration;
+        }
       }
       if (declaration.previousNamedSibling) {
         if (declaration.previousNamedSibling.type === "type_annotation") {
@@ -72,7 +83,7 @@ export class HintHelper {
           if (
             declaration.previousNamedSibling.previousNamedSibling &&
             declaration.previousNamedSibling.previousNamedSibling.type ===
-              "block_comment"
+            "block_comment"
           ) {
             comment =
               declaration.previousNamedSibling.previousNamedSibling.text;


### PR DESCRIPTION
I think this fixes #209. Shows hovers for custom type aliases and types (when there isn't a block comment above it). I wasn't thrilled with the hovers for the union variants because of the lack of syntax coloring, but I think it is better than nothing. 