### PR TITLE
Add more inference tests and fix bug with operator functions

### DIFF
--- a/src/util/types/expressionTree.ts
+++ b/src/util/types/expressionTree.ts
@@ -111,6 +111,7 @@ export interface EOperator extends SyntaxNode {
 }
 export interface EOperatorAsFunctionExpr extends SyntaxNode {
   nodeType: "OperatorAsFunctionExpr";
+  operator: EOperator;
 }
 export interface ENumberConstant extends SyntaxNode {
   nodeType: "NumberConstant";
@@ -639,6 +640,13 @@ export function mapSyntaxNodeToExpression(
         nodeType: "GlslCodeExpr",
         content: TreeUtils.findFirstNamedChildOfType("glsl_content", node),
       } as EGlslCodeExpr);
+    case "operator_as_function_expr":
+      return Object.assign(node, {
+        nodeType: "OperatorAsFunctionExpr",
+        operator: mapSyntaxNodeToExpression(
+          TreeUtils.findFirstNamedChildOfType("operator_identifier", node),
+        ),
+      } as EOperatorAsFunctionExpr);
     default:
       return mapSyntaxNodeToExpression(node.firstNamedChild);
   }

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -514,6 +514,14 @@ function missingFunctionError(node: SyntaxNode): Diagnostic {
   };
 }
 
+function missingValueError(node: SyntaxNode): Diagnostic {
+  return {
+    node,
+    endNode: node,
+    message: `No definition found for \`${node.text}\``,
+  };
+}
+
 interface RecordDiff {
   extra: Map<string, Type>;
   missing: Map<string, Type>;
@@ -974,7 +982,8 @@ export class InferenceScope {
       );
 
     if (!definition) {
-      return TUnknown;
+      this.diagnostics.push(missingValueError(e));
+      return TVar("a");
     }
 
     const binding = this.getBinding(definition.expr);
@@ -1369,10 +1378,12 @@ export class InferenceScope {
     );
   }
 
-  private inferOperatorAsFunctionExpr(operator: EOperatorAsFunctionExpr): Type {
+  private inferOperatorAsFunctionExpr(
+    operatorFunction: EOperatorAsFunctionExpr,
+  ): Type {
     // Find operator reference
     const definition = findDefinition(
-      operator,
+      operatorFunction.operator,
       this.uri,
       this.elmWorkspace.getImports(),
     );


### PR DESCRIPTION
Added some good inference tests and found a bug in the process with operator as function expressions. Also, the make declaration code action should now have the inferred type for a function with no params.