### PR TITLE
Add basic support for move function refactoring

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,21 @@
+import { RequestType, CodeActionParams } from 'vscode-languageserver';
+
+export const GetMoveDestinationRequest = new RequestType<MoveParams, MoveDestinationsResponse, void, void>('elm/getMoveDestinations');
+
+export const MoveRequest = new RequestType<MoveParams, void, void, void>('elm/move');
+
+export interface MoveParams {
+	sourceUri: string;
+	params: CodeActionParams;
+	destination?: string;
+}
+
+export interface MoveDestinationsResponse {
+	destinations: MoveDestination[];
+}
+
+export interface MoveDestination {
+	name: string,
+	path: string,
+	uri: string
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,21 +1,28 @@
-import { RequestType, CodeActionParams } from 'vscode-languageserver';
+import { RequestType, CodeActionParams } from "vscode-languageserver";
 
-export const GetMoveDestinationRequest = new RequestType<MoveParams, MoveDestinationsResponse, void, void>('elm/getMoveDestinations');
+export const GetMoveDestinationRequest = new RequestType<
+  MoveParams,
+  MoveDestinationsResponse,
+  void,
+  void
+>("elm/getMoveDestinations");
 
-export const MoveRequest = new RequestType<MoveParams, void, void, void>('elm/move');
+export const MoveRequest = new RequestType<MoveParams, void, void, void>(
+  "elm/move",
+);
 
 export interface MoveParams {
-	sourceUri: string;
-	params: CodeActionParams;
-	destination?: string;
+  sourceUri: string;
+  params: CodeActionParams;
+  destination?: MoveDestination;
 }
 
 export interface MoveDestinationsResponse {
-	destinations: MoveDestination[];
+  destinations: MoveDestination[];
 }
 
 export interface MoveDestination {
-	name: string,
-	path: string,
-	uri: string
+  name: string;
+  path: string;
+  uri: string;
 }

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -3,39 +3,103 @@ import {
   CodeActionParams,
   ExecuteCommandParams,
   IConnection,
+  CodeActionKind,
 } from "vscode-languageserver";
 import { ElmAnalyseDiagnostics } from "./diagnostics/elmAnalyseDiagnostics";
 import { ElmMakeDiagnostics } from "./diagnostics/elmMakeDiagnostics";
+import { MoveRefactoringHandler } from './handlers/moveRefactoringHandler';
+import { ElmWorkspace } from '../elmWorkspace';
+import { URI } from 'vscode-uri';
+import { ElmWorkspaceMatcher } from '../util/elmWorkspaceMatcher';
+import { TreeUtils } from '../util/treeUtils';
+import { Settings, IClientSettings } from '../util/settings';
+import { SyntaxNode } from 'web-tree-sitter';
 
 export class CodeActionProvider {
-  private connection: IConnection;
-  private elmAnalyse: ElmAnalyseDiagnostics | null;
-  private elmMake: ElmMakeDiagnostics;
-
   constructor(
-    connection: IConnection,
-    elmAnalyse: ElmAnalyseDiagnostics | null,
-    elmMake: ElmMakeDiagnostics,
+    private connection: IConnection,
+    private elmWorkspaces: ElmWorkspace[],
+    private settings: Settings,
+    private elmAnalyse: ElmAnalyseDiagnostics | null,
+    private elmMake: ElmMakeDiagnostics,
   ) {
-    this.connection = connection;
-    this.elmAnalyse = elmAnalyse;
-    this.elmMake = elmMake;
     this.onCodeAction = this.onCodeAction.bind(this);
     this.onExecuteCommand = this.onExecuteCommand.bind(this);
-    this.connection.onCodeAction(this.onCodeAction);
+    this.connection.onCodeAction(
+      new ElmWorkspaceMatcher(elmWorkspaces, (param: CodeActionParams) =>
+        URI.parse(param.textDocument.uri),
+      ).handlerForWorkspace(this.onCodeAction));
     this.connection.onExecuteCommand(this.onExecuteCommand);
+
+    if (settings.extendedCapabilities?.moveFunctionRefactoringSupport) {
+      new MoveRefactoringHandler(this.connection, this.elmWorkspaces);
+    }
   }
 
-  private onCodeAction(params: CodeActionParams): CodeAction[] {
+  private onCodeAction(
+    params: CodeActionParams,
+    elmWorkspace: ElmWorkspace
+  ): CodeAction[] {
     this.connection.console.info("A code action was requested");
     const analyse =
       (this.elmAnalyse && this.elmAnalyse.onCodeAction(params)) ?? [];
     const make = this.elmMake.onCodeAction(params);
-    return [...analyse, ...make];
+    return [...analyse, ...make, ...this.getRefactorCodeActions(params, elmWorkspace)];
   }
 
   private async onExecuteCommand(params: ExecuteCommandParams) {
     this.connection.console.info("A command execution was requested");
     return this.elmAnalyse && this.elmAnalyse.onExecuteCommand(params);
+  }
+
+  private getRefactorCodeActions(
+    params: CodeActionParams,
+    elmWorkspace: ElmWorkspace
+  ): CodeAction[] {
+    const codeActions: CodeAction[] = [];
+
+    const forest = elmWorkspace.getForest();
+    const tree = forest.getTree(params.textDocument.uri);
+
+    if (tree) {
+      const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+        tree.rootNode,
+        params.range.start,
+      );
+
+      if (this.settings.extendedCapabilities?.moveFunctionRefactoringSupport) {
+        codeActions.push(...this.getMoveFunctionCodeActions(params, nodeAtPosition));
+      }
+    }
+
+    return codeActions;
+  }
+
+  private getMoveFunctionCodeActions(
+    params: CodeActionParams,
+    nodeAtPosition: SyntaxNode
+  ): CodeAction[] {
+    const codeActions: CodeAction[] = [];
+
+    if (
+      nodeAtPosition.parent?.type === "type_annotation" ||
+      nodeAtPosition.parent?.type === "function_declaration_left"
+    ) {
+      codeActions.push({
+        title: "Move Function",
+        command: {
+          title: "Refactor",
+          command: "elm.refactor",
+          arguments: [
+            "moveFunction",
+            params,
+            nodeAtPosition.parent?.type === "type_annotation" ? nodeAtPosition.text : nodeAtPosition.parent.text
+          ]
+        },
+        kind: CodeActionKind.RefactorRewrite
+      });
+    }
+
+    return codeActions;
   }
 }

--- a/src/providers/handlers/moveRefactoringHandler.ts
+++ b/src/providers/handlers/moveRefactoringHandler.ts
@@ -1,169 +1,179 @@
-import { IConnection, TextEdit, Range, Position } from 'vscode-languageserver';
-import { GetMoveDestinationRequest, MoveDestinationsResponse, MoveParams, MoveRequest, MoveDestination } from '../../protocol';
-import { ElmWorkspace } from '../../elmWorkspace';
-import { URI } from 'vscode-uri';
-import { ElmWorkspaceMatcher } from '../../util/elmWorkspaceMatcher';
-import { TreeUtils } from '../../util/treeUtils';
-import { References } from '../../util/references';
+import { IConnection, TextEdit, Range, Position } from "vscode-languageserver";
+import {
+  GetMoveDestinationRequest,
+  MoveDestinationsResponse,
+  MoveParams,
+  MoveRequest,
+  MoveDestination,
+} from "../../protocol";
+import { ElmWorkspace } from "../../elmWorkspace";
+import { URI } from "vscode-uri";
+import { ElmWorkspaceMatcher } from "../../util/elmWorkspaceMatcher";
+import { TreeUtils } from "../../util/treeUtils";
+import { References } from "../../util/references";
 
 export class MoveRefactoringHandler {
-	constructor(
-		private connection: IConnection,
-		private elmWorkspaces: ElmWorkspace[]
-	) {
-		this.connection.onRequest(GetMoveDestinationRequest,
-			new ElmWorkspaceMatcher(elmWorkspaces, (param: MoveParams) =>
-				URI.parse(param.sourceUri),
-			).handlerForWorkspace(this.handleGetMoveDestinationsRequest.bind(this)));
+  constructor(
+    private connection: IConnection,
+    private elmWorkspaces: ElmWorkspace[],
+  ) {
+    this.connection.onRequest(
+      GetMoveDestinationRequest,
+      new ElmWorkspaceMatcher(elmWorkspaces, (param: MoveParams) =>
+        URI.parse(param.sourceUri),
+      ).handlerForWorkspace(this.handleGetMoveDestinationsRequest.bind(this)),
+    );
 
-		this.connection.onRequest(MoveRequest,
-			new ElmWorkspaceMatcher(elmWorkspaces, (param: MoveParams) =>
-				URI.parse(param.sourceUri),
-			).handlerForWorkspace(this.handleMoveRequest.bind(this)));
-	}
+    this.connection.onRequest(
+      MoveRequest,
+      new ElmWorkspaceMatcher(elmWorkspaces, (param: MoveParams) =>
+        URI.parse(param.sourceUri),
+      ).handlerForWorkspace(this.handleMoveRequest.bind(this)),
+    );
+  }
 
-	private handleGetMoveDestinationsRequest(
-		params: MoveParams,
-		elmWorkspace: ElmWorkspace
-	): MoveDestinationsResponse {
-		const forest = elmWorkspace.getForest();
+  private handleGetMoveDestinationsRequest(
+    params: MoveParams,
+    elmWorkspace: ElmWorkspace,
+  ): MoveDestinationsResponse {
+    const forest = elmWorkspace.getForest();
 
-		const destinations: MoveDestination[] = forest.treeIndex
-			.filter(tree => tree.writeable && tree.uri !== params.sourceUri)
-			.map(tree => {
-				let uri = URI.parse(tree.uri).fsPath;
-				const rootPath = elmWorkspace.getRootPath().fsPath
+    const destinations: MoveDestination[] = forest.treeIndex
+      .filter(tree => tree.writeable && tree.uri !== params.sourceUri)
+      .map(tree => {
+        let uri = URI.parse(tree.uri).fsPath;
+        const rootPath = elmWorkspace.getRootPath().fsPath;
 
-				uri = uri.slice(rootPath.length + 1);
-				const index = uri.lastIndexOf("\\");
+        uri = uri.slice(rootPath.length + 1);
+        const index = uri.lastIndexOf("\\");
 
-				return {
-					name: uri.slice(index + 1),
-					path: uri.slice(0, index),
-					uri: tree.uri
-				}
-			});
+        return {
+          name: uri.slice(index + 1),
+          path: uri.slice(0, index),
+          uri: tree.uri,
+        };
+      });
 
-		return {
-			destinations
-		}
-	}
+    return {
+      destinations,
+    };
+  }
 
-	private handleMoveRequest(
-		params: MoveParams,
-		elmWorkspace: ElmWorkspace
-	) {
-		if (!params.destination) {
-			return;
-		}
+  private handleMoveRequest(params: MoveParams, elmWorkspace: ElmWorkspace) {
+    if (!params.destination) {
+      return;
+    }
 
-		const forest = elmWorkspace.getForest();
-		const imports = elmWorkspace.getImports();
-		const tree = forest.getTree(params.sourceUri);
-		const destinationTree = forest.getTree(params.destination);
+    const forest = elmWorkspace.getForest();
+    const imports = elmWorkspace.getImports();
+    const tree = forest.getTree(params.sourceUri);
+    const destinationTree = forest.getTree(params.destination);
 
-		if (tree && destinationTree) {
-			const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
-				tree.rootNode,
-				params.params.range.start,
-			);
+    if (tree && destinationTree) {
+      const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+        tree.rootNode,
+        params.params.range.start,
+      );
 
-			const isTypeNode = nodeAtPosition.parent?.type === "type_annotation";
-			const isDeclarationNode = nodeAtPosition.parent?.parent?.type === "value_declaration";
+      const isTypeNode = nodeAtPosition.parent?.type === "type_annotation";
+      const isDeclarationNode =
+        nodeAtPosition.parent?.parent?.type === "value_declaration";
 
-			const typeNode = isDeclarationNode ?
-				nodeAtPosition.parent?.parent?.previousNamedSibling : isTypeNode ?
-					nodeAtPosition.parent : undefined;
+      const typeNode = isDeclarationNode
+        ? nodeAtPosition.parent?.parent?.previousNamedSibling
+        : isTypeNode
+        ? nodeAtPosition.parent
+        : undefined;
 
-			const declarationNode = isDeclarationNode ? nodeAtPosition.parent?.parent : isTypeNode ?
-				nodeAtPosition.parent?.nextNamedSibling : undefined;
+      const declarationNode = isDeclarationNode
+        ? nodeAtPosition.parent?.parent
+        : isTypeNode
+        ? nodeAtPosition.parent?.nextNamedSibling
+        : undefined;
 
-			const functionName = isTypeNode ? nodeAtPosition.text : nodeAtPosition.parent?.text;
+      const functionName = isTypeNode
+        ? nodeAtPosition.text
+        : nodeAtPosition.parent?.text;
 
-			if (typeNode && declarationNode) {
-				const startPosition = typeNode.startPosition;
-				const endPosition = declarationNode.endPosition;
+      if (typeNode && declarationNode) {
+        const startPosition = typeNode.startPosition;
+        const endPosition = declarationNode.endPosition;
 
-				const functionText = `\n\n${typeNode.text}\n${declarationNode.text}`;
+        const functionText = `\n\n${typeNode.text}\n${declarationNode.text}`;
 
-				const changes: { [uri: string]: TextEdit[] } = {};
+        const changes: { [uri: string]: TextEdit[] } = {};
 
-				changes[params.sourceUri] = [];
-				changes[params.destination] = [];
+        changes[params.sourceUri] = [];
+        changes[params.destination] = [];
 
-				// Remove from source
-				changes[params.sourceUri].push(TextEdit.del(
-					Range.create(
-						Position.create(
-							startPosition.row,
-							startPosition.column,
-						),
-						Position.create(
-							endPosition.row,
-							endPosition.column,
-						),
-					),
-				));
+        // Remove from source
+        changes[params.sourceUri].push(
+          TextEdit.del(
+            Range.create(
+              Position.create(startPosition.row, startPosition.column),
+              Position.create(endPosition.row, endPosition.column),
+            ),
+          ),
+        );
 
-				// Add to destination
-				changes[params.destination].push(TextEdit.insert(
-					Position.create(
-						destinationTree.rootNode.endPosition.row + 1,
-						0
-					),
-					functionText
-				));
+        // Add to destination
+        changes[params.destination].push(
+          TextEdit.insert(
+            Position.create(destinationTree.rootNode.endPosition.row + 1, 0),
+            functionText,
+          ),
+        );
 
-				// Update references
-				const destinationModuleName = TreeUtils.getModuleNameNode(destinationTree)?.text;
+        // Update references
+        const destinationModuleName = TreeUtils.getModuleNameNode(
+          destinationTree,
+        )?.text;
 
-				const references = References.find({
-					node: declarationNode,
-					nodeType: "Function",
-					uri: params.sourceUri
-				}, forest, imports);
+        const references = References.find(
+          {
+            node: declarationNode,
+            nodeType: "Function",
+            uri: params.sourceUri,
+          },
+          forest,
+          imports,
+        );
 
-				const referenceUris = new Set(references.map(ref => ref.uri));
+        const referenceUris = new Set(references.map(ref => ref.uri));
 
-				// TODO: Unexpose function in the source file if is
-				// TODO: Remove old imports to the old source file from all reference uris
+        // TODO: Unexpose function in the source file if is
+        // TODO: Remove old imports to the old source file from all reference uris
 
-				referenceUris.delete(params.destination);
+        referenceUris.delete(params.destination);
 
-				if (referenceUris.size > 0) {
-					// TODO: Expose function in destination file if there are external references
-				}
+        if (referenceUris.size > 0) {
+          // TODO: Expose function in destination file if there are external references
+        }
 
-				// Add the new imports for each file with a reference
-				referenceUris.forEach(refUri => {
-					if (!changes[refUri]) {
-						changes[refUri] = [];
-					}
+        // Add the new imports for each file with a reference
+        referenceUris.forEach(refUri => {
+          if (!changes[refUri]) {
+            changes[refUri] = [];
+          }
 
-					const refTree = forest.getTree(refUri);
+          const refTree = forest.getTree(refUri);
 
-					if (refTree) {
-						const importNodes = TreeUtils.findAllNamedChildrenOfType(
-							"import_clause",
-							refTree.rootNode
-						);
+          if (refTree) {
+            const lastImportNode = TreeUtils.getLastImportNode(refTree);
 
-						if (importNodes?.length) {
-							const lastImportNode = importNodes[importNodes?.length - 1];
+            if (lastImportNode) {
+              changes[refUri].push(
+                TextEdit.insert(
+                  Position.create(lastImportNode.endPosition.row + 1, 0),
+                  `import ${destinationModuleName} exposing (${functionName})`,
+                ),
+              );
+            }
+          }
+        });
 
-							changes[refUri].push(TextEdit.insert(
-								Position.create(
-									lastImportNode.endPosition.row + 1,
-									0
-								),
-								`import ${destinationModuleName} exposing (${functionName})`
-							));
-						}
-					}
-				});
-
-				this.connection.workspace.applyEdit({ changes });
-			}
-		}
-	}
+        this.connection.workspace.applyEdit({ changes });
+      }
+    }
+  }
 }

