### PR TITLE
Improve definition for conflicting module/type names and various completion improvements

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -344,6 +344,7 @@ export class CompletionProvider {
 
       completions.push(
         ...this.getCompletionsFromOtherFile(
+          tree,
           elmWorkspace.getImports(),
           params.textDocument.uri,
           replaceRange,
@@ -493,6 +494,7 @@ export class CompletionProvider {
   }
 
   private getCompletionsFromOtherFile(
+    tree: Tree,
     imports: IImports,
     uri: string,
     range: Range,
@@ -521,8 +523,22 @@ export class CompletionProvider {
         const dotIndex = label.lastIndexOf(".");
         const valuePart = label.slice(dotIndex + 1);
 
+        const importNode = TreeUtils.findImportClauseByName(
+          tree,
+          element.fromModuleName,
+        );
+
+        // Check if a value is already imported for this module using the exposing list
+        // In this case, we want to prefex the unqualified value since they are using the import exposing list
+        const valuesAlreadyExposed =
+          importNode &&
+          !!TreeUtils.findFirstNamedChildOfType("exposing_list", importNode);
+
         // Try to determine if just the value is being typed
-        if (valuePart.toLowerCase().startsWith(inputText.toLowerCase())) {
+        if (
+          !valuesAlreadyExposed &&
+          valuePart.toLowerCase().startsWith(inputText.toLowerCase())
+        ) {
           filterText = valuePart;
         }
 
@@ -1001,11 +1017,13 @@ export class CompletionProvider {
         possibleImport.valueToImport ?? possibleImport.value,
       );
 
+      const sortText = i < 10 ? `0${i}` : i;
+
       const completionOptions = {
         markdownDocumentation,
         label: possibleImport.value,
         range,
-        sortPrefix: `f${i}`,
+        sortPrefix: `f${sortText}`,
         detail,
         additionalTextEdits: importTextEdit ? [importTextEdit] : undefined,
       };

--- a/src/util/importUtils.ts
+++ b/src/util/importUtils.ts
@@ -27,6 +27,11 @@ export class ImportUtils {
         currentTree,
       );
 
+      const importedModules =
+        TreeUtils.findAllImportClauseNodes(currentTree)?.map(
+          (n) => TreeUtils.findFirstNamedChildOfType("upper_case_qid", n)?.text,
+        ) ?? [];
+
       // Filter out already imported values
       // Then sort by startsWith filter text, then matches filter text
       return this.getPossibleImports(forest, uri)
@@ -62,7 +67,16 @@ export class ImportUtils {
             } else if (!aMatches && bMatches) {
               return 1;
             } else {
-              return 0;
+              const aModuleImported = importedModules.includes(a.module);
+              const bModuleImported = importedModules.includes(b.module);
+
+              if (aModuleImported && !bModuleImported) {
+                return -1;
+              } else if (!aModuleImported && bModuleImported) {
+                return 1;
+              } else {
+                return 0;
+              }
             }
           }
         });

--- a/test/definitionProviderTests/definitionProviderTestBase.ts
+++ b/test/definitionProviderTests/definitionProviderTestBase.ts
@@ -76,6 +76,30 @@ export class DefinitionProviderTestBase {
           expect((definition as Location).uri).toContain(
             determinedTestType.targetFile,
           );
+
+          if (determinedTestType.targetPosition) {
+            const rootNode = this.treeParser
+              .getWorkspace(determinedTestType.sources)
+              .getForest()
+              .treeIndex.find((a) => a.uri === targetUri)!.tree.rootNode;
+            const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+              rootNode,
+              determinedTestType.targetPosition,
+            );
+
+            expect((definition as Location).range).toEqual(
+              expect.objectContaining({
+                start: {
+                  line: determinedTestType.targetPosition.line,
+                  character: nodeAtPosition.startPosition.column,
+                },
+                end: {
+                  line: expect.any(Number),
+                  character: expect.any(Number),
+                },
+              }),
+            );
+          }
         }
         break;
 

--- a/test/definitionProviderTests/moduleResolveDefinition.test.ts
+++ b/test/definitionProviderTests/moduleResolveDefinition.test.ts
@@ -1,0 +1,166 @@
+import { DefinitionProviderTestBase } from "./definitionProviderTestBase";
+
+describe("moduleResolveDefinition", () => {
+  const testBase = new DefinitionProviderTestBase();
+
+  it(`conflicting module and types`, async () => {
+    const source = `
+--@ Model.elm
+module Model exposing (..)
+
+type alias Model = {
+--X
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Model exposing (Model)
+     
+func : Model
+        --^Model.elm
+`;
+    await testBase.testDefinition(source);
+
+    const source2 = `
+--@ Model.elm
+module Model exposing (..)
+--X
+
+type alias Model = {
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Model exposing (Model)
+      
+func = Model.
+        --^Model.elm
+`;
+    await testBase.testDefinition(source2);
+  });
+
+  it(`conflicting module alias and types`, async () => {
+    const source = `
+--@ Module/Model.elm
+module Module.Model exposing (..)
+
+type alias Model = {
+--X
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Module.Model as Model exposing (Model)
+     
+func : Model
+        --^Module/Model.elm
+`;
+    await testBase.testDefinition(source);
+
+    const source2 = `
+--@ Module/Model.elm
+module Module.Model exposing (..)
+--X
+
+type alias Model = {
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Module.Model as Model exposing (Model)
+      
+func = Model.
+        --^Module/Model.elm
+`;
+    await testBase.testDefinition(source2);
+  });
+
+  it(`module and submodule definitions`, async () => {
+    const source = `
+--@ Module/Model.elm
+module Module.Model exposing (..)
+--X
+
+type alias Model = {
+  var: String
+}
+
+--@ Module.elm
+module Module exposing (..)
+
+type alias Model = {
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Module.Model
+     
+func = Module.Model.func
+             --^Module/Model.elm
+`;
+    await testBase.testDefinition(source);
+
+    const source2 = `
+--@ Module/Model.elm
+module Module.Model exposing (..)
+
+type alias Model = {
+  var: String
+}
+
+--@ Module.elm
+module Module exposing (..)
+--X
+
+type alias Model = {
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Module
+import Module.Model
+      
+func = Module.Model.func
+      --^Module.elm
+`;
+    await testBase.testDefinition(source2);
+  });
+
+  it(`module and submodule definitions`, async () => {
+    const source = `
+--@ Module.elm
+module Module exposing (..)
+--X
+
+type alias Model = {
+  var: String
+}
+
+--@ Main.elm
+module Main exposing (..)
+
+import Module as Model
+     
+func = 
+  let
+    Model.
+    --^Module.elm
+  
+  in
+  []
+`;
+    await testBase.testDefinition(source);
+  });
+});

--- a/test/utils/sourceParser.ts
+++ b/test/utils/sourceParser.ts
@@ -59,6 +59,7 @@ interface IResolvesToDifferentFileTest {
   targetFile: string;
   sources: { [K: string]: string };
   fileWithTarget: string;
+  targetPosition?: Position;
 }
 
 export function getInvokeAndTargetPositionFromSource(source: string): TestType {
@@ -125,6 +126,7 @@ export function getInvokeAndTargetPositionFromSource(source: string): TestType {
       sources,
       targetFile,
       fileWithTarget,
+      targetPosition,
     };
   } else {
     if (!invokePosition || !targetPosition) {


### PR DESCRIPTION
Fixes definitions for conflicting names of types and modules. For example, a module import named `Model` and a type named `Model` conflicted before and broke things. To fix this, I detect if there is a dot after the name, then it is a module, or else its a type. 

There are also some various completions filtering and sorting improvements. Like if a module import is exposing values, we guess that the completions from that module should just be the value, without the module prefix. Also sort auto imports based on modules that are already imported. 