### PR TITLE
Fix another union constructor definition bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2698,6 +2698,11 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "escape-string-regexp": "^4.0.0",
     "execa": "^4.1.0",
     "fast-diff": "^1.2.0",
+    "fromentries": "^1.3.2",
     "globby": "^11.0.1",
     "pjson": "1.0.9",
     "reflect-metadata": "^0.1.13",

--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -107,10 +107,12 @@ export class ASTProvider {
         ) {
           changedDeclaration = startNode;
           params.program.getTypeCache().invalidateValueDeclaration(startNode);
-        } else {
-          params.program.getTypeCache().invalidateProject();
         }
       });
+
+    if (!changedDeclaration) {
+      params.program.getTypeCache().invalidateProject();
+    }
 
     tree = newTree;
 

--- a/src/util/treeUtils.ts
+++ b/src/util/treeUtils.ts
@@ -966,6 +966,28 @@ export class TreeUtils {
     }
   }
 
+  public static getValueDeclaration(
+    typeAnnotation?: SyntaxNode,
+  ): SyntaxNode | undefined {
+    if (typeAnnotation?.type !== "type_annotation") {
+      return;
+    }
+
+    let candidate = typeAnnotation.nextNamedSibling;
+
+    // Skip comments
+    while (
+      candidate?.type === "line_comment" ||
+      candidate?.type === "comment_block"
+    ) {
+      candidate = candidate.nextNamedSibling;
+    }
+
+    if (candidate?.type === "value_declaration") {
+      return candidate;
+    }
+  }
+
   /**
    * This gets a list of all ancestors of a type
    * in order from the closest declaration up to the top level declaration

--- a/src/util/types/typeExpression.ts
+++ b/src/util/types/typeExpression.ts
@@ -67,7 +67,7 @@ export class TypeExpression {
       const inferenceResult = new TypeExpression(
         e,
         workspace,
-        false,
+        /* rigidVars */ false,
       ).inferTypeDeclaration(e);
 
       TypeReplacement.freeze(inferenceResult.type);
@@ -99,7 +99,7 @@ export class TypeExpression {
       const inferenceResult = new TypeExpression(
         e,
         workspace,
-        false,
+        /* rigidVars */ false,
         activeAliases,
       ).inferTypeAliasDeclaration(e);
 
@@ -132,11 +132,13 @@ export class TypeExpression {
       const inferenceResult = new TypeExpression(
         e,
         workspace,
-        true,
+        /* rigidVars */ true,
       ).inferTypeExpression(e.typeExpression!);
 
       const type = TypeReplacement.replace(inferenceResult.type, new Map());
       TypeReplacement.freeze(inferenceResult.type);
+
+      workspace.getTypeCache().trackTypeAnnotation(e);
 
       return { ...inferenceResult, type };
     };
@@ -159,7 +161,7 @@ export class TypeExpression {
     const inferenceResult = new TypeExpression(
       e,
       workspace,
-      false,
+      /* rigidVars */ false,
     ).inferUnionConstructor(e);
     TypeReplacement.freeze(inferenceResult.type);
 
@@ -176,7 +178,7 @@ export class TypeExpression {
     const inferenceResult = new TypeExpression(
       e,
       workspace,
-      false,
+      /* rigidVars */ false,
     ).inferPortAnnotation(e);
     TypeReplacement.freeze(inferenceResult.type);
 
@@ -353,7 +355,7 @@ export class TypeExpression {
       TypeExpression.typeAnnotationInference(
         annotation as ETypeAnnotation,
         this.workspace,
-        true,
+        /* rigid */ true,
       )?.expressionTypes.get(definition.expr) ?? TUnknown;
 
     if (type.nodeType === "Var") {

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -397,21 +397,21 @@ function typeMismatchError(
     let s = "";
 
     if (diff.extra.size > 0) {
-      s += `\nExtra fields: ${checker.typeToString(
+      s += `\nExtra fields: \`${checker.typeToString(
         TRecord(Object.fromEntries(diff.extra.entries())),
-      )}`;
+      )}\``;
     }
     if (diff.missing.size > 0) {
-      s += `\nMissing fields: ${checker.typeToString(
+      s += `\nMissing fields: \`${checker.typeToString(
         TRecord(Object.fromEntries(diff.missing.entries())),
-      )}`;
+      )}\``;
     }
     if (diff.mismatched.size > 0) {
       s += `\nMismatched fields: `;
       diff.mismatched.forEach(([expected, found], field) => {
-        s += `\n Field ${field} expected ${checker.typeToString(
+        s += `\n Field \`${field}\` expected \`${checker.typeToString(
           expected,
-        )}, found ${checker.typeToString(found)}`;
+        )}\`, found \`${checker.typeToString(found)}\``;
       });
     }
 
@@ -2001,6 +2001,7 @@ export class InferenceScope {
           t2,
           errorExpr,
           patternBinding,
+          diff,
         ),
       );
 

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -52,6 +52,7 @@ import {
   error,
   errorWithEndNode,
 } from "./diagnostics";
+import fromEntries from "fromentries";
 
 export let inferTime = 0;
 export function resetInferTime(): void {
@@ -398,12 +399,12 @@ function typeMismatchError(
 
     if (diff.extra.size > 0) {
       s += `\nExtra fields: \`${checker.typeToString(
-        TRecord(Object.fromEntries(diff.extra.entries())),
+        TRecord(fromEntries(diff.extra.entries())),
       )}\``;
     }
     if (diff.missing.size > 0) {
       s += `\nMissing fields: \`${checker.typeToString(
-        TRecord(Object.fromEntries(diff.missing.entries())),
+        TRecord(fromEntries(diff.missing.entries())),
       )}\``;
     }
     if (diff.mismatched.size > 0) {
@@ -1913,7 +1914,7 @@ export class InferenceScope {
       fields.some((field) => !Object.keys(ty.fields).includes(field.text))
     ) {
       if (ty.nodeType !== "Unknown") {
-        const actualTyParams = Object.fromEntries(
+        const actualTyParams = fromEntries(
           fields.map((field, i) => [field.text, vars[i]] as [string, Type]),
         );
         const actualTy = TRecord(actualTyParams);

--- a/test/definitionProviderTests/typeResolveDefinition.test.ts
+++ b/test/definitionProviderTests/typeResolveDefinition.test.ts
@@ -192,4 +192,19 @@ func =
 `;
     await testBase.testDefinition(source);
   });
+
+  it(`test union constructor resolves when used in a bin op expr`, async () => {
+    const source = `
+--@ main.elm
+
+type Page = 
+    Home
+   --X
+
+func var = 
+    var == Home
+          --^
+`;
+    await testBase.testDefinition(source);
+  });
 });


### PR DESCRIPTION
- Fixes union constructor definitions in a better way than I did before (did it how intellij-elm does)
- Show record diffs in the type error. The logic was there already, just forget to pass the diff through
- Update the diagnostics test to skip libraries with node errors and skip non-writable files (Cuts the time down to ~35 minutes)
- Also fixed a caching bug with type annotations (should fix the one you saw when making changes in `elm-cell-grid`)

We are now down to ~60 failing libraries with incorrect diagnostics.