### PR TITLE
Add support for OnDidCreateFiles and OnDidRenameFiles

### DIFF
--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -26,6 +26,7 @@ export interface IElmWorkspace {
   init(progressCallback: (percent: number) => void): void;
   hasDocument(uri: URI): boolean;
   hasPath(uri: URI): boolean;
+  getPath(uri: URI): string | undefined;
   getForest(): Forest;
   getImports(): Imports;
   getRootPath(): URI;
@@ -65,9 +66,13 @@ export class ElmWorkspace implements IElmWorkspace {
   }
 
   public hasPath(uri: URI): boolean {
+    return !!this.getPath(uri);
+  }
+
+  public getPath(uri: URI): string | undefined {
     return this.elmFolders
       .map((f) => f.uri)
-      .some((elmFolder) => uri.fsPath.startsWith(elmFolder));
+      .find((elmFolder) => uri.fsPath.startsWith(elmFolder));
   }
 
   public getForest(): Forest {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,4 +1,5 @@
 import { CodeActionParams, RequestType } from "vscode-languageserver";
+import { URI } from "vscode-uri";
 
 export const GetMoveDestinationRequest = new RequestType<
   IMoveParams,
@@ -45,3 +46,25 @@ export const UnexposeRequest = new RequestType<
   void,
   void
 >("elm/unexpose");
+
+export interface IOnDidCreateFilesParams {
+  readonly files: ReadonlyArray<URI>;
+}
+
+export interface IOnDidRenameFilesParams {
+  readonly files: ReadonlyArray<{ oldUri: URI; newUri: URI }>;
+}
+
+export const OnDidCreateFilesRequest = new RequestType<
+  IOnDidCreateFilesParams,
+  void,
+  void,
+  void
+>("elm/ondidCreateFiles");
+
+export const OnDidRenameFilesRequest = new RequestType<
+  IOnDidRenameFilesParams,
+  void,
+  void,
+  void
+>("elm/ondidRenameFiles");

--- a/src/providers/handlers/fileEventsHandler.ts
+++ b/src/providers/handlers/fileEventsHandler.ts
@@ -1,0 +1,97 @@
+import { relative } from "path";
+import { IElmWorkspace } from "../../elmWorkspace";
+import {
+  OnDidCreateFilesRequest,
+  OnDidRenameFilesRequest,
+} from "../../protocol";
+import { ElmWorkspaceMatcher } from "../../util/elmWorkspaceMatcher";
+import { RefactorEditUtils } from "../../util/refactorEditUtils";
+import { container } from "tsyringe";
+import { IConnection } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+
+export class FileEventsHandler {
+  private connection: IConnection;
+
+  constructor() {
+    this.connection = container.resolve<IConnection>("Connection");
+
+    this.connection.onRequest(OnDidCreateFilesRequest, async (params) => {
+      for (const file of params.files) {
+        await new ElmWorkspaceMatcher((file: URI) => file).handlerForWorkspace(
+          this.onDidCreateFile.bind(this),
+        )(URI.revive(file));
+      }
+    });
+
+    this.connection.onRequest(OnDidRenameFilesRequest, async (params) => {
+      for (const { oldUri, newUri } of params.files) {
+        await new ElmWorkspaceMatcher((file: URI) => file).handlerForWorkspace(
+          this.onDidRenameFile.bind(this, URI.revive(oldUri)),
+        )(URI.revive(newUri));
+      }
+    });
+  }
+
+  async onDidCreateFile(file: URI, elmWorkspace: IElmWorkspace): Promise<void> {
+    if (!file.toString().endsWith(".elm")) {
+      return;
+    }
+
+    const moduleName = this.getModuleNameFromFile(file, elmWorkspace);
+
+    if (moduleName) {
+      const addModuleDefinitionEdit = RefactorEditUtils.addModuleDeclaration(
+        moduleName,
+      );
+      await this.connection.workspace.applyEdit({
+        changes: { [file.toString()]: [addModuleDefinitionEdit] },
+      });
+    }
+  }
+
+  async onDidRenameFile(
+    oldFile: URI,
+    newFile: URI,
+    elmWorkspace: IElmWorkspace,
+  ): Promise<void> {
+    if (!newFile.toString().endsWith(".elm")) {
+      return;
+    }
+
+    const moduleName = this.getModuleNameFromFile(newFile, elmWorkspace);
+
+    const tree = elmWorkspace.getForest().getByUri(oldFile.toString())?.tree;
+    if (moduleName && tree) {
+      const renameModuleDefinitionEdit = RefactorEditUtils.renameModuleDeclaration(
+        tree,
+        moduleName,
+      );
+
+      if (renameModuleDefinitionEdit) {
+        await this.connection.workspace.applyEdit({
+          changes: { [newFile.toString()]: [renameModuleDefinitionEdit] },
+        });
+      }
+    }
+  }
+
+  getModuleNameFromFile(
+    file: URI,
+    elmWorkspace: IElmWorkspace,
+  ): string | undefined {
+    const sourceDir = elmWorkspace.getPath(file);
+
+    // The file is not in a source dir (shouldn't happen)
+    if (!sourceDir) {
+      return;
+    }
+
+    const relativePath = URI.file(relative(sourceDir, file.fsPath)).path.slice(
+      1,
+    );
+
+    // Remove extension and convert to module name
+    return relativePath.split(".").slice(0, -1).join(".").split("/").join(".");
+  }
+}

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -1,3 +1,4 @@
+import { PositionUtil } from "src/positionUtil";
 import { Position, Range, TextEdit } from "vscode-languageserver";
 import { SyntaxNode, Tree } from "web-tree-sitter";
 import { TreeUtils } from "./treeUtils";
@@ -184,6 +185,35 @@ export class RefactorEditUtils {
       ),
       imports,
     );
+  }
+
+  public static addModuleDeclaration(moduleName: string): TextEdit {
+    return TextEdit.insert(
+      Position.create(0, 0),
+      `module ${moduleName} exposing (..)`,
+    );
+  }
+
+  public static renameModuleDeclaration(
+    tree: Tree,
+    newModuleName: string,
+  ): TextEdit | undefined {
+    const moduleNameNode = TreeUtils.getModuleNameNode(tree);
+    if (moduleNameNode) {
+      return TextEdit.replace(
+        Range.create(
+          Position.create(
+            moduleNameNode.startPosition.row,
+            moduleNameNode.startPosition.column,
+          ),
+          Position.create(
+            moduleNameNode.endPosition.row,
+            moduleNameNode.endPosition.column,
+          ),
+        ),
+        newModuleName,
+      );
+    }
   }
 
   private static removeValueFromExposingList(

--- a/test/utils/mockElmWorkspace.ts
+++ b/test/utils/mockElmWorkspace.ts
@@ -50,6 +50,11 @@ export class MockElmWorkspace implements IElmWorkspace {
     return false;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getPath(uri: URI): string | undefined {
+    return;
+  }
+
   getForest(): Forest {
     return this.forest;
   }


### PR DESCRIPTION
Add support for OnDidCreateFiles and OnDidRenameFiles to automatically add or rename the module declaration. In the future, we should handle the module rename better (references), but it didn't seem like the current module rename worked that well anyways. 