### PR TITLE
Add the ability to expose/unexpose functions and types

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -26,3 +26,22 @@ export interface MoveDestination {
   path: string;
   uri: string;
 }
+
+export const ExposeRequest = new RequestType<
+  ExposeUnexposeParams,
+  void,
+  void,
+  void
+>("elm/expose");
+
+export interface ExposeUnexposeParams {
+  uri: string;
+  name: string;
+}
+
+export const UnexposeRequest = new RequestType<
+  ExposeUnexposeParams,
+  void,
+  void,
+  void
+>("elm/unexpose");

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -122,10 +122,6 @@ export class CodeActionProvider {
         if (edit) {
           codeActions.push({
             title: "Unexpose Function",
-            command: Command.create("Unexpose", "elm.unexpose", {
-              uri: params.textDocument.uri,
-              name: functionName,
-            }),
             edit: {
               changes: {
                 [params.textDocument.uri]: [edit],

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -41,7 +41,6 @@ export class CodeActionProvider {
       new MoveRefactoringHandler(this.connection, this.elmWorkspaces);
     }
 
-    new MoveRefactoringHandler(this.connection, this.elmWorkspaces);
     new ExposeUnexposeHandler(this.connection, this.elmWorkspaces);
   }
 

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -100,10 +100,7 @@ export class CodeActionProvider {
       nodeAtPosition.parent?.type === "type_annotation" ||
       nodeAtPosition.parent?.type === "function_declaration_left"
     ) {
-      const functionName =
-        nodeAtPosition.parent?.type === "type_annotation"
-          ? nodeAtPosition.text
-          : nodeAtPosition.parent.text;
+      const functionName = nodeAtPosition.text;
 
       if (this.settings.extendedCapabilities?.moveFunctionRefactoringSupport) {
         codeActions.push({

--- a/src/providers/handlers/exposeUnexposeHandler.ts
+++ b/src/providers/handlers/exposeUnexposeHandler.ts
@@ -1,0 +1,68 @@
+import { IConnection, ExecuteCommandParams } from "vscode-languageserver";
+import { ElmWorkspace } from "../../elmWorkspace";
+import { ElmWorkspaceMatcher } from "../../util/elmWorkspaceMatcher";
+import { URI } from "vscode-uri";
+import { ExposeRequest, UnexposeRequest } from "../../protocol";
+import { ExposeUnexposeParams } from "../../protocol";
+import { RefactorEditUtils } from "../../util/refactorEditUtils";
+
+export class ExposeUnexposeHandler {
+  constructor(
+    private connection: IConnection,
+    private elmWorkspaces: ElmWorkspace[],
+  ) {
+    this.connection.onRequest(
+      ExposeRequest,
+      new ElmWorkspaceMatcher(elmWorkspaces, (params: ExposeUnexposeParams) =>
+        URI.parse(params.uri),
+      ).handlerForWorkspace(this.handleExposeRequest.bind(this)),
+    );
+
+    this.connection.onRequest(
+      UnexposeRequest,
+      new ElmWorkspaceMatcher(elmWorkspaces, (params: ExposeUnexposeParams) =>
+        URI.parse(params.uri),
+      ).handlerForWorkspace(this.handleUnexposeRequest.bind(this)),
+    );
+  }
+
+  private handleExposeRequest(
+    params: ExposeUnexposeParams,
+    elmWorkspace: ElmWorkspace,
+  ) {
+    const forest = elmWorkspace.getForest();
+    const tree = forest.getTree(params.uri);
+
+    if (tree) {
+      const edits = RefactorEditUtils.exposeValueInModule(tree, params.name);
+
+      if (edits) {
+        this.connection.workspace.applyEdit({
+          changes: {
+            [params.uri]: [edits],
+          },
+        });
+      }
+    }
+  }
+
+  private handleUnexposeRequest(
+    params: ExposeUnexposeParams,
+    elmWorkspace: ElmWorkspace,
+  ) {
+    const forest = elmWorkspace.getForest();
+    const tree = forest.getTree(params.uri);
+
+    if (tree) {
+      const edits = RefactorEditUtils.unexposedValueInModule(tree, params.name);
+
+      if (edits) {
+        this.connection.workspace.applyEdit({
+          changes: {
+            [params.uri]: [edits],
+          },
+        });
+      }
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -199,7 +199,7 @@ export class Server implements ILanguageServer {
     new ReferencesProvider(this.connection, this.elmWorkspaces);
     new DocumentSymbolProvider(this.connection, this.elmWorkspaces);
     new WorkspaceSymbolProvider(this.connection, this.elmWorkspaces);
-    new CodeLensProvider(this.connection, this.elmWorkspaces);
+    new CodeLensProvider(this.connection, this.elmWorkspaces, this.settings);
     new SelectionRangeProvider(this.connection, this.elmWorkspaces);
     new RenameProvider(this.connection, this.elmWorkspaces);
   }

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -140,7 +140,9 @@ export class RefactorEditUtils {
     exposedNodes: SyntaxNode[],
     valueName: string,
   ): TextEdit | undefined {
-    const exposedNode = exposedNodes.find((node) => node.text === valueName);
+    const exposedNode = exposedNodes.find(
+      (node) => node.text === valueName || node.text === `${valueName}(..)`,
+    );
 
     if (exposedNode) {
       let startPosition = exposedNode.startPosition;

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -11,6 +11,7 @@ export interface IClientSettings {
 
 export interface IExtendedCapabilites {
   moveFunctionRefactoringSupport: boolean;
+  exposeUnexposeSupport: boolean;
 }
 
 export type ElmAnalyseTrigger = "change" | "save" | "never";

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -44,7 +44,10 @@ export class TreeUtils {
     const moduleNode = TreeUtils.findModuleDeclaration(tree);
 
     if (moduleNode) {
-      return TreeUtils.descendantsOfType(moduleNode, "exposed_value");
+      return [
+        ...TreeUtils.descendantsOfType(moduleNode, "exposed_value"),
+        ...TreeUtils.descendantsOfType(moduleNode, "exposed_type"),
+      ];
     }
 
     return [];


### PR DESCRIPTION
Adds code actions and code lenses for exposing and unexposing functions and types. Closes #192. 

Code lenses need client side support since they can only send commands, not workspace edits. (https://github.com/elm-tooling/elm-language-client-vscode/pull/91)