### PR TITLE
Fix import code actions

### DIFF
--- a/src/providers/codeAction/importCodeAction.ts
+++ b/src/providers/codeAction/importCodeAction.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { CodeAction, TextEdit } from "vscode-languageserver";
+import { Range } from "vscode-languageserver-textdocument";
+import { SyntaxNode } from "web-tree-sitter";
+import { ITreeContainer } from "../../forest";
+import { ImportUtils, IPossibleImport } from "../../util/importUtils";
+import { RefactorEditUtils } from "../../util/refactorEditUtils";
+import { TreeUtils } from "../../util/treeUtils";
+import { Diagnostics } from "../../util/types/diagnostics";
+import { CodeActionProvider, ICodeActionParams } from "../codeActionProvider";
+
+const errorCodes = [Diagnostics.MissingValue.code];
+
+CodeActionProvider.registerCodeAction({
+  errorCodes,
+  getCodeActions: (params: ICodeActionParams): CodeAction[] | undefined => {
+    const valueNode = TreeUtils.getNamedDescendantForRange(
+      params.sourceFile,
+      params.range,
+    );
+
+    return getPossibleImports(params, params.range).map((possibleImport) => {
+      const edit = getEditFromPossibleImport(
+        params.sourceFile,
+        params.range,
+        possibleImport,
+      );
+
+      const valueToImport = getValueToImport(valueNode, possibleImport);
+
+      return CodeActionProvider.getCodeAction(
+        params,
+        valueToImport
+          ? `Import '${valueToImport}' from module "${possibleImport.module}"`
+          : `Import module "${possibleImport.module}"`,
+        edit ? [edit] : [],
+      );
+    });
+  },
+  getFixAllCodeAction: (params: ICodeActionParams) => {
+    return CodeActionProvider.getFixAllCodeAction(
+      "Add all missing imports",
+      params,
+      errorCodes,
+      (edits, diagnostic) => {
+        const firstPossibleImport = getPossibleImports(
+          params,
+          diagnostic.range,
+        )[0];
+
+        if (firstPossibleImport) {
+          const edit = getEditFromPossibleImport(
+            params.sourceFile,
+            diagnostic.range,
+            firstPossibleImport,
+          );
+
+          if (edit) {
+            edits.push(edit);
+          }
+        }
+      },
+    );
+  },
+});
+
+function getPossibleImports(
+  params: ICodeActionParams,
+  range: Range,
+): IPossibleImport[] {
+  const valueNode = TreeUtils.getNamedDescendantForRange(
+    params.sourceFile,
+    range,
+  );
+
+  const possibleImports = ImportUtils.getPossibleImports(
+    params.program.getForest(),
+    params.sourceFile.uri,
+  );
+
+  // Add import quick fixes
+  if (valueNode) {
+    return possibleImports.filter(
+      (exposed) =>
+        exposed.value === valueNode.text ||
+        ((valueNode.type === "upper_case_qid" ||
+          valueNode.type === "value_qid") &&
+          exposed.value ===
+            valueNode.namedChildren[valueNode.namedChildren.length - 1].text &&
+          exposed.module ===
+            valueNode.namedChildren
+              .slice(0, valueNode.namedChildren.length - 2) // Dots are also namedNodes
+              .map((a) => a.text)
+              .join("")),
+    );
+  }
+
+  return [];
+}
+
+function getEditFromPossibleImport(
+  sourceFile: ITreeContainer,
+  range: Range,
+  possibleImport: IPossibleImport,
+): TextEdit | undefined {
+  const valueNode = TreeUtils.getNamedDescendantForRange(sourceFile, range);
+
+  return RefactorEditUtils.addImport(
+    sourceFile.tree,
+    possibleImport.module,
+    getValueToImport(valueNode, possibleImport),
+  );
+}
+
+function getValueToImport(
+  valueNode: SyntaxNode,
+  possibleImport: IPossibleImport,
+): string | undefined {
+  return valueNode.type !== "upper_case_qid" && valueNode.type !== "value_qid"
+    ? possibleImport.valueToImport ?? possibleImport.value
+    : undefined;
+}

--- a/src/providers/codeAction/index.ts
+++ b/src/providers/codeAction/index.ts
@@ -1,0 +1,1 @@
+import "./importCodeAction";

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -320,6 +320,7 @@ export class DiagnosticsProvider {
                 return;
               }
 
+              this.updateDiagnostics(uri, DiagnosticKind.ElmMake, []);
               this.updateDiagnostics(
                 uri,
                 DiagnosticKind.TypeInference,

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -164,6 +164,23 @@ export class DiagnosticsProvider {
     });
   }
 