--- a/src/providers/handlers/moveRefactoringHandler.ts
+++ b/src/providers/handlers/moveRefactoringHandler.ts
@@ -1,0 +1,169 @@
+import { IConnection, TextEdit, Range, Position } from 'vscode-languageserver';
+import { GetMoveDestinationRequest, MoveDestinationsResponse, MoveParams, MoveRequest, MoveDestination } from '../../protocol';
+import { ElmWorkspace } from '../../elmWorkspace';
+import { URI } from 'vscode-uri';
+import { ElmWorkspaceMatcher } from '../../util/elmWorkspaceMatcher';
+import { TreeUtils } from '../../util/treeUtils';
+import { References } from '../../util/references';
+
+export class MoveRefactoringHandler {
+	constructor(
+		private connection: IConnection,
+		private elmWorkspaces: ElmWorkspace[]
+	) {
+		this.connection.onRequest(GetMoveDestinationRequest,
+			new ElmWorkspaceMatcher(elmWorkspaces, (param: MoveParams) =>
+				URI.parse(param.sourceUri),
+			).handlerForWorkspace(this.handleGetMoveDestinationsRequest.bind(this)));
+
+		this.connection.onRequest(MoveRequest,
+			new ElmWorkspaceMatcher(elmWorkspaces, (param: MoveParams) =>
+				URI.parse(param.sourceUri),
+			).handlerForWorkspace(this.handleMoveRequest.bind(this)));
+	}
+
+	private handleGetMoveDestinationsRequest(
+		params: MoveParams,
+		elmWorkspace: ElmWorkspace
+	): MoveDestinationsResponse {
+		const forest = elmWorkspace.getForest();
+
+		const destinations: MoveDestination[] = forest.treeIndex
+			.filter(tree => tree.writeable && tree.uri !== params.sourceUri)
+			.map(tree => {
+				let uri = URI.parse(tree.uri).fsPath;
+				const rootPath = elmWorkspace.getRootPath().fsPath
+
+				uri = uri.slice(rootPath.length + 1);
+				const index = uri.lastIndexOf("\\");
+
+				return {
+					name: uri.slice(index + 1),
+					path: uri.slice(0, index),
+					uri: tree.uri
+				}
+			});
+
+		return {
+			destinations
+		}
+	}
+
+	private handleMoveRequest(
+		params: MoveParams,
+		elmWorkspace: ElmWorkspace
+	) {
+		if (!params.destination) {
+			return;
+		}
+
+		const forest = elmWorkspace.getForest();
+		const imports = elmWorkspace.getImports();
+		const tree = forest.getTree(params.sourceUri);
+		const destinationTree = forest.getTree(params.destination);
+
+		if (tree && destinationTree) {
+			const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+				tree.rootNode,
+				params.params.range.start,
+			);
+
+			const isTypeNode = nodeAtPosition.parent?.type === "type_annotation";
+			const isDeclarationNode = nodeAtPosition.parent?.parent?.type === "value_declaration";
+
+			const typeNode = isDeclarationNode ?
+				nodeAtPosition.parent?.parent?.previousNamedSibling : isTypeNode ?
+					nodeAtPosition.parent : undefined;
+
+			const declarationNode = isDeclarationNode ? nodeAtPosition.parent?.parent : isTypeNode ?
+				nodeAtPosition.parent?.nextNamedSibling : undefined;
+
+			const functionName = isTypeNode ? nodeAtPosition.text : nodeAtPosition.parent?.text;
+
+			if (typeNode && declarationNode) {
+				const startPosition = typeNode.startPosition;
+				const endPosition = declarationNode.endPosition;
+
+				const functionText = `\n\n${typeNode.text}\n${declarationNode.text}`;
+
+				const changes: { [uri: string]: TextEdit[] } = {};
+
+				changes[params.sourceUri] = [];
+				changes[params.destination] = [];
+
+				// Remove from source
+				changes[params.sourceUri].push(TextEdit.del(
+					Range.create(
+						Position.create(
+							startPosition.row,
+							startPosition.column,
+						),
+						Position.create(
+							endPosition.row,
+							endPosition.column,
+						),
+					),
+				));
+
+				// Add to destination
+				changes[params.destination].push(TextEdit.insert(
+					Position.create(
+						destinationTree.rootNode.endPosition.row + 1,
+						0
+					),
+					functionText
+				));
+
+				// Update references
+				const destinationModuleName = TreeUtils.getModuleNameNode(destinationTree)?.text;
+
+				const references = References.find({
+					node: declarationNode,
+					nodeType: "Function",
+					uri: params.sourceUri
+				}, forest, imports);
+
+				const referenceUris = new Set(references.map(ref => ref.uri));
+
+				// TODO: Unexpose function in the source file if is
+				// TODO: Remove old imports to the old source file from all reference uris
+
+				referenceUris.delete(params.destination);
+
+				if (referenceUris.size > 0) {
+					// TODO: Expose function in destination file if there are external references
+				}
+
+				// Add the new imports for each file with a reference
+				referenceUris.forEach(refUri => {
+					if (!changes[refUri]) {
+						changes[refUri] = [];
+					}
+
+					const refTree = forest.getTree(refUri);
+
+					if (refTree) {
+						const importNodes = TreeUtils.findAllNamedChildrenOfType(
+							"import_clause",
+							refTree.rootNode
+						);
+
+						if (importNodes?.length) {
+							const lastImportNode = importNodes[importNodes?.length - 1];
+
+							changes[refUri].push(TextEdit.insert(
+								Position.create(
+									lastImportNode.endPosition.row + 1,
+									0
+								),
+								`import ${destinationModuleName} exposing (${functionName})`
+							));
+						}
+					}
+				});
+
+				this.connection.workspace.applyEdit({ changes });
+			}
+		}
+	}
+}

