### PR TITLE
Fix elm.json ignored when path similar to another

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -210,12 +210,12 @@ export class Server implements ILanguageServer {
 
   private findTopLevelFolders(listOfElmJsonFolders: URI[]) {
     const result: Map<string, URI> = new Map();
-    listOfElmJsonFolders.forEach(uri => {
+    listOfElmJsonFolders.forEach((uri) => {
       result.set(uri.fsPath, uri);
     });
 
-    listOfElmJsonFolders.forEach(parentUri => {
-      listOfElmJsonFolders.forEach(childUri => {
+    listOfElmJsonFolders.forEach((parentUri) => {
+      listOfElmJsonFolders.forEach((childUri) => {
         const parentPath = parentUri.fsPath + path.sep;
         const childPath = childUri.fsPath + path.sep;
         if (parentPath !== childPath && childPath.startsWith(parentPath)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -210,17 +210,16 @@ export class Server implements ILanguageServer {
 
   private findTopLevelFolders(listOfElmJsonFolders: URI[]) {
     const result: Map<string, URI> = new Map();
-    listOfElmJsonFolders.forEach((element) => {
-      result.set(element.toString(), element);
+    listOfElmJsonFolders.forEach(uri => {
+      result.set(uri.fsPath, uri);
     });
 
-    listOfElmJsonFolders.forEach((a) => {
-      listOfElmJsonFolders.forEach((b) => {
-        if (
-          b.toString() !== a.toString() &&
-          b.toString().startsWith(a.toString())
-        ) {
-          result.delete(b.toString());
+    listOfElmJsonFolders.forEach(parentUri => {
+      listOfElmJsonFolders.forEach(childUri => {
+        const parentPath = parentUri.fsPath + path.sep;
+        const childPath = childUri.fsPath + path.sep;
+        if (parentPath !== childPath && childPath.startsWith(parentPath)) {
+          result.delete(childUri.fsPath);
         }
       });
     });


### PR DESCRIPTION

When the path of one elm.json file matches the start of another, the
second one is ignored. This works as intended when the second path is
a nested directory:

- /path/to/parent/elm.json
- /path/to/parent/child/elm.json - this should be ignored

This change fixes a bug where we were unintentinally ignoring elm.json
files in directories whose names started with the same characters as a
sibling:

- /path/to/foo/elm.json
- /path/to/foobar/elm.json - this should not be ignored