+  public interuptDiagnostics<T>(f: () => T): T {
+    if (!this.pendingRequest) {
+      return f();
+    }
+
+    this.pendingRequest.cancel();
+    this.pendingRequest = undefined;
+    const result = f();
+
+    this.triggerDiagnostics();
+    return result;
+  }
+
+  public getCurrentDiagnostics(uri: string): Diagnostic[] {
+    return this.currentDiagnostics.get(uri)?.get() ?? [];
+  }
+
   private requestDiagnostics(uri: string): void {
     this.pendingDiagnostics.set(uri, Date.now());
     this.triggerDiagnostics();
@@ -180,20 +197,6 @@ export class DiagnosticsProvider {
 
     this.triggerDiagnostics();
   }
-
-  public interuptDiagnostics<T>(f: () => T): T {
-    if (!this.pendingRequest) {
-      return f();
-    }
-
-    this.pendingRequest.cancel();
-    this.pendingRequest = undefined;
-    const result = f();
-
-    this.triggerDiagnostics();
-    return result;
-  }
-
   private triggerDiagnostics(delay = 200): void {
     const sendPendingDiagnostics = (): void => {
       const orderedFiles = this.pendingDiagnostics.getOrderedFiles();
@@ -298,7 +301,7 @@ export class DiagnosticsProvider {
             }
 
             const uri = files[index];
-            const workspace = this.elmWorkspaceMatcher.getElmWorkspaceFor(
+            const workspace = this.elmWorkspaceMatcher.getProgramFor(
               URI.parse(uri),
             );
 
@@ -350,7 +353,7 @@ export class DiagnosticsProvider {
     );
   }
 
-  public async getElmMakeDiagnostics(uri: string): Promise<void> {
+  private async getElmMakeDiagnostics(uri: string): Promise<void> {
     const elmMakeDiagnostics = await this.elmMakeDiagnostics.createDiagnostics(
       URI.parse(uri),
     );
@@ -358,6 +361,7 @@ export class DiagnosticsProvider {
     this.resetDiagnostics(elmMakeDiagnostics, DiagnosticKind.ElmMake);
 
     elmMakeDiagnostics.forEach((diagnostics, diagnosticsUri) => {
+      this.updateDiagnostics(diagnosticsUri, DiagnosticKind.TypeInference, []);
       this.updateDiagnostics(
         diagnosticsUri,
         DiagnosticKind.ElmMake,

--- a/src/providers/diagnostics/elmDiagnosticsHelper.ts
+++ b/src/providers/diagnostics/elmDiagnosticsHelper.ts
@@ -1,7 +1,9 @@
 import path from "path";
 import { Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver";
 import { URI } from "vscode-uri";
+import { Diagnostics } from "../../util/types/diagnostics";
 import { IElmIssue } from "./diagnosticsProvider";
+import { NAMING_ERROR } from "./elmMakeDiagnostics";
 
 export class ElmDiagnosticsHelper {
   public static issuesToDiagnosticMap(
@@ -50,11 +52,17 @@ export class ElmDiagnosticsHelper {
 
     const messagePrefix = issue.overview ? `${issue.overview} - ` : "";
 
+    let code = undefined;
+
+    if (issue.overview.startsWith(NAMING_ERROR)) {
+      code = Diagnostics.MissingValue.code;
+    }
+
     return Diagnostic.create(
       lineRange,
       `${messagePrefix}${issue.details.replace(/\[\d+m/g, "")}`,
       this.severityStringToDiagnosticSeverity(issue.type),
-      undefined,
+      code,
       "Elm",
     );
   }

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -373,9 +373,7 @@ export class ElmLsDiagnostics {
   ): CodeAction[] {
     const result: CodeAction[] = [];
 
-    const elmWorkspace = this.elmWorkspaceMatcher.getElmWorkspaceFor(
-      URI.parse(uri),
-    );
+    const elmWorkspace = this.elmWorkspaceMatcher.getProgramFor(URI.parse(uri));
 
     const forest = elmWorkspace.getForest();
 

--- a/src/providers/diagnostics/typeInferenceDiagnostics.ts
+++ b/src/providers/diagnostics/typeInferenceDiagnostics.ts
@@ -14,10 +14,10 @@ export class TypeInferenceDiagnostics {
 
   public getDiagnosticsForFileAsync(
     treeContainer: ITreeContainer,
-    elmWorkspace: IElmWorkspace,
+    program: IElmWorkspace,
     cancellationToken: CancellationToken,
   ): Promise<Diagnostic[]> {
-    const checker = elmWorkspace.getTypeChecker();
+    const checker = program.getTypeChecker();
 
     const diagnostics: Diagnostic[] = [];
 
@@ -27,7 +27,7 @@ export class TypeInferenceDiagnostics {
       TreeUtils.findAllTopLevelFunctionDeclarations(treeContainer.tree) ?? [];
 
     return new Promise((resolve, reject) => {
-      checker
+      program
         .getDiagnosticsAsync(
           treeContainer,
           new ServerCancellationToken(cancellationToken),

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -14,3 +14,4 @@ export * from "./hoverProvider";
 export * from "./referencesProvider";
 export * from "./renameProvider";
 export * from "./workspaceSymbolProvider";
+import "./codeAction";

--- a/src/util/multiMap.ts
+++ b/src/util/multiMap.ts
@@ -22,6 +22,16 @@ export class MultiMap<K, V> extends Map<K, V | V[]> {
     }
   }
 
+  public getAll(key: K): V[] | undefined {
+    const found = super.get(key);
+
+    if (Array.isArray(found)) {
+      return found;
+    } else if (found) {
+      return [found];
+    }
+  }
+
   public set(key: K, val: V): this {
     if (super.has(key)) {
       const existing = super.get(key);

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -8,6 +8,7 @@ import {
   EFunctionCallExpr,
   mapSyntaxNodeToExpression,
 } from "./types/expressionTree";
+import { Range } from "vscode-languageserver-textdocument";
 
 export type NodeType =
   | "Function"
@@ -39,14 +40,16 @@ export interface IExposed {
 export type IExposing = Map<string, IExposed>;
 
 export function flatMap<T, U>(
-  array: T[],
-  callback: (value: T, index: number, array: T[]) => U[],
+  array: T[] | undefined,
+  callback: (value: T, index: number, array: T[]) => U[] | undefined,
 ): U[] {
   const flattend: U[] = [];
-  for (let i = 0; i < array.length; i++) {
-    const elementArray = callback(array[i], i, array);
-    for (const el of elementArray) {
-      flattend.push(el);
+  if (array) {
+    for (let i = 0; i < array.length; i++) {
+      const elementArray = callback(array[i], i, array);
+      if (elementArray) {
+        flattend.push(...elementArray);
+      }
     }
   }
   return flattend;
@@ -804,6 +807,22 @@ export class TreeUtils {
         },
       );
     }
+  }
+
+  public static getNamedDescendantForRange(
+    sourceFile: ITreeContainer,
+    range: Range,
+  ): SyntaxNode {
+    return sourceFile.tree.rootNode.namedDescendantForPosition(
+      {
+        column: range.start.character,
+        row: range.start.line,
+      },
+      {
+        column: range.end.character,
+        row: range.end.line,
+      },
+    );
   }
 
   public static findPreviousNode(

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -449,7 +449,7 @@ function argumentCountError(
       node,
       Diagnostics.ArgumentCount,
       endNode,
-      name ? `\`${name}\`` : "This value",
+      name ?? "This value",
       actual,
     );
   } else {

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -31,4 +31,23 @@ export class Utils {
       a.end.line === b.end.line
     );
   }
+
+  public static rangeOverlaps(a: Range, b: Range): boolean {
+    if (b.start.line < a.start.line || b.end.line < a.start.line) {
+      return false;
+    }
+    if (b.start.line > a.end.line || b.end.line > a.end.line) {
+      return false;
+    }
+    if (
+      b.start.line === a.start.line &&
+      b.start.character < a.start.character
+    ) {
+      return false;
+    }
+    if (b.end.line === a.end.line && b.end.character > a.end.character) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/test/codeActionProvider.test.ts
+++ b/test/codeActionProvider.test.ts
@@ -1,0 +1,183 @@
+import { container } from "tsyringe";
+import { CodeAction } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import { IElmWorkspace } from "../src/elmWorkspace";
+import { CodeActionProvider, ICodeActionParams } from "../src/providers";
+import { Utils } from "../src/util/utils";
+import { baseUri } from "./utils/mockElmWorkspace";
+import { getTargetPositionFromSource } from "./utils/sourceParser";
+import { SourceTreeParser } from "./utils/sourceTreeParser";
+
+function codeActionEquals(a: CodeAction, b: CodeAction): boolean {
+  return a.title === b.title;
+}
+
+const basicsSources = `
+--@ Basics.elm
+module Basics exposing ((+), (|>), (==), Int, Float, Bool(..), Order(..))
+
+infix left  0 (|>) = apR
+infix non   4 (==) = eq
+infix left  6 (+)  = add
+
+type Int = Int
+
+type Float = Float
+
+type Bool = True | False
+
+add : number -> number -> number
+add =
+  Elm.Kernel.Basics.add
+
+apR : a -> (a -> b) -> b
+apR x f =
+  f x
+
+eq : a -> a -> Bool
+eq =
+  Elm.Kernel.Utils.equal
+
+type Order = LT | EQ | GT
+`;
+
+class MockCodeActionsProvider extends CodeActionProvider {
+  public handleCodeAction(params: ICodeActionParams): CodeAction[] | undefined {
+    return this.onCodeAction(params);
+  }
+}
+
+describe("test codeActionProvider", () => {
+  const treeParser = new SourceTreeParser();
+  let codeActionProvider: MockCodeActionsProvider;
+
+  const debug = process.argv.find((arg) => arg === "--debug");
+
+  async function testCodeAction(
+    source: string,
+    expectedCodeActions: CodeAction[],
+  ) {
+    await treeParser.init();
+
+    if (!codeActionProvider) {
+      codeActionProvider = new MockCodeActionsProvider();
+    }
+
+    const result = getTargetPositionFromSource(source);
+
+    if (!result) {
+      throw new Error("Getting sources failed");
+    }
+
+    const testUri = URI.file(baseUri + "Test.elm").toString();
+
+    const program = treeParser.getWorkspace(result.sources);
+    const sourceFile = program.getForest().getByUri(testUri);
+
+    if (!sourceFile) throw new Error("Getting tree failed");
+
+    const workspaces = container.resolve<IElmWorkspace[]>("ElmWorkspaces");
+    workspaces.splice(0, workspaces.length);
+    workspaces.push(program);
+
+    const range = { start: result.position, end: result.position };
+    const codeActions =
+      codeActionProvider.handleCodeAction({
+        program,
+        sourceFile,
+        range,
+        textDocument: { uri: testUri },
+        context: {
+          diagnostics: program
+            .getDiagnostics(sourceFile)
+            .filter((diag) => Utils.rangeOverlaps(diag.range, range)),
+        },
+      }) ?? [];
+
+    const codeActionsExist = expectedCodeActions.every((codeAction) =>
+      codeActions.find((c) => codeActionEquals(codeAction, c)),
+    );
+
+    if (debug && !codeActionsExist) {
+      console.log(
+        `Expecting ${JSON.stringify(expectedCodeActions)}, got ${JSON.stringify(
+          codeActions,
+        )}`,
+      );
+    }
+
+    expect(codeActionsExist).toBeTruthy();
+  }
+
+  test("add import of value", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func = foo
+      --^
+
+--@ App.elm
+module App exposing (foo)
+
+foo = ""
+`;
+    await testCodeAction(basicsSources + source, [
+      { title: `Import 'foo' from module "App"` },
+    ]);
+  });
+
+  test("add import of qualified value", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func = App.foo
+          --^
+
+--@ App.elm
+module App exposing (foo)
+
+foo = ""
+`;
+    await testCodeAction(basicsSources + source, [
+      { title: `Import module "App"` },
+    ]);
+
+    const source2 = `
+--@ Test.elm
+module Test exposing (..)
+
+func = App.foo
+      --^
+
+--@ App.elm
+module App exposing (foo)
+
+foo = ""
+`;
+    await testCodeAction(basicsSources + source2, [
+      { title: `Import module "App"` },
+    ]);
+  });
+
+  test("add all missing imports", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func = foo + bar
+      --^
+
+--@ App.elm
+module App exposing (foo, bar)
+
+foo = ""
+
+bar = ""
+`;
+    await testCodeAction(basicsSources + source, [
+      { title: `Add all missing imports` },
+    ]);
+  });
+});

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -69,25 +69,23 @@ describe("test elm diagnostics", () => {
 
     const testUri = URI.file(baseUri + "Test.elm").toString();
 
-    const workspace = treeParser.getWorkspace(result.sources);
-    const treeContainer = workspace.getForest().getByUri(testUri);
+    const program = treeParser.getWorkspace(result.sources);
+    const treeContainer = program.getForest().getByUri(testUri);
 
     if (!treeContainer) throw new Error("Getting tree failed");
 
-    const checker = workspace.getTypeChecker();
     const diagnostics: Diagnostic[] = [];
 
-    workspace.getForest().treeMap.forEach((treeContainer) => {
+    program.getForest().treeMap.forEach((treeContainer) => {
       if (!treeContainer.uri.includes("Basic")) {
-        diagnostics.push(...checker.getDiagnostics(treeContainer));
+        diagnostics.push(...program.getDiagnostics(treeContainer));
       }
     });
 
     let nodeAtPosition: SyntaxNode;
 
     if ("position" in result) {
-      const rootNode = workspace.getForest().treeMap.get(testUri)!.tree
-        .rootNode;
+      const rootNode = program.getForest().treeMap.get(testUri)!.tree.rootNode;
       nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
         rootNode,
         result.position,


### PR DESCRIPTION
Adds a new system for code actions using a registration model that should be nicer and easy to handle "fix all" code actions. Moves the import code action out of the `elmMakeDiagnostics` and into a shared code action registration that is used for type inference diagnostics as well. In the future I will work to consolidate other code actions to this new way. Also started adding tests for code actions. I assume it will need some cleanup, but its most of the way there. 

Another thing I changed was the diagnostics behavior between the compiler and our analyzer. Now, when you save, we clear our diagnostics and get them only from the compiler. Then if you make a change, we clear the compiler ones and only get ours. We can talk about this more if we need to.