### PR TITLE
Catch exceptions from type inference

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     "prettier/prettier": "error",
     "no-prototype-builtins": "warn",
     "no-case-declarations": "warn",
-    "no-use-before-define": "warn",
+    "no-use-before-define": "off",
     "no-async-promise-executor": "warn",
     "@typescript-eslint/no-misused-promises": "warn",
     "@typescript-eslint/unbound-method": "warn",

--- a/src/providers/diagnostics/typeInferenceDiagnostics.ts
+++ b/src/providers/diagnostics/typeInferenceDiagnostics.ts
@@ -44,24 +44,20 @@ export class TypeInferenceDiagnostics {
         .map((func) => func.firstChild?.firstChild)
         .filter(Utils.notUndefinedOrNull)
         .map((node) => {
-          try {
-            const typeString: string = TypeRenderer.typeToString(
-              findType(node, uri, elmWorkspace),
-              node.tree,
-              uri,
-              elmWorkspace.getImports(),
-            );
+          const typeString: string = TypeRenderer.typeToString(
+            findType(node, uri, elmWorkspace),
+            node.tree,
+            uri,
+            elmWorkspace.getImports(),
+          );
 
-            if (typeString && typeString !== "Unknown" && node) {
-              return {
-                range: this.getNodeRange(node),
-                message: `Missing type annotation: \`${typeString}\``,
-                severity: DiagnosticSeverity.Information,
-                source: this.TYPE_INFERENCE,
-              };
-            }
-          } catch (e) {
-            console.log(e);
+          if (typeString && typeString !== "Unknown" && node) {
+            return {
+              range: this.getNodeRange(node),
+              message: `Missing type annotation: \`${typeString}\``,
+              severity: DiagnosticSeverity.Information,
+              source: this.TYPE_INFERENCE,
+            };
           }
         })
         .filter(Utils.notUndefined.bind(this));


### PR DESCRIPTION
We might want to do this in the type inference handlers instead. But this fix has been tested by our VIM users and has been confirmed resolving the problem.

https://github.com/elm-tooling/elm-language-server/issues/337

I think it might also make sense to open an issue in the language-server implementation lib? What's your POV @jmbockhorst 