### PR TITLE
Add record access completions for types and nested types

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -166,6 +166,29 @@ export class CompletionProvider {
           params.textDocument.uri,
           forest,
         );
+      } else if (
+        (nodeAtPosition.type === "field_access_segment" ||
+          nodeAtPosition.parent?.type === "field_access_segment") &&
+        nodeAtPosition.parent
+      ) {
+        const dotIndex = (
+          TreeUtils.findFirstNamedChildOfType("dot", nodeAtPosition) ??
+          TreeUtils.findFirstNamedChildOfType("dot", nodeAtPosition.parent)
+        )?.startPosition.column;
+
+        if (dotIndex) {
+          return this.getRecordCompletions(
+            nodeAtPosition,
+            tree,
+            Range.create(
+              Position.create(params.position.line, dotIndex + 1),
+              params.position,
+            ),
+            elmWorkspace.getImports(),
+            params.textDocument.uri,
+            forest,
+          );
+        }
       }
 
       completions.push(

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -1000,18 +1000,28 @@ export class TreeUtils {
         "lower_case_identifier",
       );
       if (variableNodes.length > 0) {
+        const indexOfNode = variableNodes.findIndex(
+          (varNode) => varNode.text === nodeAtPosition.text,
+        );
+
         const variableRef = TreeUtils.findDefinitionNodeByReferencingNode(
-          variableNodes[0],
+          variableNodes[indexOfNode > 0 ? indexOfNode - 1 : 0],
           uri,
           tree,
           imports,
         );
 
-        const variableDef =
+        let variableDef: SyntaxNode | null | undefined =
           TreeUtils.getTypeOrTypeAliasOfFunctionParameter(variableRef?.node) ??
           TreeUtils.getReturnTypeOrTypeAliasOfFunctionDefinition(
             variableRef?.node,
           );
+
+        if (!variableDef && variableRef?.node)
+          variableDef = TreeUtils.findFirstNamedChildOfType(
+            "type_expression",
+            variableRef.node,
+          )?.firstNamedChild;
 
         if (variableDef) {
           const variableType = TreeUtils.findDefinitionNodeByReferencingNode(
@@ -1399,7 +1409,7 @@ export class TreeUtils {
     forest: IForest,
   ): { node: SyntaxNode; uri: string } | undefined {
     if (node?.parent?.parent) {
-      let type =
+      let type: SyntaxNode | undefined | null =
         TreeUtils.findFirstNamedChildOfType(
           "record_base_identifier",
           node.parent.parent,
@@ -1409,6 +1419,25 @@ export class TreeUtils {
           node.parent,
         );
 
+      if (!type) {
+        const valueNodes =
+          TreeUtils.findAllNamedChildrenOfType(
+            ["value_expr", "field_access_segment"],
+            node.parent,
+          ) ??
+          TreeUtils.findAllNamedChildrenOfType(
+            ["value_expr", "field_access_segment"],
+            node.parent.parent,
+          );
+
+        // We don't want the current access segment
+        valueNodes?.pop();
+
+        if (valueNodes?.length) {
+          type = valueNodes[valueNodes.length - 1].lastNamedChild;
+        }
+      }
+
       // Handle records of function returns
       if (!type && node.parent.parent.parent) {
         type =
@@ -1417,9 +1446,9 @@ export class TreeUtils {
           )?.parent ?? undefined;
       }
 
-      if (type && type.firstNamedChild) {
+      if (type) {
         const definitionNode = TreeUtils.findDefinitionNodeByReferencingNode(
-          type.firstNamedChild,
+          type.firstNamedChild ? type.firstNamedChild : type,
           uri,
           tree,
           imports,
@@ -1437,8 +1466,12 @@ export class TreeUtils {
             aliasNode = TreeUtils.getReturnTypeOrTypeAliasOfFunctionDefinition(
               definitionNode.node,
             );
+          } else if (definitionNode.nodeType === "FieldType") {
+            aliasNode = TreeUtils.findFirstNamedChildOfType(
+              "type_expression",
+              definitionNode.node,
+            );
           } else if (definitionNode.nodeType === "TypeAlias") {
-            aliasNode = definitionNode.node;
             return { node: definitionNode.node, uri: definitionNode.uri };
           }
 


### PR DESCRIPTION
Closes #237. Completions for record access of types and nested types. 

Part of #247. For this case to work, `getReturnTypeOrTypeAliasOfFunctionDefinition` needs to be updated to handle anonymous type alias return types, but that example should work if the function had a type annotation. 