### PR TITLE
Add a "extract function" refactor code action

### DIFF
--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -16,7 +16,9 @@ export class CapabilityCalculator {
     this.clientCapabilities;
 
     return {
-      codeActionProvider: true,
+      codeActionProvider: {
+        resolveProvider: true,
+      },
       codeLensProvider: {
         resolveProvider: true,
       },

--- a/src/providers/codeAction/addTypeAnnotationCodeAction.ts
+++ b/src/providers/codeAction/addTypeAnnotationCodeAction.ts
@@ -8,7 +8,11 @@ import { PositionUtil } from "../../positionUtil";
 import { getSpaces } from "../../util/refactorEditUtils";
 import { TreeUtils } from "../../util/treeUtils";
 import { Diagnostics } from "../../util/types/diagnostics";
-import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
+import {
+  CodeActionProvider,
+  IRefactorCodeAction,
+  IRefactorEdit,
+} from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 
 const errorCodes = [Diagnostics.MissingTypeAnnotation.code];
@@ -82,8 +86,8 @@ CodeActionProvider.registerRefactorAction(refactorName, {
 
     return [];
   },
-  getEditsForAction: (params: ICodeActionParams): TextEdit[] => {
-    return getEdits(params, params.range);
+  getEditsForAction: (params: ICodeActionParams): IRefactorEdit => {
+    return { edits: getEdits(params, params.range) };
   },
 });
 

--- a/src/providers/codeAction/addTypeAnnotationCodeAction.ts
+++ b/src/providers/codeAction/addTypeAnnotationCodeAction.ts
@@ -39,7 +39,13 @@ CodeActionProvider.registerCodeAction({
       errorCodes,
       fixId,
       (edits, diagnostic) => {
-        edits.push(...getEdits(params, diagnostic.range));
+        const newEdits = getEdits(params, diagnostic.range);
+        if (
+          newEdits.length > 0 &&
+          !edits.find((edit) => edit.newText === newEdits[0].newText)
+        ) {
+          edits.push(...newEdits);
+        }
       },
     );
   },

--- a/src/providers/codeAction/addTypeAnnotationCodeAction.ts
+++ b/src/providers/codeAction/addTypeAnnotationCodeAction.ts
@@ -1,7 +1,14 @@
-import { CodeAction, Range, TextEdit } from "vscode-languageserver";
+import {
+  CodeAction,
+  CodeActionKind,
+  Range,
+  TextEdit,
+} from "vscode-languageserver";
+import { PositionUtil } from "../../positionUtil";
+import { getSpaces } from "../../util/refactorEditUtils";
 import { TreeUtils } from "../../util/treeUtils";
 import { Diagnostics } from "../../util/types/diagnostics";
-import { CodeActionProvider } from "../codeActionProvider";
+import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 
 const errorCodes = [Diagnostics.MissingTypeAnnotation.code];
@@ -38,6 +45,42 @@ CodeActionProvider.registerCodeAction({
   },
 });
 
+// Handle adding annotation to let expr declaration
+const refactorName = "add_type_annotation";
+CodeActionProvider.registerRefactorAction(refactorName, {
+  getAvailableActions: (params: ICodeActionParams): IRefactorCodeAction[] => {
+    const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+      params.sourceFile.tree.rootNode,
+      params.range.start,
+    );
+
+    if (
+      nodeAtPosition.parent?.type === "function_declaration_left" &&
+      TreeUtils.findParentOfType("let_in_expr", nodeAtPosition) &&
+      nodeAtPosition.parent.parent &&
+      !TreeUtils.getTypeAnnotation(nodeAtPosition.parent.parent)
+    ) {
+      return [
+        {
+          title: "Add inferred annotation",
+          kind: CodeActionKind.RefactorExtract,
+          data: {
+            actionName: "add_type_annotation",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        },
+      ];
+    }
+
+    return [];
+  },
+  getEditsForAction: (params: ICodeActionParams): TextEdit[] => {
+    return getEdits(params, params.range);
+  },
+});
+
 function getEdits(params: ICodeActionParams, range: Range): TextEdit[] {
   const nodeAtPosition = TreeUtils.getNamedDescendantForRange(
     params.sourceFile,
@@ -52,8 +95,16 @@ function getEdits(params: ICodeActionParams, range: Range): TextEdit[] {
       params.sourceFile,
     );
 
+    const startPosition = PositionUtil.FROM_TS_POSITION(
+      nodeAtPosition.startPosition,
+    ).toVSPosition();
     return [
-      TextEdit.insert(range.start, `${nodeAtPosition.text} : ${typeString}\n`),
+      TextEdit.insert(
+        startPosition,
+        `${nodeAtPosition.text} : ${typeString}\n${getSpaces(
+          startPosition.character,
+        )}`,
+      ),
     ];
   } else {
     return [];

--- a/src/providers/codeAction/exposeUnexposeCodeAction.ts
+++ b/src/providers/codeAction/exposeUnexposeCodeAction.ts
@@ -2,7 +2,11 @@ import { CodeActionKind } from "vscode-languageserver";
 import { TextEdit } from "vscode-languageserver-textdocument";
 import { RefactorEditUtils } from "../../util/refactorEditUtils";
 import { TreeUtils } from "../../util/treeUtils";
-import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
+import {
+  CodeActionProvider,
+  IRefactorCodeAction,
+  IRefactorEdit,
+} from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 
 const refactorName = "expose_unexpose";
@@ -89,7 +93,7 @@ CodeActionProvider.registerRefactorAction(refactorName, {
   getEditsForAction: (
     params: ICodeActionParams,
     actionName: string,
-  ): TextEdit[] => {
+  ): IRefactorEdit => {
     const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
       params.sourceFile.tree.rootNode,
       params.range.start,
@@ -104,7 +108,7 @@ CodeActionProvider.registerRefactorAction(refactorName, {
           tree,
           nodeAtPosition.text,
         );
-        return edit ? [edit] : [];
+        return edit ? { edits: [edit] } : {};
       }
       case "expose_function":
       case "expose_type": {
@@ -112,10 +116,10 @@ CodeActionProvider.registerRefactorAction(refactorName, {
           tree,
           nodeAtPosition.text,
         );
-        return edit ? [edit] : [];
+        return edit ? { edits: [edit] } : {};
       }
     }
 
-    return [];
+    return {};
   },
 });

--- a/src/providers/codeAction/exposeUnexposeCodeAction.ts
+++ b/src/providers/codeAction/exposeUnexposeCodeAction.ts
@@ -1,0 +1,121 @@
+import { CodeActionKind } from "vscode-languageserver";
+import { TextEdit } from "vscode-languageserver-textdocument";
+import { RefactorEditUtils } from "../../util/refactorEditUtils";
+import { TreeUtils } from "../../util/treeUtils";
+import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
+import { ICodeActionParams } from "../paramsExtensions";
+
+const refactorName = "expose_unexpose";
+CodeActionProvider.registerRefactorAction(refactorName, {
+  getAvailableActions: (params: ICodeActionParams): IRefactorCodeAction[] => {
+    const result: IRefactorCodeAction[] = [];
+    const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+      params.sourceFile.tree.rootNode,
+      params.range.start,
+    );
+    const tree = params.sourceFile.tree;
+
+    if (
+      (nodeAtPosition.parent?.type === "type_annotation" ||
+        nodeAtPosition.parent?.type === "function_declaration_left") &&
+      !TreeUtils.findParentOfType("let_in_expr", nodeAtPosition)
+    ) {
+      const functionName = nodeAtPosition.text;
+
+      if (TreeUtils.isExposedFunction(tree, functionName)) {
+        result.push({
+          title: "Unexpose Function",
+          kind: CodeActionKind.Refactor,
+          data: {
+            actionName: "unexpose_function",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        });
+      } else {
+        result.push({
+          title: "Expose Function",
+          kind: CodeActionKind.Refactor,
+          data: {
+            actionName: "expose_function",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        });
+      }
+    }
+
+    if (
+      nodeAtPosition.type === "upper_case_identifier" &&
+      (nodeAtPosition.parent?.type === "type_alias_declaration" ||
+        nodeAtPosition.parent?.type === "type_declaration")
+    ) {
+      const typeName = nodeAtPosition.text;
+
+      const alias =
+        nodeAtPosition.parent?.type === "type_alias_declaration"
+          ? " Alias"
+          : "";
+
+      if (TreeUtils.isExposedTypeOrTypeAlias(tree, typeName)) {
+        result.push({
+          title: `Unexpose Type${alias}`,
+          kind: CodeActionKind.Refactor,
+          data: {
+            actionName: "unexpose_type",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        });
+      } else {
+        result.push({
+          title: `Expose Type${alias}`,
+          kind: CodeActionKind.Refactor,
+          data: {
+            actionName: "expose_type",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        });
+      }
+    }
+
+    return result;
+  },
+  getEditsForAction: (
+    params: ICodeActionParams,
+    actionName: string,
+  ): TextEdit[] => {
+    const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+      params.sourceFile.tree.rootNode,
+      params.range.start,
+    );
+
+    const tree = params.sourceFile.tree;
+
+    switch (actionName) {
+      case "unexpose_function":
+      case "unexpose_type": {
+        const edit = RefactorEditUtils.unexposedValueInModule(
+          tree,
+          nodeAtPosition.text,
+        );
+        return edit ? [edit] : [];
+      }
+      case "expose_function":
+      case "expose_type": {
+        const edit = RefactorEditUtils.exposeValueInModule(
+          tree,
+          nodeAtPosition.text,
+        );
+        return edit ? [edit] : [];
+      }
+    }
+
+    return [];
+  },
+});

--- a/src/providers/codeAction/extractFunctionCodeAction.ts
+++ b/src/providers/codeAction/extractFunctionCodeAction.ts
@@ -70,7 +70,12 @@ CodeActionProvider.registerRefactorAction(refactorName, {
       hadParenthesis = true;
     }
 
-    if (node.type === "list_expr") {
+    // List, record, and tuple expr should all be treated like parenthesis groups
+    if (
+      node.type === "list_expr" ||
+      node.type === "record_expr" ||
+      node.type === "tuple_expr"
+    ) {
       hadParenthesis = true;
     }
 

--- a/src/providers/codeAction/extractFunctionCodeAction.ts
+++ b/src/providers/codeAction/extractFunctionCodeAction.ts
@@ -25,7 +25,7 @@ CodeActionProvider.registerRefactorAction(refactorName, {
     ) {
       if (TreeUtils.findParentOfType("let_in_expr", node)) {
         result.push({
-          title: "Extract function to enclosing let scope",
+          title: "Extract function to enclosing let",
           kind: CodeActionKind.RefactorExtract,
           data: {
             actionName: "extract_let",

--- a/src/providers/codeAction/extractFunctionCodeAction.ts
+++ b/src/providers/codeAction/extractFunctionCodeAction.ts
@@ -1,0 +1,199 @@
+import { CodeActionKind, Position, TextEdit } from "vscode-languageserver";
+import { SyntaxNode } from "web-tree-sitter";
+import { RefactorEditUtils } from "../../util/refactorEditUtils";
+import { TreeUtils } from "../../util/treeUtils";
+import { TFunction } from "../../util/types/typeInference";
+import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
+import { ICodeActionParams } from "../paramsExtensions";
+
+const refactorName = "extract_function";
+CodeActionProvider.registerRefactorAction(refactorName, {
+  getAvailableActions: (params: ICodeActionParams): IRefactorCodeAction[] => {
+    const result: IRefactorCodeAction[] = [];
+
+    const node = TreeUtils.getNamedDescendantForRange(
+      params.sourceFile,
+      params.range,
+    );
+
+    if (
+      node.type.includes("expr") &&
+      node.startPosition.column === params.range.start.character &&
+      node.startPosition.row === params.range.start.line &&
+      node.endPosition.column === params.range.end.character &&
+      node.endPosition.row === params.range.end.line
+    ) {
+      if (TreeUtils.findParentOfType("let_in_expr", node)) {
+        result.push({
+          title: "Extract function to enclosing let scope",
+          kind: CodeActionKind.RefactorExtract,
+          data: {
+            actionName: "extract_let",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        });
+      }
+
+      result.push({
+        title: "Extract function to top level",
+        kind: CodeActionKind.RefactorExtract,
+        data: {
+          actionName: "extract_top_level",
+          refactorName,
+          uri: params.sourceFile.uri,
+          range: params.range,
+        },
+      });
+    }
+
+    return result;
+  },
+  getEditsForAction: (
+    params: ICodeActionParams,
+    actionName: string,
+  ): TextEdit[] | undefined => {
+    const edits: TextEdit[] = [];
+    let node = TreeUtils.getNamedDescendantForRange(
+      params.sourceFile,
+      params.range,
+    );
+
+    let hadParenthesis = false;
+    if (node.type === "parenthesized_expr") {
+      node = node.childForFieldName("expression") ?? node;
+      hadParenthesis = true;
+    }
+
+    const checker = params.program.getTypeChecker();
+    const rootNode = params.sourceFile.tree.rootNode;
+
+    let insertPosition: Position = {
+      line: rootNode.endPosition.row,
+      character: 0,
+    };
+    let targetScope: SyntaxNode;
+    let addTypeAnnotation = true;
+
+    switch (actionName) {
+      case "extract_let":
+        {
+          const letInExpr = TreeUtils.findParentOfType("let_in_expr", node);
+
+          if (letInExpr) {
+            const valueDeclarations =
+              TreeUtils.findAllNamedChildrenOfType(
+                "value_declaration",
+                letInExpr,
+              ) ?? [];
+            insertPosition = {
+              line:
+                valueDeclarations[valueDeclarations.length - 1].endPosition
+                  .row + 1,
+              character: letInExpr.startPosition.column + 4,
+            };
+
+            targetScope = letInExpr;
+            addTypeAnnotation = false;
+          }
+        }
+        break;
+
+      case "extract_top_level":
+        {
+          insertPosition = {
+            line:
+              RefactorEditUtils.findLineNumberAfterCurrentFunction(node) ??
+              rootNode.endPosition.row,
+            character: 0,
+          };
+
+          targetScope = rootNode;
+        }
+        break;
+    }
+
+    const args: SyntaxNode[] = [];
+
+    // Get the list of references that won't be visible
+    node
+      .descendantsOfType(["value_expr", "record_base_identifier"])
+      .forEach((val) => {
+        if (args.find((arg) => arg.text === val.text)) {
+          return;
+        }
+
+        // Qualified reference will be visible
+        if (val.text.includes(".")) {
+          return;
+        }
+
+        const ref = checker.findDefinition(
+          val.firstNamedChild?.firstNamedChild ?? val.firstNamedChild ?? val,
+          params.sourceFile,
+        );
+
+        // Reference in other file will be visible
+        if (ref?.uri !== params.sourceFile.uri) {
+          return;
+        }
+
+        // Reference inside self will be visible
+        if (
+          node.startIndex <= ref.node.startIndex &&
+          node.endIndex >= ref.node.endIndex
+        ) {
+          return;
+        }
+
+        let scope: SyntaxNode | null = targetScope;
+
+        // Check the target scope and parent scopes for the reference
+        while (scope) {
+          if (params.sourceFile.symbolLinks?.get(scope)?.get(val.text)) {
+            return;
+          }
+          scope = scope.parent;
+        }
+
+        args.push(val);
+      });
+
+    let typeAnnotation: string | undefined;
+    if (addTypeAnnotation) {
+      let type = checker.findType(node);
+
+      if (args.length > 0) {
+        type = TFunction(args.map(checker.findType), type);
+      }
+
+      typeAnnotation = checker.typeToString(type, params.sourceFile);
+    }
+
+    edits.push(
+      RefactorEditUtils.createFunction(
+        insertPosition.line,
+        "newFunction",
+        typeAnnotation,
+        args.map((arg) => arg.text),
+        node.text,
+        node.startPosition.column,
+        insertPosition.character,
+      ),
+    );
+
+    let textToInsert =
+      args.length > 0
+        ? `newFunction ${args.map((arg) => arg.text).join(" ")}`
+        : `newFunction`;
+
+    if (hadParenthesis && args.length > 0) {
+      textToInsert = `(${textToInsert})`;
+    }
+
+    edits.push(TextEdit.replace(params.range, textToInsert));
+
+    return edits;
+  },
+});

--- a/src/providers/codeAction/importCodeAction.ts
+++ b/src/providers/codeAction/importCodeAction.ts
@@ -6,6 +6,7 @@ import { ImportUtils, IPossibleImport } from "../../util/importUtils";
 import { RefactorEditUtils } from "../../util/refactorEditUtils";
 import { TreeUtils } from "../../util/treeUtils";
 import { Diagnostics } from "../../util/types/diagnostics";
+import { findDefinition } from "../../util/types/expressionTree";
 import { CodeActionProvider } from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 
@@ -58,7 +59,7 @@ CodeActionProvider.registerCodeAction({
             firstPossibleImport,
           );
 
-          if (edit) {
+          if (edit && !edits.find((e) => e.newText === edit.newText)) {
             edits.push(edit);
           }
         }

--- a/src/providers/codeAction/index.ts
+++ b/src/providers/codeAction/index.ts
@@ -1,3 +1,4 @@
 import "./importCodeAction";
 import "./makeDeclarationFromUsageCodeAction";
 import "./addTypeAnnotationCodeAction";
+import "./extractFunctionCodeAction";

--- a/src/providers/codeAction/index.ts
+++ b/src/providers/codeAction/index.ts
@@ -2,3 +2,5 @@ import "./importCodeAction";
 import "./makeDeclarationFromUsageCodeAction";
 import "./addTypeAnnotationCodeAction";
 import "./extractFunctionCodeAction";
+import "./exposeUnexposeCodeAction";
+import "./moveFunctionCodeAction";

--- a/src/providers/codeAction/makeDeclarationFromUsageCodeAction.ts
+++ b/src/providers/codeAction/makeDeclarationFromUsageCodeAction.ts
@@ -3,6 +3,7 @@ import { TextEdit } from "vscode-languageserver-textdocument";
 import { RefactorEditUtils } from "../../util/refactorEditUtils";
 import { TreeUtils } from "../../util/treeUtils";
 import { Diagnostics } from "../../util/types/diagnostics";
+import { TFunction } from "../../util/types/typeInference";
 import { CodeActionProvider } from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 
@@ -61,16 +62,15 @@ function getEdits(params: ICodeActionParams, range: Range): TextEdit[] {
       nodeAtPosition,
     );
 
-    const typeString: string = checker.typeToString(
-      checker.findType(nodeAtPosition),
-      params.sourceFile,
-    );
+    const type = checker.findType(nodeAtPosition);
+    const typeString: string = checker.typeToString(type, params.sourceFile);
 
     const edit = RefactorEditUtils.createTopLevelFunction(
       insertLineNumber ?? tree.rootNode.endPosition.row,
       funcName,
       typeString,
-      TreeUtils.findParentOfType("function_call_expr", nodeAtPosition),
+      type.nodeType === "Function" ? type.params.length : 0,
+      `Debug.todo "TODO"`,
     );
 
     if (edit) {

--- a/src/providers/codeAction/moveFunctionCodeAction.ts
+++ b/src/providers/codeAction/moveFunctionCodeAction.ts
@@ -1,0 +1,58 @@
+import { container } from "tsyringe";
+import { CodeActionKind, TextEdit } from "vscode-languageserver";
+import { Settings } from "../../util/settings";
+import { TreeUtils } from "../../util/treeUtils";
+import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
+import { ICodeActionParams } from "../paramsExtensions";
+
+const refactorName = "move_function";
+CodeActionProvider.registerRefactorAction(refactorName, {
+  getAvailableActions: (params: ICodeActionParams): IRefactorCodeAction[] => {
+    if (
+      !container.resolve<Settings>("Settings").extendedCapabilities
+        ?.moveFunctionRefactoringSupport
+    ) {
+      return [];
+    }
+
+    const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
+      params.sourceFile.tree.rootNode,
+      params.range.start,
+    );
+
+    if (
+      (nodeAtPosition.parent?.type === "type_annotation" ||
+        nodeAtPosition.parent?.type === "function_declaration_left") &&
+      !TreeUtils.findParentOfType("let_in_expr", nodeAtPosition)
+    ) {
+      const functionName = nodeAtPosition.text;
+
+      return [
+        {
+          title: "Move Function",
+          command: {
+            title: "Refactor",
+            command: "elm.refactor",
+            arguments: [
+              "moveFunction",
+              { textDocument: params.textDocument, range: params.range },
+              functionName,
+            ],
+          },
+          kind: CodeActionKind.RefactorRewrite,
+          data: {
+            actionName: "move_function",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        },
+      ];
+    }
+
+    return [];
+  },
+  getEditsForAction: (): TextEdit[] => {
+    return [];
+  },
+});

--- a/src/providers/codeAction/moveFunctionCodeAction.ts
+++ b/src/providers/codeAction/moveFunctionCodeAction.ts
@@ -2,7 +2,11 @@ import { container } from "tsyringe";
 import { CodeActionKind, TextEdit } from "vscode-languageserver";
 import { Settings } from "../../util/settings";
 import { TreeUtils } from "../../util/treeUtils";
-import { CodeActionProvider, IRefactorCodeAction } from "../codeActionProvider";
+import {
+  CodeActionProvider,
+  IRefactorCodeAction,
+  IRefactorEdit,
+} from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 
 const refactorName = "move_function";
@@ -52,7 +56,7 @@ CodeActionProvider.registerRefactorAction(refactorName, {
 
     return [];
   },
-  getEditsForAction: (): TextEdit[] => {
-    return [];
+  getEditsForAction: (): IRefactorEdit => {
+    return {};
   },
 });

--- a/src/util/elmWorkspaceMatcher.ts
+++ b/src/util/elmWorkspaceMatcher.ts
@@ -42,6 +42,25 @@ export class ElmWorkspaceMatcher<ParamType> {
     };
   }
 
+  public handleResolve<ResultType>(
+    handler: (
+      param: ParamType,
+      program: IElmWorkspace,
+      sourceFile: ITreeContainer,
+      token?: CancellationToken,
+    ) => ResultType,
+  ): (param: ParamType, token?: CancellationToken) => ResultType {
+    return (param: ParamType, token?: CancellationToken): ResultType => {
+      const program = this.getProgramFor(param);
+      return handler(
+        param,
+        program,
+        this.getSourceFileFor(param, program),
+        token,
+      );
+    };
+  }
+
   /**
    * @deprecated Use handle() instead, which returns a params with the program and source file in it
    */

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -369,7 +369,7 @@ export class RefactorEditUtils {
   }
 }
 
-function getSpaces(n: number): string {
+export function getSpaces(n: number): string {
   return Array(n + 1)
     .map(() => "")
     .join(" ");

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -34,25 +34,66 @@ export class RefactorEditUtils {
     insertLineNumber: number,
     valueName: string,
     typeString: string | undefined,
-    valueExpression: SyntaxNode | undefined,
-  ): TextEdit | undefined {
-    const arity = valueExpression ? valueExpression.namedChildCount - 1 : 0;
-    const hasArity0 = arity == 0;
-    const argList: string = this.argListFromArity(arity);
+    args: number | string[],
+    content: string,
+  ): TextEdit {
+    return this.createFunction(
+      insertLineNumber,
+      valueName,
+      typeString,
+      args,
+      content,
+    );
+  }
+
+  public static createFunction(
+    insertLineNumber: number,
+    valueName: string,
+    typeString: string | undefined,
+    args: number | string[],
+    content: string,
+    contentIndendation = 0,
+    targetIndendation = 0,
+  ): TextEdit {
+    const hasArity0 = args === 0 || (Array.isArray(args) && args.length === 0);
+    const argList: string =
+      typeof args === "number" ? this.argListFromArity(args) : args.join(" ");
+
+    const bodyTargetIndendation = targetIndendation + 4;
+    const spaces = getSpaces(targetIndendation);
+    const bodySpaces = getSpaces(bodyTargetIndendation);
+
+    const diffIndentation = bodyTargetIndendation - contentIndendation;
+
+    if (diffIndentation > 0) {
+      const diffSpaces = getSpaces(diffIndentation);
+      content = content.split("\n").join(`\n${diffSpaces}`);
+    } else if (diffIndentation < 0) {
+      content = content
+        .split("\n")
+        .map((line) => {
+          let i = 0;
+          while (i < Math.abs(diffIndentation) && line[i] === " ") {
+            i++;
+          }
+          return line.slice(i);
+        })
+        .join("\n");
+    }
 
     if (hasArity0) {
       return TextEdit.insert(
         Position.create(insertLineNumber, 0),
         `\n\n${
-          typeString ? valueName + " : " + typeString + "\n" : ""
-        }${valueName} =\n    Debug.todo "TODO"\n`,
+          typeString ? `${spaces}${valueName}` + " : " + typeString + "\n" : ""
+        }${spaces}${valueName} =\n${bodySpaces}${content}\n`,
       );
     } else {
       return TextEdit.insert(
         Position.create(insertLineNumber, 0),
         `\n\n${
-          typeString ? valueName + " : " + typeString + "\n" : ""
-        }${valueName} ${argList} =\n    Debug.todo "TODO"\n`,
+          typeString ? `${spaces}${valueName}` + " : " + typeString + "\n" : ""
+        }${spaces}${valueName} ${argList} =\n${bodySpaces}${content}\n`,
       );
     }
   }
@@ -326,4 +367,10 @@ export class RefactorEditUtils {
       );
     }
   }
+}
+
+function getSpaces(n: number): string {
+  return Array(n + 1)
+    .map(() => "")
+    .join(" ");
 }


### PR DESCRIPTION
Did decent testing and have yet to find a case where it breaks. I also converted the other refactor actions to use the new system. 

Also added checks to prevent duplicates when using "Fix all" for type annotations or imports. 