### PR TITLE
More fixes for union constructors, enabling more tests

### DIFF
--- a/src/imports.ts
+++ b/src/imports.ts
@@ -288,19 +288,17 @@ import Platform.Sub as Sub exposing ( Sub )
       .forEach((element) => {
         if (element.exposedUnionConstructors) {
           result.push(
-            ...element.exposedUnionConstructors
-              .filter((a) => a.accessibleWithoutPrefix)
-              .map((a) => {
-                return {
-                  alias: `${a.name}`,
-                  fromModuleName: moduleName,
-                  fromUri: uri,
-                  maintainerAndPackageName,
-                  node: a.syntaxNode,
-                  type: "UnionConstructor" as NodeType,
-                  explicitlyExposed: false,
-                };
-              }),
+            ...element.exposedUnionConstructors.map((a) => {
+              return {
+                alias: `${a.name}`,
+                fromModuleName: moduleName,
+                fromUri: uri,
+                maintainerAndPackageName,
+                node: a.syntaxNode,
+                type: "UnionConstructor" as NodeType,
+                explicitlyExposed: false,
+              };
+            }),
           );
         }
       });
@@ -334,16 +332,32 @@ import Platform.Sub as Sub exposing ( Sub )
     moduleNameNode: SyntaxNode,
     foundModule: ITreeContainer,
   ): IImport[] {
-    return exposedNodes.map((a) => {
-      return {
-        alias: a.name,
-        fromModuleName: moduleNameNode.text,
-        fromUri: foundModule.uri,
-        maintainerAndPackageName: foundModule.maintainerAndPackageName,
-        node: a.syntaxNode,
-        type: a.type,
-        explicitlyExposed: true,
-      };
-    });
+    return exposedNodes
+      .map((a) => {
+        return [
+          {
+            alias: a.name,
+            fromModuleName: moduleNameNode.text,
+            fromUri: foundModule.uri,
+            maintainerAndPackageName: foundModule.maintainerAndPackageName,
+            node: a.syntaxNode,
+            type: a.type,
+            explicitlyExposed: true,
+          },
+        ].concat(
+          a.exposedUnionConstructors?.map((b) => {
+            return {
+              alias: b.name,
+              fromModuleName: moduleNameNode.text,
+              fromUri: foundModule.uri,
+              maintainerAndPackageName: foundModule.maintainerAndPackageName,
+              node: b.syntaxNode,
+              type: "UnionConstructor",
+              explicitlyExposed: false,
+            };
+          }) ?? [],
+        );
+      })
+      .reduce((a, b) => a.concat(b), []);
   }
 }

--- a/test/definitionProviderTests/aliasedImportDefinition.test.ts
+++ b/test/definitionProviderTests/aliasedImportDefinition.test.ts
@@ -31,14 +31,14 @@ type Page = Home
     await testBase.testDefinition(source);
   });
 
