### PR TITLE
Remove exposing subscriptions in Browser.sandbox snippet

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1015,7 +1015,7 @@ export class CompletionProvider {
       this.createSnippet(
         "Browser.sandbox",
         [
-          "module Main exposing (Model, Msg, update, view, subscriptions, init)",
+          "module Main exposing (Model, Msg, update, view, init)",
           "",
           "import Html exposing (..)",
           "import Browser",


### PR DESCRIPTION
Browser.sandbox didn't have subscriptions function. When use this
snippet, Elm will complain about function not found in exposing clause.