### PR TITLE
Record definition and completion fixes

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -164,6 +164,7 @@ export class CompletionProvider {
           replaceRange,
           elmWorkspace.getImports(),
           params.textDocument.uri,
+          forest,
         );
       }
 
@@ -451,6 +452,7 @@ export class CompletionProvider {
     range: Range,
     imports: IImports,
     uri: string,
+    forest: IForest,
   ): CompletionItem[] {
     const result: CompletionItem[] = [];
     let typeDeclarationNode = TreeUtils.getTypeAliasOfRecord(
@@ -458,7 +460,8 @@ export class CompletionProvider {
       tree,
       imports,
       uri,
-    );
+      forest,
+    )?.node;
 
     if (!typeDeclarationNode && node.parent?.parent) {
       typeDeclarationNode = TreeUtils.getTypeAliasOfRecordField(
@@ -466,7 +469,8 @@ export class CompletionProvider {
         tree,
         imports,
         uri,
-      );
+        forest,
+      )?.node;
     }
 
     if (!typeDeclarationNode && node.parent?.parent) {

--- a/src/providers/definitionProvider.ts
+++ b/src/providers/definitionProvider.ts
@@ -50,6 +50,7 @@ export class DefinitionProvider {
         param.textDocument.uri,
         tree,
         elmWorkspace.getImports(),
+        forest,
       );
 
       if (definitionNode) {


### PR DESCRIPTION
Fixes #246 as well as record completions for some imported functions. 

**Technical summary of changes:**
The function `getTypeAliasOfRecord` makes two definition jumps to find the type, and if the first jump is to another file, the next jump need to have the correct `uri` and `tree`. To do this, I had to pass through the `forest` so it can find the correct `tree` after the first jump. I also had to pass it into `findDefinitionNodeByReferencingNode`, but made it optional since its only needed for this specific case. Also, `getTypeAliasOfRecord` now returns the `uri` as well, so any further uses will know where the type alias is. 