--- a/src/providers/handlers/moveRefactoringHandler.ts
+++ b/src/providers/handlers/moveRefactoringHandler.ts
@@ -102,9 +102,7 @@ export class MoveRefactoringHandler {
           ? declarationNode.previousNamedSibling
           : undefined;
 
-      const functionName = isTypeNode
-        ? nodeAtPosition.text
-        : nodeAtPosition.parent?.text;
+      const functionName = nodeAtPosition.text;
 
       const moduleName = TreeUtils.getModuleNameNode(tree)?.text;
 

--- a/src/providers/handlers/moveRefactoringHandler.ts
+++ b/src/providers/handlers/moveRefactoringHandler.ts
@@ -264,7 +264,7 @@ export class MoveRefactoringHandler {
             const importEdit = RefactorEditUtils.addImport(
               refTree,
               destinationModuleName,
-              needToExpose ? functionName : "",
+              needToExpose ? functionName : undefined,
             );
 
             if (importEdit) {

--- a/src/providers/handlers/moveRefactoringHandler.ts
+++ b/src/providers/handlers/moveRefactoringHandler.ts
@@ -95,6 +95,13 @@ export class MoveRefactoringHandler {
         ? nodeAtPosition.parent?.nextNamedSibling
         : undefined;
 
+      const commentNode =
+        typeNode?.previousNamedSibling?.type === "block_comment"
+          ? typeNode.previousNamedSibling
+          : declarationNode?.previousNamedSibling?.type === "block_comment"
+          ? declarationNode.previousNamedSibling
+          : undefined;
+
       const functionName = isTypeNode
         ? nodeAtPosition.text
         : nodeAtPosition.parent?.text;
@@ -111,12 +118,14 @@ export class MoveRefactoringHandler {
         destinationModuleName
       ) {
         const startPosition =
-          typeNode?.startPosition ?? declarationNode.startPosition;
+          commentNode?.startPosition ??
+          typeNode?.startPosition ??
+          declarationNode.startPosition;
         const endPosition = declarationNode.endPosition;
 
-        const functionText = `\n\n${typeNode ? `${typeNode.text}\n` : ""}${
-          declarationNode.text
-        }`;
+        const functionText = `\n\n${
+          commentNode ? `${commentNode.text}\n` : ""
+        }${typeNode ? `${typeNode.text}\n` : ""}${declarationNode.text}`;
 
         const changes: { [uri: string]: TextEdit[] } = {};
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,12 +153,12 @@ export class Server implements ILanguageServer {
     const elmAnalyse =
       settings.elmAnalyseTrigger !== "never"
         ? new ElmAnalyseDiagnostics(
-          this.connection,
-          this.elmWorkspaces,
-          textDocumentEvents,
-          this.settings,
-          documentFormattingProvider,
-        )
+            this.connection,
+            this.elmWorkspaces,
+            textDocumentEvents,
+            this.settings,
+            documentFormattingProvider,
+          )
         : null;
 
     const elmMake = new ElmMakeDiagnostics(
@@ -177,7 +177,13 @@ export class Server implements ILanguageServer {
       elmMake,
     );
 
-    new CodeActionProvider(this.connection, this.elmWorkspaces, this.settings, elmAnalyse, elmMake);
+    new CodeActionProvider(
+      this.connection,
+      this.elmWorkspaces,
+      this.settings,
+      elmAnalyse,
+      elmMake,
+    );
 
     // tslint:disable:no-unused-expression
     new ASTProvider(

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,12 +153,12 @@ export class Server implements ILanguageServer {
     const elmAnalyse =
       settings.elmAnalyseTrigger !== "never"
         ? new ElmAnalyseDiagnostics(
-            this.connection,
-            this.elmWorkspaces,
-            textDocumentEvents,
-            this.settings,
-            documentFormattingProvider,
-          )
+          this.connection,
+          this.elmWorkspaces,
+          textDocumentEvents,
+          this.settings,
+          documentFormattingProvider,
+        )
         : null;
 
     const elmMake = new ElmMakeDiagnostics(
@@ -177,7 +177,7 @@ export class Server implements ILanguageServer {
       elmMake,
     );
 
-    new CodeActionProvider(this.connection, elmAnalyse, elmMake);
+    new CodeActionProvider(this.connection, this.elmWorkspaces, this.settings, elmAnalyse, elmMake);
 
     // tslint:disable:no-unused-expression
     new ASTProvider(

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -84,7 +84,7 @@ export class RefactorEditUtils {
 
   public static changeQualifiedReferenceModule(
     node: SyntaxNode,
-    moduleName: string,
+    newModuleName: string,
   ): TextEdit | undefined {
     if (node.parent && node.parent.type === "value_qid") {
       const moduleNode = TreeUtils.findFirstNamedChildOfType(
@@ -104,7 +104,7 @@ export class RefactorEditUtils {
               moduleNode.endPosition.column,
             ),
           ),
-          moduleName,
+          newModuleName,
         );
       }
     }

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -68,15 +68,71 @@ export class RefactorEditUtils {
   public static addImport(
     tree: Tree,
     moduleName: string,
-    valueName: string,
+    valueName?: string,
   ): TextEdit | undefined {
     const lastImportNode = TreeUtils.getLastImportNode(tree);
 
     if (lastImportNode) {
       return TextEdit.insert(
         Position.create(lastImportNode.endPosition.row + 1, 0),
-        `import ${moduleName} exposing (${valueName})`,
+        valueName
+          ? `import ${moduleName} exposing (${valueName})`
+          : `import ${moduleName}`,
       );
+    }
+  }
+
+  public static changeQualifiedReferenceModule(
+    node: SyntaxNode,
+    moduleName: string,
+  ): TextEdit | undefined {
+    if (node.parent && node.parent.type === "value_qid") {
+      const moduleNode = TreeUtils.findFirstNamedChildOfType(
+        "upper_case_identifier",
+        node.parent,
+      );
+
+      if (moduleNode) {
+        return TextEdit.replace(
+          Range.create(
+            Position.create(
+              moduleNode.startPosition.row,
+              moduleNode.startPosition.column,
+            ),
+            Position.create(
+              moduleNode.endPosition.row,
+              moduleNode.endPosition.column,
+            ),
+          ),
+          moduleName,
+        );
+      }
+    }
+  }
+
+  public static removeQualifiedReference(
+    node: SyntaxNode,
+  ): TextEdit | undefined {
+    if (node.parent && node.parent.type === "value_qid") {
+      const moduleNode = TreeUtils.findFirstNamedChildOfType(
+        "upper_case_identifier",
+        node.parent,
+      );
+
+      if (moduleNode) {
+        return TextEdit.del(
+          Range.create(
+            Position.create(
+              moduleNode.startPosition.row,
+              moduleNode.startPosition.column,
+            ),
+            Position.create(
+              moduleNode.endPosition.row,
+              moduleNode.endPosition.column + 1,
+            ),
+          ),
+        );
+      }
     }
   }
 

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -1,0 +1,112 @@
+import { Tree, SyntaxNode } from "web-tree-sitter";
+import { TextEdit, Position, Range } from "vscode-languageserver";
+import { TreeUtils } from "./treeUtils";
+
+export class RefactorEditUtils {
+  public static unexposedValueInModule(
+    tree: Tree,
+    valueName: string,
+  ): TextEdit | undefined {
+    const exposedNodes = TreeUtils.getModuleExposingListNodes(tree);
+    return this.removeValueFromExposingList(exposedNodes, valueName);
+  }
+
+  public static exposeValueInModule(
+    tree: Tree,
+    valueName: string,
+  ): TextEdit | undefined {
+    const exposedNodes = TreeUtils.getModuleExposingListNodes(tree);
+
+    if (exposedNodes.length > 0) {
+      const lastExposedNode = exposedNodes[exposedNodes.length - 1];
+
+      if (lastExposedNode) {
+        return TextEdit.insert(
+          Position.create(
+            lastExposedNode.endPosition.row,
+            lastExposedNode.endPosition.column,
+          ),
+          `, ${valueName}`,
+        );
+      }
+    }
+  }
+
+  public static removeValueFromImport(
+    tree: Tree,
+    moduleName: string,
+    valueName: string,
+  ): TextEdit | undefined {
+    const importClause = TreeUtils.findImportClauseByName(tree, moduleName);
+
+    if (importClause) {
+      const exposedValues = TreeUtils.descendantsOfType(
+        importClause,
+        "exposed_value",
+      );
+
+      if (exposedValues.length === 1 && exposedValues[0].text === valueName) {
+        // Remove the entire import if it was the only one
+        return TextEdit.del(
+          Range.create(
+            Position.create(
+              importClause.startPosition.row,
+              importClause.startPosition.column,
+            ),
+            Position.create(
+              importClause.endPosition.row,
+              importClause.endPosition.column,
+            ),
+          ),
+        );
+      } else {
+        return this.removeValueFromExposingList(exposedValues, valueName);
+      }
+    }
+  }
+
+  public static addImport(
+    tree: Tree,
+    moduleName: string,
+    valueName: string,
+  ): TextEdit | undefined {
+    const lastImportNode = TreeUtils.getLastImportNode(tree);
+
+    if (lastImportNode) {
+      return TextEdit.insert(
+        Position.create(lastImportNode.endPosition.row + 1, 0),
+        `import ${moduleName} exposing (${valueName})`,
+      );
+    }
+  }
+
+  private static removeValueFromExposingList(
+    exposedNodes: SyntaxNode[],
+    valueName: string,
+  ): TextEdit | undefined {
+    const exposedNode = exposedNodes.find(node => node.text === valueName);
+
+    if (exposedNode) {
+      let startPosition = exposedNode.startPosition;
+      let endPosition = exposedNode.endPosition;
+
+      if (exposedNode.previousNamedSibling?.text === ",") {
+        startPosition = exposedNode.previousNamedSibling.startPosition;
+      }
+
+      if (
+        exposedNode.previousNamedSibling?.text !== "," &&
+        exposedNode.nextNamedSibling?.text === ","
+      ) {
+        endPosition = exposedNode.nextNamedSibling.endPosition;
+      }
+
+      return TextEdit.del(
+        Range.create(
+          Position.create(startPosition.row, startPosition.column),
+          Position.create(endPosition.row, endPosition.column),
+        ),
+      );
+    }
+  }
+}

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -6,6 +6,11 @@ export interface IClientSettings {
   elmTestPath: string;
   elmAnalyseTrigger: ElmAnalyseTrigger;
   trace: { server: string };
+  extendedCapabilities?: IExtendedCapabilites;
+}
+
+export interface IExtendedCapabilites {
+  moveFunctionRefactoringSupport: boolean;
 }
 
 export type ElmAnalyseTrigger = "change" | "save" | "never";
@@ -44,6 +49,10 @@ export class Settings {
       );
     }
     return this.clientSettings;
+  }
+
+  public get extendedCapabilities(): IExtendedCapabilites | undefined {
+    return this.clientSettings.extendedCapabilities;
   }
 
   private updateSettings(config: any): void {

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -687,13 +687,13 @@ export class TreeUtils {
     ) {
       const definitionNode =
         nodeAtPosition.parent.parent &&
-          nodeAtPosition.parent.parent.parent &&
-          nodeAtPosition.parent.parent.parent.type === "let"
+        nodeAtPosition.parent.parent.parent &&
+        nodeAtPosition.parent.parent.parent.type === "let"
           ? this.findFunction(
-            nodeAtPosition.parent.parent.parent,
-            nodeAtPosition.text,
-            false,
-          )
+              nodeAtPosition.parent.parent.parent,
+              nodeAtPosition.text,
+              false,
+            )
           : this.findFunction(tree.rootNode, nodeAtPosition.text);
 
       if (definitionNode) {
@@ -1162,13 +1162,10 @@ export class TreeUtils {
   public static getReturnTypeOrTypeAliasOfFunctionDefinition(
     node: SyntaxNode | undefined,
   ): SyntaxNode | undefined {
-    if (
-      node &&
-      node.previousNamedSibling?.type === "type_annotation"
-    ) {
+    if (node && node.previousNamedSibling?.type === "type_annotation") {
       const typeAnnotationNodes = TreeUtils.descendantsOfType(
         node.previousNamedSibling,
-        "type_ref"
+        "type_ref",
       );
       if (typeAnnotationNodes) {
         const type = typeAnnotationNodes[typeAnnotationNodes.length - 1];
@@ -1181,14 +1178,18 @@ export class TreeUtils {
     node: SyntaxNode | undefined,
     tree: Tree,
     imports: IImports,
-    uri: string
+    uri: string,
   ): SyntaxNode | undefined {
-    if (node?.parent?.type == "function_call_expr" && node.parent.firstNamedChild) {
-      const parameterIndex = node.parent.namedChildren.map(c => c.text).indexOf(node.text) - 1;
+    if (
+      node?.parent?.type == "function_call_expr" &&
+      node.parent.firstNamedChild
+    ) {
+      const parameterIndex =
+        node.parent.namedChildren.map(c => c.text).indexOf(node.text) - 1;
 
       const functionName = TreeUtils.descendantsOfType(
         node.parent.firstNamedChild,
-        "lower_case_identifier"
+        "lower_case_identifier",
       );
 
       const functionDefinition = TreeUtils.findDefinitionNodeByReferencingNode(
@@ -1201,7 +1202,7 @@ export class TreeUtils {
       if (functionDefinition?.node.previousNamedSibling?.lastNamedChild) {
         const typeAnnotationNodes = TreeUtils.findAllNamedChildrenOfType(
           ["type_ref", "record_type"],
-          functionDefinition.node.previousNamedSibling.lastNamedChild
+          functionDefinition.node.previousNamedSibling.lastNamedChild,
         );
 
         if (typeAnnotationNodes) {
@@ -1210,7 +1211,7 @@ export class TreeUtils {
           if (typeNode?.type === "type_ref") {
             const typeNodes = TreeUtils.descendantsOfType(
               typeNode,
-              "upper_case_identifier"
+              "upper_case_identifier",
             );
 
             if (typeNodes.length > 0) {
@@ -1233,16 +1234,11 @@ export class TreeUtils {
     node: SyntaxNode | undefined,
     tree: Tree,
     imports: IImports,
-    uri: string
+    uri: string,
   ): SyntaxNode | undefined {
     const fieldName = node?.parent?.firstNamedChild?.text;
 
-    let recordType = TreeUtils.getTypeAliasOfRecord(
-      node,
-      tree,
-      imports,
-      uri
-    );
+    let recordType = TreeUtils.getTypeAliasOfRecord(node, tree, imports, uri);
 
     while (!recordType && node?.parent?.parent) {
       node = node.parent.parent;
@@ -1250,17 +1246,17 @@ export class TreeUtils {
         node,
         tree,
         imports,
-        uri
+        uri,
       );
     }
 
     if (recordType) {
       const fieldTypes = TreeUtils.descendantsOfType(recordType, "field_type");
       const fieldNode = fieldTypes.find(a => {
-        return TreeUtils.findFirstNamedChildOfType(
-          "lower_case_identifier",
-          a,
-        )?.text === fieldName;
+        return (
+          TreeUtils.findFirstNamedChildOfType("lower_case_identifier", a)
+            ?.text === fieldName
+        );
       });
 
       if (fieldNode) {
@@ -1272,7 +1268,7 @@ export class TreeUtils {
         if (typeExpression) {
           const typeNode = TreeUtils.descendantsOfType(
             typeExpression,
-            "upper_case_identifier"
+            "upper_case_identifier",
           );
 
           if (typeNode.length > 0) {
@@ -1295,17 +1291,22 @@ export class TreeUtils {
     uri: string,
   ): SyntaxNode | undefined {
     if (node?.parent?.parent) {
-      let type = TreeUtils.findFirstNamedChildOfType(
-        "record_base_identifier",
-        node.parent.parent,
-      ) ?? TreeUtils.findFirstNamedChildOfType(
-        "record_base_identifier",
-        node.parent,
-      );
+      let type =
+        TreeUtils.findFirstNamedChildOfType(
+          "record_base_identifier",
+          node.parent.parent,
+        ) ??
+        TreeUtils.findFirstNamedChildOfType(
+          "record_base_identifier",
+          node.parent,
+        );
 
       // Handle records of function returns
       if (!type && node.parent.parent.parent) {
-        type = TreeUtils.getReturnTypeOrTypeAliasOfFunctionDefinition(node.parent.parent.parent)?.parent ?? undefined;
+        type =
+          TreeUtils.getReturnTypeOrTypeAliasOfFunctionDefinition(
+            node.parent.parent.parent,
+          )?.parent ?? undefined;
       }
 
       if (type && type.firstNamedChild) {
@@ -1319,9 +1320,13 @@ export class TreeUtils {
         if (definitionNode) {
           let aliasNode;
           if (definitionNode.nodeType == "FunctionParameter") {
-            aliasNode = TreeUtils.getTypeOrTypeAliasOfFunctionParameter(definitionNode.node);
+            aliasNode = TreeUtils.getTypeOrTypeAliasOfFunctionParameter(
+              definitionNode.node,
+            );
           } else if (definitionNode.nodeType == "Function") {
-            aliasNode = TreeUtils.getReturnTypeOrTypeAliasOfFunctionDefinition(definitionNode.node);
+            aliasNode = TreeUtils.getReturnTypeOrTypeAliasOfFunctionDefinition(
+              definitionNode.node,
+            );
           } else if (definitionNode.nodeType == "TypeAlias") {
             aliasNode = definitionNode.node;
           }
@@ -1329,7 +1334,7 @@ export class TreeUtils {
           if (aliasNode) {
             const childNode = TreeUtils.descendantsOfType(
               aliasNode,
-              "upper_case_identifier"
+              "upper_case_identifier",
             );
 
             if (childNode.length > 0) {
@@ -1386,7 +1391,7 @@ export class TreeUtils {
       position.character === 0 ? 0 : position.character - 1;
     const charBeforeCursor = node.text
       .split("\n")
-    [position.line].substring(previousCharColumn, position.character);
+      [position.line].substring(previousCharColumn, position.character);
 
     if (!functionNameRegex.test(charBeforeCursor)) {
       return node.namedDescendantForPosition({
@@ -1440,6 +1445,13 @@ export class TreeUtils {
     }
     if (node.parent) {
       return this.findParentOfType(typeToLookFor, node.parent);
+    }
+  }
+
+  public static getLastImportNode(tree: Tree): SyntaxNode | undefined {
+    const allImportNodes = this.findAllImportNameNodes(tree);
+    if (allImportNodes?.length) {
+      return allImportNodes[allImportNodes.length - 1];
     }
   }
 

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -39,6 +39,16 @@ export class TreeUtils {
     }
   }
 
+  public static getModuleExposingListNodes(tree: Tree): SyntaxNode[] {
+    const moduleNode = TreeUtils.findModuleDeclaration(tree);
+
+    if (moduleNode) {
+      return TreeUtils.descendantsOfType(moduleNode, "exposed_value");
+    }
+
+    return [];
+  }
+
   public static getModuleNameAndExposing(
     tree: Tree,
   ): { moduleName: string; exposing: Exposing } | undefined {

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -1465,6 +1465,14 @@ export class TreeUtils {
     }
   }
 
+  public static isReferenceFullyQualified(node: SyntaxNode): boolean {
+    return (
+      node.previousNamedSibling?.type === "dot" &&
+      node.previousNamedSibling?.previousNamedSibling?.type ===
+        "upper_case_identifier"
+    );
+  }
+
   // tslint:disable-next-line: no-identical-functions
   private static findAllImportNameNodes(tree: Tree): SyntaxNode[] | undefined {
     const result = tree.rootNode.children.filter(


### PR DESCRIPTION
Part of #194. It adds basic support for a new code action to move a function to a new file. It is a fair amount of changes so I wanted to get your feedback to make sure it was a good direction. 

Because this type of refactoring requires client support (quick pick for the destination file),
I added a new `extendedCapabilites` property to the client settings that the client can initialize. Right now the only property is `moveFunctionRefactoringSupport`, but more can easily be added.

I also added a `protocol.ts` that defines the custom requests between the server and client. 

Currently, in vscode, you can move a function to a new file and it adds new imports to all files with references. Dependent on https://github.com/elm-tooling/elm-language-client-vscode/pull/88.