### PR TITLE
Fix anonymous function param definitions and add code actions for let expr functions

### DIFF
--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -1421,31 +1421,20 @@ export class TreeUtils {
     node: SyntaxNode,
     functionParameterName: string,
   ): SyntaxNode | undefined {
-    if (
-      node.type === "parenthesized_expr" ||
-      node.type === "anonymous_function_expr"
-    ) {
-      const anonymousFunctionExprNodes =
-        node.type === "anonymous_function_expr"
-          ? [node]
-          : this.descendantsOfType(node, "anonymous_function_expr");
-      const match = anonymousFunctionExprNodes
-        .map((a) => a.children)
-        .reduce((a, b) => a.concat(b), [])
-        .find(
-          (child) =>
-            child.type === "pattern" && child.text === functionParameterName,
-        )?.firstNamedChild;
+    const anonymousFunctionExprNodes = TreeUtils.getAllAncestorsOfType(
+      "anonymous_function_expr",
+      node,
+    );
 
-      if (match) {
-        return match;
-      }
-    }
-    if (node.parent) {
-      return this.findAnonymousFunctionParameterDefinition(
-        node.parent,
-        functionParameterName,
-      );
+    const match = anonymousFunctionExprNodes
+      .map((a) => TreeUtils.findAllNamedChildrenOfType("pattern", a) ?? [])
+      .reduce((a, b) => a.concat(b), [])
+      .map((pattern) => pattern.descendantsOfType("lower_pattern"))
+      .reduce((a, b) => a.concat(b), [])
+      .find((child) => child.text === functionParameterName);
+
+    if (match) {
+      return match;
     }
   }
 
@@ -2156,6 +2145,11 @@ export class TreeUtils {
         return;
       }
 
+      const asClause = TreeUtils.findFirstNamedChildOfType(
+        "as_clause",
+        moduleImport,
+      );
+
       if (
         imports.imports[uri]
           .filter(
@@ -2168,6 +2162,8 @@ export class TreeUtils {
           .some((imp) => imp.alias === name)
       ) {
         return "";
+      } else if (asClause) {
+        return `${asClause?.lastNamedChild?.text ?? module}.`;
       } else {
         return `${module}.`;
       }

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -2145,11 +2145,6 @@ export class TreeUtils {
         return;
       }
 
-      const asClause = TreeUtils.findFirstNamedChildOfType(
-        "as_clause",
-        moduleImport,
-      );
-
       if (
         imports.imports[uri]
           .filter(
@@ -2162,11 +2157,18 @@ export class TreeUtils {
           .some((imp) => imp.alias === name)
       ) {
         return "";
-      } else if (asClause) {
-        return `${asClause?.lastNamedChild?.text ?? module}.`;
-      } else {
-        return `${module}.`;
       }
+
+      const asClause = TreeUtils.findFirstNamedChildOfType(
+        "as_clause",
+        moduleImport,
+      );
+
+      if (asClause) {
+        return `${asClause?.lastNamedChild?.text ?? module}.`;
+      }
+
+      return `${module}.`;
     }
   }
 

--- a/src/util/types/typeExpression.ts
+++ b/src/util/types/typeExpression.ts
@@ -289,6 +289,7 @@ export class TypeExpression {
       type,
       expressionTypes: this.expressionTypes,
       diagnostics: this.diagnostics,
+      resolvedDeclarations: new SyntaxNodeMap(),
     };
   }
 

--- a/src/util/types/typeRenderer.ts
+++ b/src/util/types/typeRenderer.ts
@@ -36,11 +36,8 @@ export class TypeRenderer {
 
     switch (t.nodeType) {
       case "Unknown":
-        return "Unknown";
       case "InProgressBinding":
-        throw new Error(
-          "Should never try to convert an in progress binding type to a string",
-        );
+        return "unknown";
       case "Unit":
         return "()";
       case "Var":
@@ -66,6 +63,10 @@ export class TypeRenderer {
   }
 
   private renderUnion(t: TUnion): string {
+    if (t.module === "WebGL" && t.name === "Shader") {
+      return "shader";
+    }
+
     let type;
     if (t.params.length === 0) {
       type = t.name;

--- a/test/definitionProviderTests/miscDefinition.test.ts
+++ b/test/definitionProviderTests/miscDefinition.test.ts
@@ -52,17 +52,18 @@ foo =
 
   // LAMBDAS (ANONYMOUS FUNCTIONS)
 
-  xit(`test lambda parameter ref`, async () => {
+  it(`test lambda parameter ref`, async () => {
     const source = `
 f = \\x -> x
    --X  --^
 `;
+    console.log(source);
     await testBase.testDefinition(source);
   });
 
-  xit(`test lambda parameter nested`, async () => {
+  it(`test lambda parameter nested`, async () => {
     const source = `
-f = \\x -> (\() -> x)
+f = \\x -> (\\() -> x)
    --X          --^
 `;
     await testBase.testDefinition(source);
@@ -70,23 +71,23 @@ f = \\x -> (\() -> x)
 
   it(`test lambda parameter nested and should not resolve`, async () => {
     const source = `
-f = \() -> x (\\x -> ())
+f = \\() -> x (\\x -> ())
          --^unresolved
 `;
     await testBase.testDefinition(source);
   });
 
-  xit(`test lambda parameter destructured record field ref`, async () => {
+  it(`test lambda parameter destructured record field ref`, async () => {
     const source = `
-f = \{x} -> x
+f = \\{x} -> x
     --X   --^
 `;
     await testBase.testDefinition(source);
   });
 
-  xit(`test lambda parameter destructured tuple ref`, async () => {
+  it(`test lambda parameter destructured tuple ref`, async () => {
     const source = `
-f = \(x,y) -> x
+f = \\(x,y) -> x
     --X     --^
 `;
     await testBase.testDefinition(source);
@@ -94,7 +95,7 @@ f = \(x,y) -> x
 
   xit(`test lambda parameter destructured with alias`, async () => {
     const source = `
-f = \((x,y) as point) -> point
+f = \\((x,y) as point) -> point
                --X       --^
 `;
     await testBase.testDefinition(source);

--- a/test/definitionProviderTests/miscDefinition.test.ts
+++ b/test/definitionProviderTests/miscDefinition.test.ts
@@ -57,7 +57,6 @@ foo =
 f = \\x -> x
    --X  --^
 `;
-    console.log(source);
     await testBase.testDefinition(source);
   });
 
@@ -93,7 +92,7 @@ f = \\(x,y) -> x
     await testBase.testDefinition(source);
   });
 
-  xit(`test lambda parameter destructured with alias`, async () => {
+  it(`test lambda parameter destructured with alias`, async () => {
     const source = `
 f = \\((x,y) as point) -> point
                --X       --^


### PR DESCRIPTION
Fixed anonymous function param definitions and was able to enable some existing tests. This fixed some inference bugs. 
Also added a code action to add the type annotation to functions in let expr. 

Inference bugs fixed:
- WebGl type renders as `shader` (like intellij)
- Use module alias if there is one
- Fix functions that used anonymous functions with record or tuple param deconstructors (like `tuple` in `elm-codec`)

All other reported bugs behave the same as intellij-elm, so I don't think we should worry about those edge cases for now.