-  xit(`test aliased, qualified union constructor ref`, async () => {
+  it(`test aliased, qualified union constructor ref`, async () => {
     const source = `
 --@ main.elm
 import App as A
 defaultPage = A.Home
                 --^App.elm
 --@ App.elm
-module App exposing (Page(Home))
+module App exposing (Page(..))
 type Page = Home
            --X
 `;

--- a/test/definitionProviderTests/importDefinition.test.ts
+++ b/test/definitionProviderTests/importDefinition.test.ts
@@ -163,51 +163,10 @@ type Page = Home
     await testBase.testDefinition(source);
   });
 
-  xit(`test union constructor ref in import exposing list`, async () => {
-    const source = `
---@ main.elm
-import App exposing (Page(Home))
-                          --^App.elm
---@ App.elm
-module App exposing (Page(Home))
-type Page = Home
-           --X
-`;
-    await testBase.testDefinition(source);
-  });
-
-  xit(`test union constructor ref in expression`, async () => {
-    const source = `
---@ main.elm
-import App exposing (Page(Home))
-defaultPage = Home
-              --^App.elm
---@ App.elm
-module App exposing (Page(Home))
-type Page = Home
-           --X
-`;
-    await testBase.testDefinition(source);
-  });
-
-  xit(`test union constructor ref in expression via import exposing all constructors`, async () => {
+  it(`test union constructor ref in expression`, async () => {
     const source = `
 --@ main.elm
 import App exposing (Page(..))
-defaultPage = Home
-              --^App.elm
---@ App.elm
-module App exposing (Page(Home))
-type Page = Home
-           --X
-`;
-    await testBase.testDefinition(source);
-  });
-
-  xit(`test union constructor ref in expression via module exposing all constructors`, async () => {
-    const source = `
---@ main.elm
-import App exposing (Page(Home))
 defaultPage = Home
               --^App.elm
 --@ App.elm
@@ -218,7 +177,35 @@ type Page = Home
     await testBase.testDefinition(source);
   });
 
-  xit(`test union constructor ref in expression exposing all from both sides`, async () => {
+  it(`test union constructor ref in expression via import exposing all constructors`, async () => {
+    const source = `
+--@ main.elm
+import App exposing (Page(..))
+defaultPage = Home
+              --^App.elm
+--@ App.elm
+module App exposing (Page(..))
+type Page = Home
+           --X
+`;
+    await testBase.testDefinition(source);
+  });
+
+  it(`test union constructor ref in expression via module exposing all constructors`, async () => {
+    const source = `
+--@ main.elm
+import App exposing (Page(..))
+defaultPage = Home
+              --^App.elm
+--@ App.elm
+module App exposing (Page(..))
+type Page = Home
+           --X
+`;
+    await testBase.testDefinition(source);
+  });
+
+  it(`test union constructor ref in expression exposing all from both sides`, async () => {
     const source = `
 --@ main.elm
 import App exposing (..)
@@ -235,7 +222,7 @@ type Page = Home
   it(`test union constructor ref in expression but not exposed by module`, async () => {
     const source = `
 --@ main.elm
-import App exposing (Page(Home))
+import App exposing (Page(..))
 defaultPage = Home
               --^unresolved
 --@ App.elm
@@ -252,8 +239,8 @@ import Foo as
 import App exposing (Page(..))
 defaultPage = Home
               --^App.elm
---@ App.elmtest union constructor ref in
-module App exposing (Page(Home))
+--@ App.elm
+module App exposing (Page(..))
 type Page = Home
            --X
 --@Foo.elm
@@ -262,16 +249,16 @@ module Foo exposing(..)
     await testBase.testDefinition(source);
   });
 
-  xit(`test union constructor ref in pattern destructuring`, async () => {
+  it(`test union constructor ref in pattern destructuring`, async () => {
     const source = `
 --@ main.elm
-import App exposing (Page(Home))
+import App exposing (Page(..))
 title page =
     case page of
         Home -> "home"
         --^App.elm
 --@ App.elm
-module App exposing (Page(Home))
+module App exposing (Page(..))
 type Page = Home
            --X
 `;
@@ -462,21 +449,6 @@ power a b = 42
 import Math exposing (..)
 f = 2 ** 3
      --^Math.elm
---@ Math.elm
-module Math exposing ((**))
-infix left 5 (**) = power
-power a b = 42
---X
-`;
-    await testBase.testDefinition(source);
-  });
-
-  xit(`test binary operator as a function`, async () => {
-    const source = `
---@ main.elm
-import Math exposing ((**))
-f = (**) 2 3
-    --^Math.elm
 --@ Math.elm
 module Math exposing ((**))
 infix left 5 (**) = power

--- a/test/definitionProviderTests/qualifiedImportDefinition.test.ts
+++ b/test/definitionProviderTests/qualifiedImportDefinition.test.ts
@@ -45,21 +45,21 @@ type Page = Home
     await testBase.testDefinition(source);
   });
 
-  xit(`test qualified union constructor ref`, async () => {
+  it(`test qualified union constructor ref`, async () => {
     const source = `
 --@ main.elm
 import App
 defaultPage = App.Home
                   --^App.elm
 --@ App.elm
-module App exposing (Page(Home))
+module App exposing (Page(..))
 type Page = Home
            --X
 `;
     await testBase.testDefinition(source);
   });
 
-  xit(`test qualified union constructor ref in pattern destructuring`, async () => {
+  it(`test qualified union constructor ref in pattern destructuring`, async () => {
     const source = `
 --@ main.elm
 import App
@@ -68,7 +68,7 @@ title page =
         App.Home -> "home"
             --^App.elm
 --@ App.elm
-module App exposing (Page(Home))
+module App exposing (Page(..))
 type Page = Home
            --X
 `;

--- a/test/definitionProviderTests/typeResolveDefinition.test.ts
+++ b/test/definitionProviderTests/typeResolveDefinition.test.ts
@@ -45,16 +45,6 @@ title page =
     await testBase.testDefinition(source);
   });
 
-  xit(`test union constructor ref from module exposing list`, async () => {
-    const source = `
-module Main exposing (Page(Home))
-                           --^
-type Page = Home
-            --X
-`;
-    await testBase.testDefinition(source);
-  });
-
   it(`test type alias ref from module exposing list`, async () => {
     const source = `
 module Main exposing (Person)
@@ -155,11 +145,11 @@ func: User
 func =
 User { data = "" }
 `;
-await testBase.testDefinition(source);
-});
+    await testBase.testDefinition(source);
+  });
 
-it(`test type declaration resolves to itself`, async () => {
-  const source = `
+  it(`test type declaration resolves to itself`, async () => {
+    const source = `
   type UnitlessFloat
   --X   --^
     = UnitlessFloat
@@ -167,8 +157,8 @@ it(`test type declaration resolves to itself`, async () => {
     await testBase.testDefinition(source);
   });
 
-it(`test union contructor resolves to itself`, async () => {
-  const source = `
+  it(`test union contructor resolves to itself`, async () => {
+    const source = `
   type UnitlessFloat
   = UnitlessFloat
     --X   --^


### PR DESCRIPTION
Fixes for union constructors and imports. One of the big problems with the tests is we were using `exposing (Page(Home))`, which isn't valid syntax anymore (as of 0.19). Intellij-elm has since fixed their tests and removed irrelevant ones, which I did as well. Was able to enable pretty much all of the type and union constructor tests, so I feel pretty good about it. 