### PR TITLE
Add some completion tests

### DIFF
--- a/src/test/completionProvider.test.ts
+++ b/src/test/completionProvider.test.ts
@@ -45,9 +45,18 @@ describe("CompletionProvider", () => {
   const completionProvider = new MockCompletionProvider(connectionMock, []);
   const treeParser = new SourceTreeParser();
 
+  /**
+   * Run completion tests on a source
+   *
+   * @param source The source code in an array of lines
+   * @param expectedCompletions The array of expected completions
+   * @param testExactCompletions Test that the completion list ONLY includes the expected completions
+   * @param testDotCompletion Test completions if a dot was the trigger character
+   */
   async function testCompletions(
     source: string[],
     expectedCompletions: string[],
+    testExactCompletions?: boolean,
     testDotCompletion?: boolean,
   ) {
     await treeParser.init();
@@ -63,18 +72,26 @@ describe("CompletionProvider", () => {
     position.line += 2;
 
     function testCompletionsWithContext(context: CompletionContext) {
-      const completions = completionProvider.handleCompletion(
-        {
-          textDocument: { uri: mockUri },
-          position: position!,
-          context,
-        },
-        treeParser.getWorkspace(sources),
-      );
+      const completions =
+        completionProvider.handleCompletion(
+          {
+            textDocument: { uri: mockUri },
+            position: position!,
+            context,
+          },
+          treeParser.getWorkspace(sources),
+        ) ?? [];
 
-      expect(completions?.length).toBe(expectedCompletions.length);
-      completions?.forEach((completion, i) => {
-        expect(completion.label).toBe(expectedCompletions[i]);
+      if (testExactCompletions) {
+        expect(completions.length).toBe(expectedCompletions.length);
+      } else {
+        expect(completions.length).toBeGreaterThanOrEqual(
+          expectedCompletions.length,
+        );
+      }
+
+      expectedCompletions.forEach((completion) => {
+        expect(completions.find((c) => c.label === completion)).toBeTruthy;
       });
     }
 
@@ -97,7 +114,7 @@ describe("CompletionProvider", () => {
       `  { model | p{-caret-} }`,
     ];
 
-    await testCompletions(source, ["prop1", "prop2"]);
+    await testCompletions(source, ["prop1", "prop2"], true);
   });
 
   it("Updating a nested record should have completions", async () => {
@@ -117,7 +134,40 @@ describe("CompletionProvider", () => {
       `  { model | prop1 = { i{-caret-} } }`,
     ];
 
-    await testCompletions(source, ["item1", "item2"]);
+    await testCompletions(source, ["item1", "item2"], true);
+  });
+
+  it("A record return type should have completions", async () => {
+    const source = [
+      `type alias Model = `,
+      `  { prop1: String`,
+      `  , prop2: Int`,
+      `  }`,
+      ``,
+      `view : Model`,
+      `view =`,
+      `  { p{-caret-} }`,
+    ];
+
+    await testCompletions(source, ["prop1", "prop2"], true);
+
+    const source2 = [
+      `type alias Model = `,
+      `  { prop1: String`,
+      `  , prop2: Int`,
+      `  }`,
+      ``,
+      `view : Model`,
+      `view =`,
+      `  let`,
+      `    func : Model`,
+      `    func = `,
+      `      { p{-caret-} }`,
+      ``,
+      `  in`,
+    ];
+
+    await testCompletions(source2, ["prop1", "prop2"], true);
   });
 
   it("Record access should have completions inside a let", async () => {
@@ -140,6 +190,60 @@ describe("CompletionProvider", () => {
       `    model`,
     ];
 
-    await testCompletions(source, ["prop1", "prop2"], true);
+    await testCompletions(source, ["prop1", "prop2"], true, true);
+  });
+
+  it("Function parameter should have completions in a function", async () => {
+    const source = [`test : Model -> String`, `test param =`, `  p{-caret-}`];
+
+    await testCompletions(source, ["param"]);
+  });
+
+  it("Function parameter should have completions in a nested expression", async () => {
+    const source = [
+      `test : Model -> String`,
+      `test param =`,
+      `  let`,
+      `    list = List.map (\_ -> p{-caret-})`,
+    ];
+
+    await testCompletions(source, ["param"]);
+  });
+
+  it("Let values should have completions", async () => {
+    const source = [
+      `test : Model -> String`,
+      `test param =`,
+      `  let`,
+      `    val = "test"`,
+      ``,
+      `    another = v{-caret-}`,
+    ];
+
+    await testCompletions(source, ["val"]);
+
+    const source2 = [
+      `test : Model -> String`,
+      `test param =`,
+      `  let`,
+      `    val = "test"`,
+      ``,
+      `  in`,
+      `    "string" ++ v{-caret-}`,
+    ];
+
+    await testCompletions(source2, ["val"]);
+  });
+
+  it("Imported values should have completions", async () => {
+    const source = [
+      `import Html exposing (div)`,
+      ``,
+      `test : Model -> Html msg`,
+      `test param =`,
+      `  d{-caret-}`,
+    ];
+
+    await testCompletions(source, ["div"]);
   });
 });


### PR DESCRIPTION
Just add some simple completion tests. The default test is just checking that the completions are somewhere in the list (Since the client does the sorting). Some of the tests check that only those completions are in the list (Like record access) using the `testExactCompletions` flag. 