### PR TITLE
Parse files incrementally and use more type caching

### DIFF
--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -41,7 +41,7 @@ export class CapabilityCalculator {
         prepareProvider: true,
       },
       selectionRangeProvider: true,
-      textDocumentSync: TextDocumentSyncKind.Full,
+      textDocumentSync: TextDocumentSyncKind.Incremental,
       workspaceSymbolProvider: true,
     };
   }

--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -92,16 +92,15 @@ export class ASTProvider {
           : undefined,
       ])
       .forEach(([startNode, endNode]) => {
-        if (startNode || endNode) {
-          elmWorkspace
-            .getTypeCache()
-            .invalidateValueDeclaration(startNode ?? endNode!);
-
-          if (startNode && endNode) {
-            elmWorkspace.getTypeCache().invalidateValueDeclaration(endNode);
-          }
+        if (
+          startNode &&
+          endNode &&
+          startNode.id === endNode.id &&
+          TreeUtils.getTypeAnnotation(startNode)
+        ) {
+          elmWorkspace.getTypeCache().invalidateValueDeclaration(startNode);
         } else {
-          elmWorkspace.getTypeCache().invalidateAll();
+          elmWorkspace.getTypeCache().invalidateProject();
         }
       });
 

--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -9,15 +9,18 @@ import {
   Emitter,
 } from "vscode-languageserver";
 import { URI } from "vscode-uri";
-import Parser, { Tree, SyntaxNode } from "web-tree-sitter";
+import Parser, { Tree, Edit, Point } from "web-tree-sitter";
 import { IElmWorkspace } from "../elmWorkspace";
-import { IDocumentEvents } from "../util/documentEvents";
 import { ElmWorkspaceMatcher } from "../util/elmWorkspaceMatcher";
+import { Position, Range } from "vscode-languageserver-textdocument";
 import { FileEventsHandler } from "./handlers/fileEventsHandler";
+import { TextDocumentEvents } from "../util/textDocumentEvents";
+import { TreeUtils } from "../util/treeUtils";
 
 export class ASTProvider {
   private connection: IConnection;
   private parser: Parser;
+  private documentEvents: TextDocumentEvents;
 
   private treeChangeEvent = new Emitter<{ uri: string; tree: Tree }>();
   readonly onTreeChange: Event<{ uri: string; tree: Tree }> = this
@@ -26,18 +29,20 @@ export class ASTProvider {
   constructor() {
     this.parser = container.resolve("Parser");
     this.connection = container.resolve<IConnection>("Connection");
-    const documentEvents = container.resolve<IDocumentEvents>("DocumentEvents");
+    this.documentEvents = container.resolve<TextDocumentEvents>(
+      TextDocumentEvents,
+    );
 
     new FileEventsHandler();
 
-    documentEvents.on(
+    this.documentEvents.on(
       "change",
       new ElmWorkspaceMatcher((params: DidChangeTextDocumentParams) =>
         URI.parse(params.textDocument.uri),
       ).handlerForWorkspace(this.handleChangeTextDocument),
     );
 
-    documentEvents.on(
+    this.documentEvents.on(
       "open",
       new ElmWorkspaceMatcher((params: DidOpenTextDocumentParams) =>
         URI.parse(params.textDocument.uri),
@@ -57,21 +62,50 @@ export class ASTProvider {
     const document: VersionedTextDocumentIdentifier = params.textDocument;
 
     let tree: Tree | undefined = forest.getTree(document.uri);
-    if (tree === undefined) {
-      const fileContent: string = readFileSync(
-        URI.parse(document.uri).fsPath,
-        "utf8",
-      );
-      tree = this.parser.parse(fileContent);
-    }
 
     if ("contentChanges" in params) {
-      for (const changeEvent of params.contentChanges) {
-        tree = this.parser.parse(changeEvent.text);
+      for (const change of params.contentChanges) {
+        if ("range" in change) {
+          tree?.edit(this.getEditFromChange(change, tree.rootNode.text));
+        }
       }
-    } else {
-      tree = this.parser.parse(params.textDocument.text);
     }
+
+    const newText =
+      this.documentEvents.get(params.textDocument.uri)?.getText() ??
+      readFileSync(URI.parse(document.uri).fsPath, "utf8");
+
+    const newTree = this.parser.parse(newText, tree);
+
+    tree
+      ?.getChangedRanges(newTree)
+      .map((range) => [
+        tree?.rootNode.descendantForPosition(range.startPosition),
+        tree?.rootNode.descendantForPosition(range.endPosition),
+      ])
+      .map(([startNode, endNode]) => [
+        startNode
+          ? TreeUtils.findParentOfType("value_declaration", startNode)
+          : undefined,
+        endNode
+          ? TreeUtils.findParentOfType("value_declaration", endNode)
+          : undefined,
+      ])
+      .forEach(([startNode, endNode]) => {
+        if (startNode || endNode) {
+          elmWorkspace
+            .getTypeCache()
+            .invalidateValueDeclaration(startNode ?? endNode!);
+
+          if (startNode && endNode) {
+            elmWorkspace.getTypeCache().invalidateValueDeclaration(endNode);
+          }
+        } else {
+          elmWorkspace.getTypeCache().invalidateAll();
+        }
+      });
+
+    tree = newTree;
 
     if (tree) {
       forest.setTree(document.uri, true, true, tree, true);
@@ -97,4 +131,62 @@ export class ASTProvider {
       this.treeChangeEvent.fire({ uri: document.uri, tree });
     }
   };
+
+  private getEditFromChange(
+    change: { text: string; range: Range },
+    text: string,
+  ): Edit {
+    const [startIndex, endIndex] = this.getIndexesFromRange(change.range, text);
+
+    return {
+      startIndex,
+      oldEndIndex: endIndex,
+      newEndIndex: startIndex + change.text.length,
+      startPosition: this.toTSPoint(change.range.start),
+      oldEndPosition: this.toTSPoint(change.range.end),
+      newEndPosition: this.toTSPoint(
+        this.addPositions(change.range.start, this.textToPosition(change.text)),
+      ),
+    };
+  }
+
+  private textToPosition(text: string): Position {
+    const lines = text.split(/\r\n|\r|\n/);
+
+    return {
+      line: lines.length - 1,
+      character: lines[lines.length - 1].length,
+    };
+  }
+
+  private getIndexesFromRange(range: Range, text: string): [number, number] {
+    let startIndex = range.start.character;
+    let endIndex = range.end.character;
+
+    const regex = new RegExp(/\r\n|\r|\n/);
+    const eolResult = regex.exec(text);
+
+    const lines = text.split(regex);
+    const eol = eolResult && eolResult.length > 0 ? eolResult[0] : "";
+
+    for (let i = 0; i < range.end.line; i++) {
+      if (i < range.start.line) {
+        startIndex += lines[i].length + eol.length;
+      }
+      endIndex += lines[i].length + eol.length;
+    }
+
+    return [startIndex, endIndex];
+  }
+
+  private addPositions(pos1: Position, pos2: Position): Position {
+    return {
+      line: pos1.line + pos2.line,
+      character: pos1.character + pos2.character,
+    };
+  }
+
+  private toTSPoint(position: Position): Point {
+    return { row: position.line, column: position.character };
+  }
 }

--- a/src/util/textDocumentEvents.ts
+++ b/src/util/textDocumentEvents.ts
@@ -56,7 +56,7 @@ export class TextDocumentEvents extends EventEmitter {
 
       this._documents[td.uri] = document;
 
-      this.emit("change", Object.freeze({ document }));
+      this.emit("change", Object.freeze({ document, ...params }));
     });
 
     events.on("save", (params: DidSaveTextDocumentParams) => {

--- a/src/util/types/syntaxNodeMap.ts
+++ b/src/util/types/syntaxNodeMap.ts
@@ -39,4 +39,16 @@ export class SyntaxNodeMap<K extends SyntaxNode, V> {
       callback(val, ({ id: key } as unknown) as K),
     );
   }
+
+  public clear(): void {
+    this.map.clear();
+  }
+
+  public delete(key: K): void {
+    if (!("id" in key)) {
+      throw new Error("SyntaxNodeMap key must have an `id` property");
+    }
+
+    this.map.delete((<any>key).id);
+  }
 }

--- a/src/util/types/syntaxNodeMap.ts
+++ b/src/util/types/syntaxNodeMap.ts
@@ -45,10 +45,6 @@ export class SyntaxNodeMap<K extends SyntaxNode, V> {
   }
 
   public delete(key: K): void {
-    if (!("id" in key)) {
-      throw new Error("SyntaxNodeMap key must have an `id` property");
-    }
-
-    this.map.delete((<any>key).id);
+    this.map.delete(key.id);
   }
 }

--- a/src/util/types/typeCache.ts
+++ b/src/util/types/typeCache.ts
@@ -5,12 +5,18 @@ import { InferenceResult } from "./typeInference";
 type CacheKey =
   | "PACKAGE_TYPE_ANNOTATION"
   | "PACKAGE_TYPE_AND_TYPE_ALIAS"
-  | "PACKAGE_VALUE";
+  | "PACKAGE_VALUE"
+  | "PROJECT_TYPE_ANNOTATION"
+  | "PROJECT_TYPE_AND_TYPE_ALIAS"
+  | "PROJECT_VALUE";
 
 export class TypeCache {
   private packageTypeAnnotation: SyntaxNodeMap<SyntaxNode, InferenceResult>;
   private packageTypeAndTypeAlias: SyntaxNodeMap<SyntaxNode, InferenceResult>;
   private packageValue: SyntaxNodeMap<SyntaxNode, InferenceResult>;
+  private projectTypeAnnotation: SyntaxNodeMap<SyntaxNode, InferenceResult>;
+  private projectTypeAndTypeAlias: SyntaxNodeMap<SyntaxNode, InferenceResult>;
+  private projectValue: SyntaxNodeMap<SyntaxNode, InferenceResult>;
 
   constructor() {
     this.packageTypeAnnotation = new SyntaxNodeMap<
@@ -22,6 +28,15 @@ export class TypeCache {
       InferenceResult
     >();
     this.packageValue = new SyntaxNodeMap<SyntaxNode, InferenceResult>();
+    this.projectTypeAnnotation = new SyntaxNodeMap<
+      SyntaxNode,
+      InferenceResult
+    >();
+    this.projectTypeAndTypeAlias = new SyntaxNodeMap<
+      SyntaxNode,
+      InferenceResult
+    >();
+    this.projectValue = new SyntaxNodeMap<SyntaxNode, InferenceResult>();
   }
 
   public getOrSet(
@@ -36,6 +51,22 @@ export class TypeCache {
         return this.packageTypeAndTypeAlias.getOrSet(node, setter);
       case "PACKAGE_VALUE":
         return this.packageValue.getOrSet(node, setter);
+      case "PROJECT_TYPE_ANNOTATION":
+        return this.projectTypeAnnotation.getOrSet(node, setter);
+      case "PROJECT_TYPE_AND_TYPE_ALIAS":
+        return this.projectTypeAndTypeAlias.getOrSet(node, setter);
+      case "PROJECT_VALUE":
+        return this.projectValue.getOrSet(node, setter);
     }
+  }
+
+  public invalidateAll(): void {
+    this.projectTypeAnnotation.clear();
+    this.projectTypeAndTypeAlias.clear();
+    this.projectValue.clear();
+  }
+
+  public invalidateValueDeclaration(node: SyntaxNode): void {
+    this.projectValue.delete(node);
   }
 }

--- a/src/util/types/typeCache.ts
+++ b/src/util/types/typeCache.ts
@@ -5,18 +5,18 @@ import { InferenceResult } from "./typeInference";
 type CacheKey =
   | "PACKAGE_TYPE_ANNOTATION"
   | "PACKAGE_TYPE_AND_TYPE_ALIAS"
-  | "PACKAGE_VALUE"
+  | "PACKAGE_VALUE_DECLARATION"
   | "PROJECT_TYPE_ANNOTATION"
   | "PROJECT_TYPE_AND_TYPE_ALIAS"
-  | "PROJECT_VALUE";
+  | "PROJECT_VALUE_DECLARATION";
 
 export class TypeCache {
   private packageTypeAnnotation: SyntaxNodeMap<SyntaxNode, InferenceResult>;
   private packageTypeAndTypeAlias: SyntaxNodeMap<SyntaxNode, InferenceResult>;
-  private packageValue: SyntaxNodeMap<SyntaxNode, InferenceResult>;
+  private packageValueDeclaration: SyntaxNodeMap<SyntaxNode, InferenceResult>;
   private projectTypeAnnotation: SyntaxNodeMap<SyntaxNode, InferenceResult>;
   private projectTypeAndTypeAlias: SyntaxNodeMap<SyntaxNode, InferenceResult>;
-  private projectValue: SyntaxNodeMap<SyntaxNode, InferenceResult>;
+  private projectValueDeclaration: SyntaxNodeMap<SyntaxNode, InferenceResult>;
 
   constructor() {
     this.packageTypeAnnotation = new SyntaxNodeMap<
@@ -27,7 +27,10 @@ export class TypeCache {
       SyntaxNode,
       InferenceResult
     >();
-    this.packageValue = new SyntaxNodeMap<SyntaxNode, InferenceResult>();
+    this.packageValueDeclaration = new SyntaxNodeMap<
+      SyntaxNode,
+      InferenceResult
+    >();
     this.projectTypeAnnotation = new SyntaxNodeMap<
       SyntaxNode,
       InferenceResult
@@ -36,7 +39,10 @@ export class TypeCache {
       SyntaxNode,
       InferenceResult
     >();
-    this.projectValue = new SyntaxNodeMap<SyntaxNode, InferenceResult>();
+    this.projectValueDeclaration = new SyntaxNodeMap<
+      SyntaxNode,
+      InferenceResult
+    >();
   }
 
   public getOrSet(
@@ -49,24 +55,24 @@ export class TypeCache {
         return this.packageTypeAnnotation.getOrSet(node, setter);
       case "PACKAGE_TYPE_AND_TYPE_ALIAS":
         return this.packageTypeAndTypeAlias.getOrSet(node, setter);
-      case "PACKAGE_VALUE":
-        return this.packageValue.getOrSet(node, setter);
+      case "PACKAGE_VALUE_DECLARATION":
+        return this.packageValueDeclaration.getOrSet(node, setter);
       case "PROJECT_TYPE_ANNOTATION":
         return this.projectTypeAnnotation.getOrSet(node, setter);
       case "PROJECT_TYPE_AND_TYPE_ALIAS":
         return this.projectTypeAndTypeAlias.getOrSet(node, setter);
-      case "PROJECT_VALUE":
-        return this.projectValue.getOrSet(node, setter);
+      case "PROJECT_VALUE_DECLARATION":
+        return this.projectValueDeclaration.getOrSet(node, setter);
     }
   }
 
-  public invalidateAll(): void {
+  public invalidateProject(): void {
     this.projectTypeAnnotation.clear();
     this.projectTypeAndTypeAlias.clear();
-    this.projectValue.clear();
+    this.projectValueDeclaration.clear();
   }
 
   public invalidateValueDeclaration(node: SyntaxNode): void {
-    this.projectValue.delete(node);
+    this.projectValueDeclaration.delete(node);
   }
 }

--- a/src/util/types/typeExpression.ts
+++ b/src/util/types/typeExpression.ts
@@ -83,7 +83,9 @@ export class TypeExpression {
         .getTypeCache()
         .getOrSet("PACKAGE_TYPE_AND_TYPE_ALIAS", e, setter);
     } else {
-      return setter();
+      return workspace
+        .getTypeCache()
+        .getOrSet("PROJECT_TYPE_AND_TYPE_ALIAS", e, setter);
     }
   }
 
@@ -115,7 +117,9 @@ export class TypeExpression {
         .getTypeCache()
         .getOrSet("PACKAGE_TYPE_AND_TYPE_ALIAS", e, setter);
     } else {
-      return setter();
+      return workspace
+        .getTypeCache()
+        .getOrSet("PROJECT_TYPE_AND_TYPE_ALIAS", e, setter);
     }
   }
 
@@ -152,7 +156,9 @@ export class TypeExpression {
         .getTypeCache()
         .getOrSet("PACKAGE_TYPE_ANNOTATION", e.typeExpression, setter);
     } else {
-      return setter();
+      return workspace
+        .getTypeCache()
+        .getOrSet("PROJECT_TYPE_ANNOTATION", e.typeExpression, setter);
     }
   }
 

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -195,15 +195,25 @@ function allTypeVars(type: Type): TVar[] {
     case "Var":
       return [type];
     case "Union":
-      return type.params.flatMap(allTypeVars);
+      return Array.prototype.flatMap !== undefined
+        ? type.params.flatMap(allTypeVars)
+        : flatMap(type.params, allTypeVars);
     case "Function":
-      return allTypeVars(type.return).concat(type.params.flatMap(allTypeVars));
+      return allTypeVars(type.return).concat(
+        Array.prototype.flatMap !== undefined
+          ? type.params.flatMap(allTypeVars)
+          : flatMap(type.params, allTypeVars),
+      );
     case "Tuple":
-      return type.types.flatMap(allTypeVars);
+      return Array.prototype.flatMap !== undefined
+        ? type.types.flatMap(allTypeVars)
+        : flatMap(type.types, allTypeVars);
     case "Record":
     case "MutableRecord": {
       return [
-        ...Object.values(type.fields).flatMap(allTypeVars),
+        ...(Array.prototype.flatMap !== undefined
+          ? Object.values(type.fields).flatMap(allTypeVars)
+          : flatMap(Object.values(type.fields), allTypeVars)),
         ...(type.baseType ? allTypeVars(type.baseType) : []),
       ];
     }
@@ -583,11 +593,11 @@ export class InferenceScope {
     if (!elmWorkspace.getForest().getByUri(uri)?.writeable) {
       return elmWorkspace
         .getTypeCache()
-        .getOrSet("PACKAGE_VALUE", declaration, setter);
+        .getOrSet("PACKAGE_VALUE_DECLARATION", declaration, setter);
     } else {
       return elmWorkspace
         .getTypeCache()
-        .getOrSet("PROJECT_VALUE", declaration, setter);
+        .getOrSet("PROJECT_VALUE_DECLARATION", declaration, setter);
     }
   }
 

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -585,7 +585,9 @@ export class InferenceScope {
         .getTypeCache()
         .getOrSet("PACKAGE_VALUE", declaration, setter);
     } else {
-      return setter();
+      return elmWorkspace
+        .getTypeCache()
+        .getOrSet("PROJECT_VALUE", declaration, setter);
     }
   }
 
@@ -1344,7 +1346,7 @@ export class InferenceScope {
       expr,
     );
 
-    if (!fieldIdentifier) {
+    if (!fieldIdentifier || fieldIdentifier.text === "") {
       return TUnknown;
     }
 
@@ -1394,7 +1396,7 @@ export class InferenceScope {
       }
     }
 
-    const type = targetTy.fields[fieldIdentifier.text];
+    const type = targetTy.fields[fieldIdentifier.text] ?? TUnknown;
     this.expressionTypes.set(expr, type);
     return type;
   }
@@ -1911,6 +1913,10 @@ export class InferenceScope {
     endExpr?: Expression,
     patternBinding = false,
   ): boolean {
+    if (!type1 || !type2) {
+      throw new Error("Undefined type error");
+    }
+
     let assignable: boolean;
 
     if (expr.nodeType === "CaseOfExpr") {
@@ -2423,7 +2429,7 @@ export function findType(
         expr.startIndex === expr.parent?.startIndex &&
         expr.endIndex === expr.parent?.endIndex
       ) {
-        return findTypeOrParentType(mapSyntaxNodeToExpression(expr.parent));
+        return findTypeOrParentType(expr.parent);
       }
     };
 

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -1247,4 +1247,93 @@ encodeScope scope =
       "normal",
     );
   });
+
+  it("Record access in list expression", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Model = 
+  { prop1: String
+  , prop2: Int
+  }
+
+map: (a -> b) -> List a -> List b
+map func list =
+  list
+
+func : List Model -> List a
+func model =
+    map (\\m -> m.{-caret-}) model
+`;
+
+    await testCompletions(source, ["prop1", "prop2"], "exactMatch");
+  });
+
+  it("Record access of a destructed union constructor", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type State
+    = State { field1 : String, field2 : String }
+
+
+func : State -> a
+func (State state) =
+    [ state.{-caret-} ]
+`;
+
+    await testCompletions(source, ["field1", "field2"], "exactMatch");
+  });
+
+  it("Record access inside Maybe case of branch", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Model = 
+  { prop1: String
+  , prop2: Int
+  }
+
+type Maybe a = Just a | Nothing
+
+func : Maybe Model -> a
+func model =
+    case model of
+        Just m ->
+            m.{-caret-}
+`;
+
+    await testCompletions(source, ["prop1", "prop2"], "exactMatch");
+  });
+
+  it("Record access destructured case branch", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Model = 
+  { prop1: Model2
+  , prop2: Int
+  }
+
+type alias Model2 = 
+  { field1: String 
+  , field2: Int }
+
+type Maybe a = Just a | Nothing
+
+func : Maybe Model -> a
+func model =
+    case model of
+        Just { prop1, prop2 } ->
+            prop1.{-caret-}
+
+        Nothing ->
+`;
+
+    await testCompletions(source, ["field1", "field2"], "exactMatch");
+  });
 });


### PR DESCRIPTION
Work done to switch the tree-sitter parsing to incremental, so we can cache types between changes. I actual did most of this before I wrote inference. This part will need the most testing, but it seems to be working pretty good for me. 

I also added type inference record completions when all other records completions fail. This should be safe since it is only used as a backup for now (still a little slower than current methods), and won't break anything if it fails. This leads to some pretty cools results and it worked pretty well in my brief testing.

Things like:
``` elm
test: List Data -> Data
test data =
    data |> List.filter (\d -> d.{-caret-})
```
now work great!
I was kinda surprised at how much just worked.

I expect that this PR will probably need some cleanup and good testing before we want to merge. 