### PR TITLE
Use a better system for diagnostics with debouncing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7591,6 +7591,11 @@
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
+    "ts-debounce": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-2.0.1.tgz",
+      "integrity": "sha512-+TztZrH7GnAD5CKxUohIAqIVHLrtivsYT7tZCLeRTCaBMSsfgYwprhA00kB/m0ezvYheOXJQqPfarAvgoayb7A=="
+    },
     "ts-essentials": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "globby": "^11.0.1",
     "pjson": "1.0.9",
     "reflect-metadata": "^0.1.13",
+    "ts-debounce": "^2.0.1",
     "tsyringe": "^4.3.0",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "1.0.1",

--- a/src/providers/diagnostics/fileDiagnostics.ts
+++ b/src/providers/diagnostics/fileDiagnostics.ts
@@ -1,0 +1,67 @@
+import { Diagnostic } from "vscode-languageserver";
+import { Utils } from "../../util/utils";
+
+export const enum DiagnosticKind {
+  ElmMake,
+  ElmAnalyse,
+  ElmTest,
+  TypeInference,
+}
+
+export function diagnosticsEquals(a: Diagnostic, b: Diagnostic): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  return (
+    a.code === b.code &&
+    a.message === b.message &&
+    a.severity === b.severity &&
+    a.source === b.source &&
+    Utils.rangeEquals(a.range, b.range) &&
+    Utils.arrayEquals(
+      a.relatedInformation ?? [],
+      b.relatedInformation ?? [],
+      (a, b) => {
+        return (
+          a.message === b.message &&
+          Utils.rangeEquals(a.location.range, b.location.range) &&
+          a.location.uri === b.location.uri
+        );
+      },
+    ) &&
+    Utils.arrayEquals(a.tags ?? [], b.tags ?? [])
+  );
+}
+
+export class FileDiagnostics {
+  private diagnostics: Map<DiagnosticKind, Diagnostic[]> = new Map<
+    DiagnosticKind,
+    Diagnostic[]
+  >();
+
+  constructor(public uri: string) {}
+
+  public get(): Diagnostic[] {
+    return [
+      ...this.getForKind(DiagnosticKind.ElmMake),
+      ...this.getForKind(DiagnosticKind.ElmAnalyse),
+      ...this.getForKind(DiagnosticKind.ElmTest),
+      ...this.getForKind(DiagnosticKind.TypeInference),
+    ];
+  }
+
+  public update(kind: DiagnosticKind, diagnostics: Diagnostic[]): boolean {
+    const existing = this.getForKind(kind);
+    if (Utils.arrayEquals(existing, diagnostics, diagnosticsEquals)) {
+      return false;
+    }
+
+    this.diagnostics.set(kind, diagnostics);
+    return true;
+  }
+
+  public getForKind(kind: DiagnosticKind): Diagnostic[] {
+    return this.diagnostics.get(kind) ?? [];
+  }
+}

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -1,3 +1,5 @@
+import { Range } from "vscode-languageserver";
+
 export class Utils {
   public static notUndefined<T>(x: T | undefined): x is T {
     return x !== undefined;
@@ -5,5 +7,28 @@ export class Utils {
 
   public static notUndefinedOrNull<T>(x: T | undefined | null): x is T {
     return x !== undefined && x !== null;
+  }
+
+  public static arrayEquals<T>(
+    a: T[],
+    b: T[],
+    itemEquals: (a: T, b: T) => boolean = (a, b): boolean => a === b,
+  ): boolean {
+    if (a === b) {
+      return true;
+    }
+    if (a.length !== b.length) {
+      return false;
+    }
+    return a.every((x, i) => itemEquals(x, b[i]));
+  }
+
+  public static rangeEquals(a: Range, b: Range): boolean {
+    return (
+      a.start.character === b.start.character &&
+      a.start.line === b.start.line &&
+      a.end.character === b.end.character &&
+      a.end.line === b.end.line
+    );
   }
 }


### PR DESCRIPTION
Use a better system for handling diagnostics. Only send a diagnostics message if the files diagnostics have changed and also debounce requests. Early testing seems like this improves performance by a lot in large workspaces.