### PR TITLE
Remove use of Diagnostic code property

### DIFF
--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -4,7 +4,7 @@ import os from "os";
 import path from "path";
 import { container } from "tsyringe";
 import util from "util";
-import { Connection, Diagnostic } from "vscode-languageserver";
+import { Connection } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import Parser, { Tree } from "web-tree-sitter";
 import { ICancellationToken } from "./cancellation";
@@ -15,6 +15,7 @@ import {
   PossibleImportsCache,
 } from "./util/possibleImportsCache";
 import { Settings } from "./util/settings";
+import { Diagnostic } from "./util/types/diagnostics";
 import { TypeCache } from "./util/types/typeCache";
 import {
   createTypeChecker,

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -7,7 +7,7 @@ import { existsSync } from "fs";
 import { URI } from "vscode-uri";
 import { SyntaxNodeMap } from "./util/types/syntaxNodeMap";
 import { SymbolMap } from "./util/types/binder";
-import { Diagnostic } from "vscode-languageserver";
+import { Diagnostic } from "./util/types/diagnostics";
 
 export interface ITreeContainer {
   uri: string;

--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -90,13 +90,14 @@ export class CodeActionProvider {
     params: ICodeActionParams,
     title: string,
     edits: TextEdit[],
+    isPreferred = false,
   ): CodeAction {
     const changes = { [params.sourceFile.uri]: edits };
     return {
       title,
       kind: CodeActionKind.QuickFix,
       edit: { changes },
-      isPreferred: true,
+      isPreferred,
     };
   }
 

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -36,6 +36,13 @@ export interface IElmIssue {
   file: string;
 }
 
+export interface IDiagnostic extends Omit<Diagnostic, "code"> {
+  data: {
+    uri: string;
+    code: string;
+  };
+}
+
 class PendingDiagnostics extends Map<string, number> {
   public getOrderedFiles(): string[] {
     return Array.from(this.entries())
@@ -177,7 +184,7 @@ export class DiagnosticsProvider {
     return result;
   }
 
-  public getCurrentDiagnostics(uri: string): Diagnostic[] {
+  public getCurrentDiagnostics(uri: string): IDiagnostic[] {
     return this.currentDiagnostics.get(uri)?.get() ?? [];
   }
 
@@ -242,7 +249,7 @@ export class DiagnosticsProvider {
   private updateDiagnostics(
     uri: string,
     kind: DiagnosticKind,
-    diagnostics: Diagnostic[],
+    diagnostics: IDiagnostic[],
   ): void {
     let didUpdate = false;
 
@@ -377,7 +384,7 @@ export class DiagnosticsProvider {
   }
 
   private resetDiagnostics(
-    diagnosticList: Map<string, Diagnostic[]>,
+    diagnosticList: Map<string, IDiagnostic[]>,
     diagnosticKind: DiagnosticKind,
   ): void {
     this.currentDiagnostics.forEach((fileDiagnostics, diagnosticsUri) => {

--- a/src/providers/diagnostics/elmDiagnosticsHelper.ts
+++ b/src/providers/diagnostics/elmDiagnosticsHelper.ts
@@ -62,7 +62,7 @@ export class ElmDiagnosticsHelper {
       range: lineRange,
       message: `${messagePrefix}${issue.details.replace(/\[\d+m/g, "")}`,
       severity: this.severityStringToDiagnosticSeverity(issue.type),
-      source: "elm",
+      source: "Elm",
       data: { uri: issue.file, code },
     };
   }

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -8,7 +8,6 @@ import {
   CodeAction,
   CodeActionKind,
   CodeActionParams,
-  Diagnostic,
   Connection,
   TextEdit,
 } from "vscode-languageserver";
@@ -22,7 +21,7 @@ import { RefactorEditUtils } from "../../util/refactorEditUtils";
 import { Settings } from "../../util/settings";
 import { TreeUtils } from "../../util/treeUtils";
 import { Utils } from "../../util/utils";
-import { IElmIssue } from "./diagnosticsProvider";
+import { IDiagnostic, IElmIssue } from "./diagnosticsProvider";
 import { ElmDiagnosticsHelper } from "./elmDiagnosticsHelper";
 import execa = require("execa");
 import { IElmWorkspace } from "../../elmWorkspace";
@@ -106,10 +105,10 @@ export class ElmMakeDiagnostics {
   private elmWorkspaceMatcher: ElmWorkspaceMatcher<URI>;
   private neededImports: Map<
     string,
-    { moduleName: string; valueName?: string; diagnostic: Diagnostic }[]
+    { moduleName: string; valueName?: string; diagnostic: IDiagnostic }[]
   > = new Map<
     string,
-    { moduleName: string; valueName?: string; diagnostic: Diagnostic }[]
+    { moduleName: string; valueName?: string; diagnostic: IDiagnostic }[]
   >();
   private settings: Settings;
   private connection: Connection;
@@ -122,7 +121,7 @@ export class ElmMakeDiagnostics {
 
   public createDiagnostics = async (
     filePath: URI,
-  ): Promise<Map<string, Diagnostic[]>> => {
+  ): Promise<Map<string, IDiagnostic[]>> => {
     const workspaceRootPath = this.elmWorkspaceMatcher
       .getProgramFor(filePath)
       .getRootPath();
@@ -200,15 +199,15 @@ export class ElmMakeDiagnostics {
 
   public onCodeAction(params: CodeActionParams): CodeAction[] {
     const { uri } = params.textDocument;
-    const elmMakeDiagnostics: Diagnostic[] = this.filterElmMakeDiagnostics(
-      params.context.diagnostics,
+    const elmMakeDiagnostics: IDiagnostic[] = this.filterElmMakeDiagnostics(
+      params.context.diagnostics as IDiagnostic[],
     );
 
     return this.convertDiagnosticsToCodeActions(elmMakeDiagnostics, uri);
   }
 
   private convertDiagnosticsToCodeActions(
-    diagnostics: Diagnostic[],
+    diagnostics: IDiagnostic[],
     uri: string,
   ): CodeAction[] {
     const result: CodeAction[] = [];
@@ -295,7 +294,7 @@ export class ElmMakeDiagnostics {
 
   private addCaseQuickfixes(
     sourceTree: ITreeContainer | undefined,
-    diagnostic: Diagnostic,
+    diagnostic: IDiagnostic,
     uri: string,
     elmWorkspace: IElmWorkspace,
   ): CodeAction[] {
@@ -393,7 +392,7 @@ export class ElmMakeDiagnostics {
   private createCaseQuickFix(
     uri: string,
     replaceWith: string,
-    diagnostic: Diagnostic,
+    diagnostic: IDiagnostic,
     title: string,
   ): CodeAction {
     const map: {
@@ -414,7 +413,7 @@ export class ElmMakeDiagnostics {
   private createQuickFix(
     uri: string,
     replaceWith: string,
-    diagnostic: Diagnostic,
+    diagnostic: IDiagnostic,
     title: string,
   ): CodeAction {
     const map: {
@@ -434,7 +433,7 @@ export class ElmMakeDiagnostics {
 
   private createImportQuickFix(
     uri: string,
-    diagnostic: Diagnostic,
+    diagnostic: IDiagnostic,
     moduleName: string,
     nameToImport?: string,
   ): CodeAction {
@@ -469,7 +468,7 @@ export class ElmMakeDiagnostics {
     };
   }
 
-  private filterElmMakeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
+  private filterElmMakeDiagnostics(diagnostics: IDiagnostic[]): IDiagnostic[] {
     return diagnostics.filter((diagnostic) => diagnostic.source === ELM_MAKE);
   }
 

--- a/src/providers/diagnostics/fileDiagnostics.ts
+++ b/src/providers/diagnostics/fileDiagnostics.ts
@@ -1,5 +1,5 @@
-import { Diagnostic } from "vscode-languageserver";
 import { Utils } from "../../util/utils";
+import { IDiagnostic } from "./diagnosticsProvider";
 
 export const enum DiagnosticKind {
   ElmMake,
@@ -8,16 +8,17 @@ export const enum DiagnosticKind {
   ElmLS,
 }
 
-export function diagnosticsEquals(a: Diagnostic, b: Diagnostic): boolean {
+export function diagnosticsEquals(a: IDiagnostic, b: IDiagnostic): boolean {
   if (a === b) {
     return true;
   }
 
   return (
-    a.code === b.code &&
     a.message === b.message &&
     a.severity === b.severity &&
     a.source === b.source &&
+    a.data.code === b.data.code &&
+    a.data.uri === b.data.uri &&
     Utils.rangeEquals(a.range, b.range) &&
     Utils.arrayEquals(
       a.relatedInformation ?? [],
@@ -35,14 +36,14 @@ export function diagnosticsEquals(a: Diagnostic, b: Diagnostic): boolean {
 }
 
 export class FileDiagnostics {
-  private diagnostics: Map<DiagnosticKind, Diagnostic[]> = new Map<
+  private diagnostics: Map<DiagnosticKind, IDiagnostic[]> = new Map<
     DiagnosticKind,
-    Diagnostic[]
+    IDiagnostic[]
   >();
 
   constructor(public uri: string) {}
 
-  public get(): Diagnostic[] {
+  public get(): IDiagnostic[] {
     return [
       ...this.getForKind(DiagnosticKind.ElmMake),
       ...this.getForKind(DiagnosticKind.ElmTest),
@@ -51,7 +52,7 @@ export class FileDiagnostics {
     ];
   }
 
-  public update(kind: DiagnosticKind, diagnostics: Diagnostic[]): boolean {
+  public update(kind: DiagnosticKind, diagnostics: IDiagnostic[]): boolean {
     const existing = this.getForKind(kind);
     if (Utils.arrayEquals(existing, diagnostics, diagnosticsEquals)) {
       return false;
@@ -61,7 +62,7 @@ export class FileDiagnostics {
     return true;
   }
 
-  public getForKind(kind: DiagnosticKind): Diagnostic[] {
+  public getForKind(kind: DiagnosticKind): IDiagnostic[] {
     return this.diagnostics.get(kind) ?? [];
   }
 }

--- a/src/util/types/diagnostics.ts
+++ b/src/util/types/diagnostics.ts
@@ -1,6 +1,16 @@
-import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
+/* eslint-disable @typescript-eslint/naming-convention */
+import { DiagnosticSeverity, Range } from "vscode-languageserver";
 import { SyntaxNode } from "web-tree-sitter";
 import { PositionUtil } from "../../positionUtil";
+
+export interface Diagnostic {
+  code: string;
+  message: string;
+  source: string;
+  severity: DiagnosticSeverity;
+  range: Range;
+  uri: string;
+}
 
 function format(text: string, ...args: (string | number)[]): string {
   return text.replace(/{(\d+)}/g, (_match, index: string) => `${args[+index]}`);
@@ -23,7 +33,7 @@ export function errorWithEndNode(
     code: diagnostic.code,
     severity: diagnostic.severity,
     source: "elm",
-    data: { uri: node.tree.uri },
+    uri: node.tree.uri,
   };
 }
 

--- a/src/util/types/typeChecker.ts
+++ b/src/util/types/typeChecker.ts
@@ -9,7 +9,7 @@ import {
 } from "./expressionTree";
 import { IElmWorkspace } from "../../elmWorkspace";
 import { container } from "tsyringe";
-import { Connection, Diagnostic } from "vscode-languageserver";
+import { Connection } from "vscode-languageserver";
 import {
   Type,
   TUnknown,
@@ -25,7 +25,7 @@ import { Sequence } from "../sequence";
 import { Utils } from "../utils";
 import { TypeExpression } from "./typeExpression";
 import { ICancellationToken } from "../../cancellation";
-import { Diagnostics, error } from "./diagnostics";
+import { Diagnostic, Diagnostics, error } from "./diagnostics";
 
 export let bindTime = 0;
 export function resetBindTime(): void {
@@ -40,13 +40,11 @@ export interface DefinitionResult {
 
 class DiagnosticsCollection extends Map<string, Diagnostic[]> {
   public add(diagnostic: Diagnostic): void {
-    const uri = (<any>diagnostic.data).uri;
-
-    let diagnostics = super.get(uri);
+    let diagnostics = super.get(diagnostic.uri);
 
     if (!diagnostics) {
       diagnostics = [];
-      super.set(uri, diagnostics);
+      super.set(diagnostic.uri, diagnostics);
     }
 
     diagnostics.push(diagnostic);

--- a/src/util/types/typeExpression.ts
+++ b/src/util/types/typeExpression.ts
@@ -35,8 +35,7 @@ import { SyntaxNodeMap } from "./syntaxNodeMap";
 import { Utils } from "../utils";
 import { RecordFieldReferenceTable } from "./recordFieldReferenceTable";
 import { IElmWorkspace } from "../../elmWorkspace";
-import { Diagnostic } from "vscode-languageserver";
-import { Diagnostics, error } from "./diagnostics";
+import { Diagnostic, Diagnostics, error } from "./diagnostics";
 
 export class TypeExpression {
   // All the type variables we've seen

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -46,8 +46,12 @@ import { RecordFieldReferenceTable } from "./recordFieldReferenceTable";
 import { TypeChecker } from "./typeChecker";
 import { performance } from "perf_hooks";
 import { ICancellationToken } from "../../cancellation";
-import { Diagnostics, error, errorWithEndNode } from "./diagnostics";
-import { Diagnostic } from "vscode-languageserver";
+import {
+  Diagnostic,
+  Diagnostics,
+  error,
+  errorWithEndNode,
+} from "./diagnostics";
 
 export let inferTime = 0;
 export function resetInferTime(): void {

--- a/test/codeActionProvider.test.ts
+++ b/test/codeActionProvider.test.ts
@@ -2,7 +2,11 @@ import { container } from "tsyringe";
 import { CodeAction } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { IElmWorkspace } from "../src/elmWorkspace";
-import { CodeActionProvider, ICodeActionParams } from "../src/providers";
+import {
+  CodeActionProvider,
+  convertFromAnalyzerDiagnostic,
+  ICodeActionParams,
+} from "../src/providers";
 import { Utils } from "../src/util/utils";
 import { baseUri } from "./utils/mockElmWorkspace";
 import { getTargetPositionFromSource } from "./utils/sourceParser";
@@ -90,7 +94,8 @@ describe("test codeActionProvider", () => {
         context: {
           diagnostics: program
             .getDiagnostics(sourceFile)
-            .filter((diag) => Utils.rangeOverlaps(diag.range, range)),
+            .filter((diag) => Utils.rangeOverlaps(diag.range, range))
+            .map(convertFromAnalyzerDiagnostic),
         },
       }) ?? [];
 

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -1,10 +1,11 @@
 import { debug } from "console";
-import { Diagnostic } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { SyntaxNode } from "web-tree-sitter";
+import { convertFromAnalyzerDiagnostic } from "../../src/providers";
 import { diagnosticsEquals } from "../../src/providers/diagnostics/fileDiagnostics";
 import { TreeUtils } from "../../src/util/treeUtils";
 import {
+  Diagnostic,
   Diagnostics,
   error,
   IDiagnosticMessage,
@@ -93,11 +94,13 @@ describe("test elm diagnostics", () => {
     }
 
     const expected = expectedDiagnostics.map((exp) =>
-      error(nodeAtPosition, exp.message, ...exp.args),
+      convertFromAnalyzerDiagnostic(
+        error(nodeAtPosition, exp.message, ...exp.args),
+      ),
     );
 
     const diagnosticsEqual = Utils.arrayEquals(
-      diagnostics,
+      diagnostics.map(convertFromAnalyzerDiagnostic),
       expected,
       diagnosticsEquals,
     );

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -1,10 +1,10 @@
 import {
-  Diagnostic,
   DiagnosticSeverity,
   DiagnosticTag,
   Range,
 } from "vscode-languageserver";
 import { URI } from "vscode-uri";
+import { IDiagnostic } from "../../src/providers/diagnostics/diagnosticsProvider";
 import { ElmLsDiagnostics } from "../../src/providers/diagnostics/elmLsDiagnostics";
 import { diagnosticsEquals } from "../../src/providers/diagnostics/fileDiagnostics";
 import { Utils } from "../../src/util/utils";
@@ -17,17 +17,18 @@ describe("ElmLsDiagnostics", () => {
   const treeParser = new SourceTreeParser();
 
   const debug = process.argv.find((arg) => arg === "--debug");
+  const uri = URI.file(baseUri + "Main.elm").toString();
 
   async function testDiagnostics(
     source: string,
     code: string,
-    expectedDiagnostics: Diagnostic[],
+    expectedDiagnostics: IDiagnostic[],
   ) {
     await treeParser.init();
     elmDiagnostics = new ElmLsDiagnostics();
 
     const workspace = treeParser.getWorkspace(getSourceFiles(source));
-    const uri = URI.file(baseUri + "Main.elm").toString();
+
     const treeContainer = workspace.getForest().getByUri(uri);
 
     if (!treeContainer) {
@@ -36,7 +37,7 @@ describe("ElmLsDiagnostics", () => {
 
     const diagnostics = elmDiagnostics
       .createDiagnostics(treeContainer, workspace)
-      .filter((diagnostic) => diagnostic.code === code);
+      .filter((diagnostic) => diagnostic.data.code === code);
 
     const diagnosticsEqual = Utils.arrayEquals(
       diagnostics,
@@ -56,13 +57,16 @@ describe("ElmLsDiagnostics", () => {
   }
 
   describe("boolean case expressions", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "boolean_case_expr",
         message: "Use an if expression instead of a case expression.",
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "boolean_case_expr",
+        },
       };
     };
 
@@ -123,14 +127,17 @@ foo x =
     const diagnosticWithRangeAndName = (
       range: Range,
       name: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_top_level",
         message: `Unused top level definition \`${name}\``,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_top_level",
+        },
       };
     };
 
@@ -296,14 +303,17 @@ getItemAtIndex index =
     const diagnosticWithRangeAndName = (
       range: Range,
       name: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_import",
         message: `Unused import \`${name}\``,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_import",
+        },
       };
     };
 
@@ -408,14 +418,17 @@ foo = 1
     const diagnosticWithRangeAndName = (
       range: Range,
       name: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_alias",
         message: `Unused import alias \`${name}\``,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_alias",
+        },
       };
     };
 
@@ -510,14 +523,17 @@ type alias Thing = { name : B.Name }
       range: Range,
       name: string,
       type: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_imported_value",
         message: `Unused imported ${type} \`${name}\``,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_imported_value",
+        },
       };
     };
 
@@ -702,14 +718,17 @@ x y =
     const diagnosticWithRangeAndName = (
       range: Range,
       name: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_pattern",
         message: `Unused pattern variable \`${name}\``,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_pattern",
+        },
       };
     };
 
@@ -876,13 +895,16 @@ x =
   });
 
   describe("drop cons of item and list", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "drop_cons_of_item_and_list",
         message: `If you cons an item to a literal list, then you can just put the item into the list.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "drop_cons_of_item_and_list",
+        },
       };
     };
 
@@ -917,13 +939,16 @@ foo =
   });
 
   describe("map nothing to nothing", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "map_nothing_to_nothing",
         message: `\`Nothing\` mapped to \`Nothing\` in case expression. Use Maybe.map or Maybe.andThen instead.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "map_nothing_to_nothing",
+        },
       };
     };
 
@@ -970,13 +995,16 @@ y = case x of
   });
 
   describe("drop concat of lists", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "drop_concat_of_lists",
         message: `If you concatenate two lists, then you can merge them into one list.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "drop_concat_of_lists",
+        },
       };
     };
 
@@ -1028,13 +1056,16 @@ foo =
   });
 
   describe("use cons over concat", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "use_cons_over_concat",
         message: `If you concatenate two lists, but the first item is a single element list, then you should use the cons operator.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "use_cons_over_concat",
+        },
       };
     };
 
@@ -1069,13 +1100,16 @@ foo =
   });
 
   describe("single field record", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "single_field_record",
         message: `Using a record is obsolete if you only plan to store a single field in it.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "single_field_record",
+        },
       };
     };
 
@@ -1173,13 +1207,16 @@ type alias CheckboxParams a =
   });
 
   describe("unnecessary list concat", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "unnecessary_list_concat",
         message: `You should just merge the arguments of \`List.concat\` to a single list.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "unnecessary_list_concat",
+        },
       };
     };
 
@@ -1239,13 +1276,16 @@ foo =
   });
 
   describe("unnecessary port module", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "unnecessary_port_module",
         message: `Module is definined as a \`port\` module, but does not define any ports.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "unnecessary_port_module",
+        },
       };
     };
 
@@ -1288,13 +1328,16 @@ port foo : String -> Cmd msg
   });
 
   describe("fully applied operator as prefix", () => {
-    const diagnosticWithRange = (range: Range): Diagnostic => {
+    const diagnosticWithRange = (range: Range): IDiagnostic => {
       return {
-        code: "no_uncurried_prefix",
         message: `Don't use fully applied prefix notation for operators.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
+        data: {
+          uri,
+          code: "no_uncurried_prefix",
+        },
       };
     };
 
@@ -1328,14 +1371,17 @@ foo = (+) 1
     const diagnosticWithRangeAndName = (
       range: Range,
       name: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_type_alias",
         message: `Type alias \`${name}\` is not used.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_type_alias",
+        },
       };
     };
 
@@ -1440,14 +1486,17 @@ foo = 1
     const diagnosticWithRangeAndName = (
       range: Range,
       name: string,
-    ): Diagnostic => {
+    ): IDiagnostic => {
       return {
-        code: "unused_value_constructor",
         message: `Value constructor \`${name}\` is not used.`,
         source: "ElmLS",
         severity: DiagnosticSeverity.Warning,
         range,
         tags: [DiagnosticTag.Unnecessary],
+        data: {
+          uri,
+          code: "unused_value_constructor",
+        },
       };
     };
 

--- a/test/utils/mockElmWorkspace.ts
+++ b/test/utils/mockElmWorkspace.ts
@@ -16,8 +16,8 @@ import {
   IPossibleImportsCache,
   PossibleImportsCache,
 } from "../../src/util/possibleImportsCache";
-import { Diagnostic } from "vscode-languageserver";
 import { ICancellationToken } from "../../src/cancellation";
+import { Diagnostic } from "../../src/util/types/diagnostics";
 
 export const baseUri = Path.join(__dirname, "../sources/src/");
 


### PR DESCRIPTION
Adds a new interface `IDiagnostic` for the server that extends `Diagnostic` and ensures the `data` property has a `uri` and `code` and that we always omit the top level `code`. Also defined a new `Diagnostic` interface for the analyzer API so it doesn't rely on LSP. 