### PR TITLE
Better completions context

### DIFF
--- a/src/positionUtil.ts
+++ b/src/positionUtil.ts
@@ -29,3 +29,18 @@ export class PositionUtil {
     };
   }
 }
+
+export function comparePosition(pos1: VSPosition, pos2: TSPosition): number {
+  if (pos1.line === pos2.row && pos1.character === pos2.column) {
+    return 0;
+  }
+
+  if (
+    pos1.line < pos2.row ||
+    (pos1.line === pos2.row && pos1.character < pos2.column)
+  ) {
+    return -1;
+  }
+
+  return 1;
+}

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -23,6 +23,7 @@ import RANKING_LIST from "./ranking";
 import { ImportUtils } from "../util/importUtils";
 import { RefactorEditUtils } from "../util/refactorEditUtils";
 import { Utils } from "../util/utils";
+import { comparePosition, PositionUtil } from "../positionUtil";
 
 export type CompletionResult =
   | CompletionItem[]
@@ -88,7 +89,7 @@ export class CompletionProvider {
         currentCharacter--;
       }
 
-      const replaceRange = Range.create(
+      let replaceRange = Range.create(
         Position.create(params.position.line, currentCharacter),
         params.position,
       );
@@ -97,10 +98,92 @@ export class CompletionProvider {
 
       const isAtStartOfLine = replaceRange.start.character === 0;
 
-      const targetWord = targetLine.substring(
+      let targetWord = targetLine.substring(
         replaceRange.start.character,
         replaceRange.end.character,
       );
+
+      let contextNode = TreeUtils.findPreviousNode(
+        tree.rootNode,
+        params.position,
+      );
+
+      // If we are in a partial identifier, skip that and adjust the contextNode to be the previous node
+      if (
+        contextNode &&
+        comparePosition(params.position, contextNode.endPosition) <= 0 &&
+        TreeUtils.isIdentifier(contextNode)
+      ) {
+        contextNode = TreeUtils.findPreviousNode(
+          tree.rootNode,
+          PositionUtil.FROM_TS_POSITION(
+            contextNode.startPosition,
+          ).toVSPosition(),
+        );
+      }
+
+      const isAfterDot = contextNode?.type === "dot";
+
+      let targetNode;
+
+      if (isAfterDot && contextNode) {
+        targetWord = targetLine.substring(
+          replaceRange.start.character,
+          contextNode.startPosition.column,
+        );
+
+        replaceRange = Range.create(
+          Position.create(
+            params.position.line,
+            contextNode.startPosition.column + 1,
+          ),
+          params.position,
+        );
+
+        const parent = contextNode.parent;
+        if (parent?.type === "value_qid") {
+          // Qualified value access
+          targetNode = contextNode.previousNamedSibling;
+        } else if (parent?.type === "field_access_segment") {
+          // Record field access
+          targetNode =
+            parent?.previousNamedSibling?.lastNamedChild?.lastNamedChild ??
+            parent.previousNamedSibling?.lastNamedChild;
+        } else if (parent?.type === "upper_case_qid") {
+          // Imports
+          targetNode = contextNode.previousNamedSibling;
+        } else if (parent?.type === "ERROR") {
+          targetNode = TreeUtils.findPreviousNode(
+            tree.rootNode,
+            PositionUtil.FROM_TS_POSITION(
+              contextNode.startPosition,
+            ).toVSPosition(),
+          );
+        }
+      }
+
+      if (targetNode) {
+        const moduleCompletions = this.getSubmodulesOrValues(
+          targetNode,
+          params.textDocument.uri,
+          tree,
+          elmWorkspace.getImports(),
+          forest,
+          replaceRange,
+          targetWord,
+        );
+
+        return moduleCompletions.length > 0
+          ? moduleCompletions
+          : this.getRecordCompletions(
+              targetNode,
+              tree,
+              replaceRange,
+              elmWorkspace.getImports(),
+              params.textDocument.uri,
+              forest,
+            );
+      }
 
       if (
         TreeUtils.findParentOfType("block_comment", nodeAtPosition) ||
@@ -245,98 +328,6 @@ export class CompletionProvider {
           params.textDocument.uri,
           forest,
         );
-      } else if (
-        nodeAtPosition.type === "field_access_segment" ||
-        nodeAtPosition.parent?.type === "field_access_segment" ||
-        RegExp("^[a-z]+.*.$").exec(targetWord)
-      ) {
-        let accessSegmentNode =
-          nodeAtPosition.type === "field_access_segment"
-            ? nodeAtPosition
-            : nodeAtPosition.parent?.type === "field_access_segment"
-            ? nodeAtPosition.parent
-            : undefined;
-
-        if (!accessSegmentNode) {
-          accessSegmentNode =
-            TreeUtils.getNamedDescendantForPosition(tree.rootNode, {
-              ...params.position,
-              character: params.position.character - 1,
-            }).parent ?? undefined;
-        }
-
-        if (accessSegmentNode) {
-          let dotIndex = TreeUtils.findFirstNamedChildOfType(
-            "dot",
-            accessSegmentNode,
-          )?.startPosition.column;
-
-          if (!dotIndex) {
-            const wordDot = targetWord.lastIndexOf(".");
-
-            if (wordDot >= 0) {
-              dotIndex =
-                params.position.character - (targetWord.length - wordDot);
-            }
-          }
-
-          if (dotIndex) {
-            return this.getRecordCompletions(
-              accessSegmentNode,
-              tree,
-              Range.create(
-                Position.create(params.position.line, dotIndex + 1),
-                params.position,
-              ),
-              elmWorkspace.getImports(),
-              params.textDocument.uri,
-              forest,
-            );
-          }
-        }
-      } else if (
-        (nodeAtPosition.parent?.type === "value_qid" &&
-          nodeAtPosition.previousNamedSibling?.type === "dot") ||
-        RegExp("^[A-Z]+.*.$").exec(targetWord) // Handles the 'Html.Attributes.' case
-      ) {
-        let targetNode = nodeAtPosition.parent;
-
-        if (targetNode?.type !== "value_qid") {
-          targetNode = TreeUtils.getNamedDescendantForPosition(tree.rootNode, {
-            ...params.position,
-            character: params.position.character - 1,
-          }).parent;
-        }
-
-        if (targetNode) {
-          const dotNodes = TreeUtils.findAllNamedChildrenOfType(
-            "dot",
-            targetNode,
-          );
-
-          // Get the last dot index
-          const dotIndex =
-            dotNodes && dotNodes.length > 0
-              ? dotNodes[dotNodes.length - 1].startPosition.column
-              : targetWord.endsWith(".")
-              ? params.position.character - 1
-              : undefined;
-
-          if (dotIndex) {
-            return this.getSubmodulesOrValues(
-              targetNode,
-              params.textDocument.uri,
-              tree,
-              elmWorkspace.getImports(),
-              forest,
-              Range.create(
-                Position.create(params.position.line, dotIndex + 1),
-                params.position,
-              ),
-              targetLine.substring(replaceRange.start.character, dotIndex),
-            );
-          }
-        }
       }
 
       completions.push(
@@ -1054,79 +1045,78 @@ export class CompletionProvider {
         }
       });
 
-    const moduleNodes = TreeUtils.findAllNamedChildrenOfType(
-      "upper_case_identifier",
+    // If we are in an import completion, don't return any values
+    if (
+      node.parent?.firstNamedChild?.type === "import" ||
+      node.parent?.parent?.firstNamedChild?.type === "import"
+    ) {
+      return result;
+    }
+
+    let alreadyImported = true;
+
+    // Try to find the module definition that is already imported
+    const definitionNode = TreeUtils.findDefinitionNodeByReferencingNode(
       node,
-    )?.filter((node) => node.text !== "");
+      uri,
+      tree,
+      imports,
+    );
 
-    if (moduleNodes && moduleNodes.length > 0) {
-      const moduleNode = moduleNodes[moduleNodes.length - 1];
+    let moduleTree: ITreeContainer | undefined;
 
-      let alreadyImported = true;
+    if (definitionNode && definitionNode.nodeType === "Module") {
+      moduleTree = forest.getByUri(definitionNode.uri);
+    } else {
+      // Try to find this module in the forest to import
+      moduleTree = forest.getByModuleName(targetModule);
+      alreadyImported = false;
+    }
 
-      // Try to find the module definition that is already imported
-      const definitionNode = TreeUtils.findDefinitionNodeByReferencingNode(
-        moduleNode,
-        uri,
-        tree,
-        imports,
-      );
+    if (moduleTree) {
+      // Get exposed values
+      const imports = ImportUtils.getPossibleImportsOfTree(moduleTree);
+      imports.forEach((value) => {
+        const markdownDocumentation = HintHelper.createHint(value.node);
+        let additionalTextEdits: TextEdit[] | undefined;
+        let detail: string | undefined;
 
-      let moduleTree: ITreeContainer | undefined;
+        // Add the import text edit if not imported
+        if (!alreadyImported) {
+          const importEdit = RefactorEditUtils.addImport(tree, targetModule);
 
-      if (definitionNode && definitionNode.nodeType === "Module") {
-        moduleTree = forest.getByUri(definitionNode.uri);
-      } else {
-        // Try to find this module in the forest to import
-        moduleTree = forest.getByModuleName(targetModule);
-        alreadyImported = false;
-      }
-
-      if (moduleTree) {
-        // Get exposed values
-        const imports = ImportUtils.getPossibleImportsOfTree(moduleTree);
-        imports.forEach((value) => {
-          const markdownDocumentation = HintHelper.createHint(value.node);
-          let additionalTextEdits: TextEdit[] | undefined;
-          let detail: string | undefined;
-
-          // Add the import text edit if not imported
-          if (!alreadyImported) {
-            const importEdit = RefactorEditUtils.addImport(tree, targetModule);
-
-            if (importEdit) {
-              additionalTextEdits = [importEdit];
-              detail = `Auto import module '${targetModule}'`;
-            }
+          if (importEdit) {
+            additionalTextEdits = [importEdit];
+            detail = `Auto import module '${targetModule}'`;
           }
+        }
 
-          const completionOptions: ICompletionOptions = {
-            label: value.value,
-            sortPrefix: "a",
-            range,
-            markdownDocumentation,
-            additionalTextEdits,
-            detail,
-          };
+        const completionOptions: ICompletionOptions = {
+          label: value.value,
+          sortPrefix: "a",
+          range,
+          markdownDocumentation,
+          additionalTextEdits,
+          detail,
+        };
 
-          switch (value.type) {
-            case "Function":
-              result.push(this.createFunctionCompletion(completionOptions));
-              break;
-            case "Type":
-              result.push(this.createTypeCompletion(completionOptions));
-              break;
-            case "TypeAlias":
-              result.push(this.createTypeAliasCompletion(completionOptions));
-              break;
-            case "UnionConstructor":
-              result.push(
-                this.createUnionConstructorCompletion(completionOptions),
-              );
-              break;
-          }
-        });
-      }
+        switch (value.type) {
+          case "Function":
+            result.push(this.createFunctionCompletion(completionOptions));
+            break;
+          case "Type":
+            result.push(this.createTypeCompletion(completionOptions));
+            break;
+          case "TypeAlias":
+            result.push(this.createTypeAliasCompletion(completionOptions));
+            break;
+          case "UnionConstructor":
+            result.push(
+              this.createUnionConstructorCompletion(completionOptions),
+            );
+            break;
+        }
+      });
     }
 
     return result;

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -392,7 +392,6 @@ export class CompletionProvider {
     targetModule?: string,
   ): CompletionItem[] {
     const currentModuleNameNode = TreeUtils.getModuleNameNode(tree);
-    console.log(currentModuleNameNode?.text);
     return forest.treeIndex
       .filter(
         (t) =>

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -1916,4 +1916,11 @@ export class TreeUtils {
       node.type === "upper_case_identifier"
     );
   }
+
+  public static isImport(node: SyntaxNode): boolean {
+    return (
+      node.parent?.firstNamedChild?.type === "import" ||
+      node.parent?.parent?.firstNamedChild?.type === "import"
+    );
+  }
 }

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -408,11 +408,7 @@ module Test exposing (..)
 import {-caret-}
 `;
 
-    await testCompletions(
-      otherSource + source,
-      ["Test", "OtherModule"],
-      "exactMatch",
-    );
+    await testCompletions(otherSource + source, ["OtherModule"], "exactMatch");
 
     const source2 = `
 --@ Test.elm
@@ -421,11 +417,7 @@ module Test exposing (..)
 import T{-caret-}
 `;
 
-    await testCompletions(
-      otherSource + source2,
-      ["Test", "OtherModule"],
-      "exactMatch",
-    );
+    await testCompletions(otherSource + source2, ["OtherModule"], "exactMatch");
   });
 
   it("Exposing a value from another module should have completions", async () => {
@@ -928,6 +920,35 @@ import Module.Sub{-caret-}
     await testCompletions(
       source2,
       ["Submodule", "Submodule.AnotherSubmodule"],
+      "exactMatch",
+    );
+
+    const source3 = `
+--@ Module.elm
+module Module exposing (..)
+
+func = ""
+
+--@ Module/Submodule.elm
+module Module.Submodule exposing (..)
+
+func = ""
+
+--@ Module/Submodule/AnotherSubmodule.elm
+module Module.Submodule.AnotherSubmodule exposing (..)
+
+func = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+import {-caret-}
+
+`;
+
+    await testCompletions(
+      source3,
+      ["Module", "Module.Submodule", "Module.Submodule.AnotherSubmodule"],
       "exactMatch",
     );
   });

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -871,6 +871,67 @@ test = Module.sub{-caret-}
     );
   });
 
+  it("Possible import completions", async () => {
+    const source = `
+--@ Module.elm
+module Module exposing (..)
+
+func = ""
+
+--@ Module/Submodule.elm
+module Module.Submodule exposing (..)
+
+func = ""
+
+--@ Module/Submodule/AnotherSubmodule.elm
+module Module.Submodule.AnotherSubmodule exposing (..)
+
+func = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+import Module.{-caret-}
+
+`;
+
+    await testCompletions(
+      source,
+      ["Submodule", "Submodule.AnotherSubmodule"],
+      "exactMatch",
+      "triggeredByDot",
+    );
+
+    const source2 = `
+--@ Module.elm
+module Module exposing (..)
+
+func = ""
+
+--@ Module/Submodule.elm
+module Module.Submodule exposing (..)
+
+func = ""
+
+--@ Module/Submodule/AnotherSubmodule.elm
+module Module.Submodule.AnotherSubmodule exposing (..)
+
+func = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+import Module.Sub{-caret-}
+
+`;
+
+    await testCompletions(
+      source2,
+      ["Submodule", "Submodule.AnotherSubmodule"],
+      "exactMatch",
+    );
+  });
+
   it("Imported qualified modules should have value completions", async () => {
     const source = `
 --@ Module.elm


### PR DESCRIPTION
This PR begins to address the that problem that `nodeAtPosition` is often determined to be very different nodes based on similar positions. For example `var.|` and `var.pr|` can product vastly different results (lower level node vs higher level) and we have a lot of specific pattern matching to try to catch all of these cases (and the result is ugly). There are also many rarer variations that can occur (like in deeper nested statements) that we don't cover, and completions don't work there.

To solve this, I took heavy inspiration from the Typescript completion provider and introduce a new `contextNode` and a `TreeUtils.findPreviousNode()` to use instead of the existing `nodeAtPosition`. `contextNode` is the node right before the caret (but is also adjusted when typing after a dot). 

We can continue to use both nodes and transition some completions to use the new `contextNode` when and where it makes sense. Currently I am mostly just using it for completions that come after a dot. Doing this means I am able to consistently get the node we want completions on (before the dot, Ex: `Module.v|` -> `Module`, `model.|` -> `model`) no matter the surrounding code (I was impressed with the testing results of this). This also means that we can get rid of a lot of the ugly node type matching code, and use a more consistent, unified approach. This should also help get better results with some of those edge cases. 