### PR TITLE
Handle some more record field access cases

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -168,17 +168,29 @@ export class CompletionProvider {
         );
       } else if (
         (nodeAtPosition.type === "field_access_segment" ||
-          nodeAtPosition.parent?.type === "field_access_segment") &&
+          nodeAtPosition.parent?.type === "field_access_segment" ||
+          TreeUtils.descendantsOfType(nodeAtPosition, "field_access_segment")
+            .length > 0) &&
         nodeAtPosition.parent
       ) {
-        const dotIndex = (
-          TreeUtils.findFirstNamedChildOfType("dot", nodeAtPosition) ??
-          TreeUtils.findFirstNamedChildOfType("dot", nodeAtPosition.parent)
+        const accessSegmentNode =
+          nodeAtPosition.type === "field_access_segment"
+            ? nodeAtPosition
+            : nodeAtPosition.parent?.type === "field_access_segment"
+            ? nodeAtPosition.parent
+            : TreeUtils.descendantsOfType(
+                nodeAtPosition,
+                "field_access_segment",
+              )[0];
+
+        const dotIndex = TreeUtils.findFirstNamedChildOfType(
+          "dot",
+          accessSegmentNode,
         )?.startPosition.column;
 
         if (dotIndex) {
           return this.getRecordCompletions(
-            nodeAtPosition,
+            accessSegmentNode,
             tree,
             Range.create(
               Position.create(params.position.line, dotIndex + 1),


### PR DESCRIPTION
Fix some more record access cases. Specifically it fixes this one, but it may improve more areas too:

``` elm
view : Model -> Html Msg
view model =
    let
        var : String
        var =
            model.|
                |> String.toFloat
                |> String.fromFloat
    in
    div [] []
```

What do you think about trying to write test cases for these? It would make it a lot easier to know what it working and to not break stuff in the future. I assume that will involve a lot to set up a mock workspace and forest, etc. 