### PR TITLE
Make entrypoints configurable via elm-tooling.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is the language server implementation for the Elm programming language.
   - [Alternative: Compile and install from source](#alternative-compile-and-install-from-source)
   - [Alternative: Install with Nix](#alternative-install-with-nix)
 - [Requirements](#requirements)
+- [Configuration](#configuration)
 - [Features](#features)
 - [Server Settings](#server-settings)
   - [Elm-Analyse Configuration](#elm-analyse-configuration)
@@ -84,6 +85,24 @@ npm install -g elm elm-test elm-format
 ```
 
 Or use local versions from your `node_modules` directory, if you want to do that you need to set the paths, via the settings (e.g. set `elmPath` to `./node_modules/.bin/elm`).
+
+## Configuration
+
+Create an [elm-tooling.json](https://github.com/lydell/elm-tooling.json) file next to your `elm.json` to configure the language server.
+
+Currently there’s just one thing that you can configure: entrypoints. The language server runs `elm make` to get type errors. By default `elm make` is run on the current file only. To get errors for the entire project you can specify your entrypoint files – basically, those with `main =` in them. Then the language server will run `elm make` on those instead.
+
+Example:
+
+```json
+{
+  "entrypoints": ["./src/Main.elm"]
+}
+```
+
+The entrypoints are relative to the directory where your `elm.json` and `elm-tooling.json` is and must start with `./`.
+
+Check out the [elm-tooling](https://github.com/lydell/elm-tooling.json/tree/master/cli) CLI for creating and validating your `elm-tooling.json`!
 
 ## Features
 

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -67,6 +67,41 @@ export interface IStyledString {
   string: string;
 }
 
+type NonEmptyArray<T> = [T, ...T[]];
+
+function elmToolingEntrypointsDecoder(json: unknown): NonEmptyArray<string> {
+  if (typeof json === "object" && json !== null && !Array.isArray(json)) {
+    if ("entrypoints" in json) {
+      const { entrypoints } = json as { [key: string]: unknown };
+      if (Array.isArray(entrypoints) && entrypoints.length > 0) {
+        const result: Array<string> = [];
+        for (const [index, item] of entrypoints.entries()) {
+          if (typeof item === "string" && item.startsWith("./")) {
+            result.push(item);
+          } else {
+            throw new Error(
+              `Expected "entrypoints" to contain string paths starting with "./" but got: ${JSON.stringify(
+                item,
+              )} at index ${index}`,
+            );
+          }
+        }
+        return [result[0], ...result.slice(1)];
+      } else {
+        throw new Error(
+          `Expected "entrypoints" to be a non-empty array but got: ${JSON.stringify(
+            json,
+          )}`,
+        );
+      }
+    } else {
+      throw new Error(`There is no "entrypoints" field.`);
+    }
+  } else {
+    throw new Error(`Expected a JSON object but got: ${JSON.stringify(json)}`);
+  }
+}
+
 export class ElmMakeDiagnostics {
   private elmWorkspaceMatcher: ElmWorkspaceMatcher<URI>;
   private neededImports: Map<
@@ -567,33 +602,52 @@ export class ElmMakeDiagnostics {
   }
 
   private async checkForErrors(
-    cwd: string,
-    filename: string,
+    workspaceRootPath: string,
+    filePath: string,
   ): Promise<IElmIssue[]> {
     const settings = await this.settings.getClientSettings();
 
-    let relativePathToFile: string[] = [path.relative(cwd, filename)];
-    try {
-      const elmToolingJson: {
-        entrypoints: Array<string>;
-        binaries?: {
-          [name: string]: string;
-        };
-      } = await readFile(path.join(cwd, "elm-tooling.json"), {
-        encoding: "utf-8",
-      }).then(JSON.parse);
-
-      if (elmToolingJson && elmToolingJson["entrypoints"]) {
-        relativePathToFile = elmToolingJson["entrypoints"];
-      }
-    } catch (error) {
-      this.connection.console.info("Could not read elm-tooling.json");
-    }
+    const elmToolingPath = path.join(workspaceRootPath, "elm-tooling.json");
+    const defaultRelativePathToFile = path.relative(
+      workspaceRootPath,
+      filePath,
+    );
+    const [relativePathsToFiles, message]: [
+      NonEmptyArray<string>,
+      string,
+    ] = await readFile(elmToolingPath, {
+      encoding: "utf-8",
+    })
+      .then(JSON.parse)
+      .then(elmToolingEntrypointsDecoder)
+      .then(
+        (entrypoints) => [
+          entrypoints,
+          `Using entrypoints from ${elmToolingPath}: ${JSON.stringify(
+            entrypoints,
+          )}`,
+        ],
+        (error: Error & { code?: string }) => {
+          const innerMessage =
+            error.code === "ENOENT"
+              ? `No elm-tooling.json found in ${workspaceRootPath}.`
+              : error.code === "EISDIR"
+              ? `Skipping ${elmToolingPath} because it is a directory, not a file.`
+              : error instanceof SyntaxError
+              ? `Skipping ${elmToolingPath} because it contains invalid JSON: ${error.message}.`
+              : `Skipping ${elmToolingPath} because: ${error.message}.`;
+          const fullMessage = `Using default entrypoint: ${defaultRelativePathToFile}. ${innerMessage}`;
+          return [[defaultRelativePathToFile], fullMessage];
+        },
+      );
+    this.connection.console.info(
+      `Find entrypoints: ${message}. See https://github.com/elm-tooling/elm-language-server#configuration for more information.`,
+    );
 
     return new Promise(async (resolve) => {
       const argsMake = [
         "make",
-        ...relativePathToFile,
+        ...relativePathsToFiles,
         "--report",
         "json",
         "--output",
@@ -602,7 +656,7 @@ export class ElmMakeDiagnostics {
 
       const argsTest = [
         "make",
-        ...relativePathToFile,
+        ...relativePathsToFiles,
         "--report",
         "json",
         "--output",
@@ -611,7 +665,7 @@ export class ElmMakeDiagnostics {
 
       const makeCommand: string = settings.elmPath;
       const testCommand: string = settings.elmTestPath;
-      const isTestFile = utils.isTestFile(filename, cwd);
+      const isTestFile = utils.isTestFile(filePath, workspaceRootPath);
       const args = isTestFile ? argsTest : argsMake;
       const testOrMakeCommand = isTestFile ? testCommand : makeCommand;
       const testOrMakeCommandWithOmittedSettings = isTestFile
@@ -630,7 +684,7 @@ export class ElmMakeDiagnostics {
           testOrMakeCommand,
           testOrMakeCommandWithOmittedSettings,
           options,
-          cwd,
+          workspaceRootPath,
           this.connection,
         );
         resolve([]);
@@ -663,9 +717,9 @@ export class ElmMakeDiagnostics {
                       .join(""),
                     file: error.path
                       ? path.isAbsolute(error.path)
-                        ? path.relative(cwd, error.path)
+                        ? path.relative(workspaceRootPath, error.path)
                         : error.path
-                      : relativePathToFile[0],
+                      : relativePathsToFiles[0],
                     overview: problem.title,
                     region: problem.region,
                     subregion: "",
@@ -685,8 +739,8 @@ export class ElmMakeDiagnostics {
                   .join(""),
                 // elm-test might supply absolute paths to files
                 file: errorObject.path
-                  ? path.relative(cwd, errorObject.path)
-                  : relativePathToFile[0],
+                  ? path.relative(workspaceRootPath, errorObject.path)
+                  : relativePathsToFiles[0],
                 overview: errorObject.title,
                 region: {
                   end: {


### PR DESCRIPTION
Closes https://github.com/elm-tooling/elm-language-client-vscode/issues/114 and https://github.com/elm-tooling/elm-language-server/issues/118

Thanks to @lydell for the definition of `elm-tooling.json` https://github.com/lydell/elm-tooling.json