### PR TITLE
Add import resolve diagnostics and clean up API

### DIFF
--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -187,6 +187,21 @@ export interface ICancellationToken {
   throwIfCancellationRequested(): void;
 }
 
+export class ServerCancellationToken implements ICancellationToken {
+  constructor(private cancellationToken: CancellationToken) {}
+
+  public isCancellationRequested(): boolean {
+    return this.cancellationToken.isCancellationRequested;
+  }
+
+  public throwIfCancellationRequested(): void {
+    if (this.isCancellationRequested()) {
+      console.log("throwing cancellation");
+      throw new OperationCanceledException();
+    }
+  }
+}
+
 /**
  * ThrottledCancellationToken taken from Typescript: https://github.com/microsoft/TypeScript/blob/79ffd03f8b73010fa03cef624e5f1770bc9c975b/src/services/services.ts#L1152
  */

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -196,7 +196,6 @@ export class ServerCancellationToken implements ICancellationToken {
 
   public throwIfCancellationRequested(): void {
     if (this.isCancellationRequested()) {
-      console.log("throwing cancellation");
       throw new OperationCanceledException();
     }
   }

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -147,10 +147,7 @@ export class Forest implements IForest {
 
     // It should be faster to look directly at elmFolders instead of traversing the forest
     importClauses.forEach((importClause) => {
-      const moduleName = TreeUtils.findFirstNamedChildOfType(
-        "upper_case_qid",
-        importClause,
-      )?.text;
+      const moduleName = importClause.childForFieldName("moduleName")?.text;
 
       if (moduleName) {
         const modulePath = moduleName.split(".").join("/") + ".elm";
@@ -163,10 +160,7 @@ export class Forest implements IForest {
           ),
         );
 
-        if (treeContainer.writeable && !found) {
-          // TODO: Diagnostics for unresolved imports
-          console.log(`Could not resolve import for ${moduleName}`);
-        } else if (found) {
+        if (found) {
           resolvedModules.set(
             moduleName,
             URI.file(

--- a/src/util/types/diagnostics.ts
+++ b/src/util/types/diagnostics.ts
@@ -68,7 +68,7 @@ export const Diagnostics = {
   General: diag("general", "General error: {0}", DiagnosticSeverity.Error),
   ImportMissing: diag(
     "import_resolve",
-    "Could not find a module to import named {0} in `dependencies` or `source-directories`.",
+    "Could not find a module to import named `{0}` in `dependencies` or `source-directories`.",
     DiagnosticSeverity.Error,
   ),
   InfiniteRecursion: diag(

--- a/src/util/types/diagnostics.ts
+++ b/src/util/types/diagnostics.ts
@@ -66,6 +66,11 @@ export const Diagnostics = {
     DiagnosticSeverity.Error,
   ),
   General: diag("general", "General error: {0}", DiagnosticSeverity.Error),
+  ImportMissing: diag(
+    "import_resolve",
+    "Could not find a module to import named {0} in `dependencies` or `source-directories`.",
+    DiagnosticSeverity.Error,
+  ),
   InfiniteRecursion: diag(
     "infinite_recursion",
     "Infinite recursion.",


### PR DESCRIPTION
Some major refactoring of the type checker api for better handling diagnostics with an async option and allowing us to calculate other diagnostics like import resolves.