### PR TITLE
Use package.elm-lang.org to resolve dependency versions

### DIFF
--- a/src/elmPackageCache.ts
+++ b/src/elmPackageCache.ts
@@ -1,0 +1,113 @@
+import { readdir } from "fs";
+import * as utils from "./util/elmUtils";
+import { ElmJson } from "./elmWorkspace";
+import { promisify } from "util";
+import { IConstraint, IVersion } from "./util/elmUtils";
+
+const readDir = promisify(readdir);
+
+export interface IPackage {
+  dependencies: Map<string, IConstraint>;
+  version: IVersion;
+}
+
+export interface IElmPackageCache {
+  getVersions(packageName: string): Promise<IVersion[]>;
+  getDependencies(
+    packageName: string,
+    version: IVersion,
+  ): Promise<Map<string, IConstraint>>;
+}
+
+export class ElmPackageCache implements IElmPackageCache {
+  private versionsCache = new Map<string, IVersion[]>();
+  private dependenciesCache = new Map<string, Map<string, IConstraint>>();
+
+  constructor(
+    private packagesRoot: string,
+    private loadElmJson: (elmJsonPath: string) => Promise<ElmJson>,
+  ) {}
+
+  public async getVersions(packageName: string): Promise<IVersion[]> {
+    const cached = this.versionsCache.get(packageName);
+
+    if (cached) {
+      return cached;
+    }
+
+    const versions = await this.getVersionsFromFileSystem(packageName);
+
+    this.versionsCache.set(packageName, versions);
+
+    return versions;
+  }
+
+  public async getDependencies(
+    packageName: string,
+    version: IVersion,
+  ): Promise<Map<string, IConstraint>> {
+    const cacheKey = `${packageName}@${version.string}`;
+    const cached = this.dependenciesCache.get(cacheKey);
+
+    if (cached) {
+      return cached;
+    }
+
+    const dependencies = await this.getDependenciesFromFileSystem(
+      packageName,
+      version,
+    );
+
+    this.dependenciesCache.set(cacheKey, dependencies);
+
+    return dependencies;
+  }
+
+  private async getVersionsFromFileSystem(
+    packageName: string,
+  ): Promise<IVersion[]> {
+    const maintainer = packageName.substring(0, packageName.indexOf("/"));
+    const name = packageName.substring(
+      packageName.indexOf("/") + 1,
+      packageName.length,
+    );
+
+    const pathToPackage = `${this.packagesRoot}${maintainer}/${name}/`;
+    const folders = await readDir(pathToPackage, "utf8");
+
+    const allVersions: IVersion[] = [];
+
+    for (const folderName of folders) {
+      const version = utils.parseVersion(folderName);
+
+      if (
+        Number.isInteger(version.major) &&
+        Number.isInteger(version.minor) &&
+        Number.isInteger(version.patch)
+      ) {
+        allVersions.push(version);
+      }
+    }
+
+    return allVersions;
+  }
+
+  private async getDependenciesFromFileSystem(
+    packageName: string,
+    version: IVersion,
+  ): Promise<Map<string, IConstraint>> {
+    const elmJsonPath = `${this.packagesRoot}${packageName}/${version.string}/elm.json`;
+    const elmJson = await this.loadElmJson(elmJsonPath);
+
+    return this.parseDependencies(elmJson);
+  }
+
+  private parseDependencies(elmJson: ElmJson): Map<string, IConstraint> {
+    return new Map<string, IConstraint>(
+      Object.entries(elmJson.dependencies).map(([name, constraint]) => [
+        name,
+        utils.parseConstraint(constraint),
+      ]),
+    );
+  }
+}

--- a/test/constraint.test.ts
+++ b/test/constraint.test.ts
@@ -1,11 +1,10 @@
-import { assert } from "console";
-import { IConstraint, IVersion } from "../src/elmWorkspace";
 import {
   constraintIntersect,
-  parseContraint,
+  IConstraint,
+  IVersion,
+  parseConstraint,
   versionSatifiesConstraint,
 } from "../src/util/elmUtils";
-import { Utils } from "../src/util/utils";
 
 describe("constraint test", () => {
   function v(
@@ -24,7 +23,7 @@ describe("constraint test", () => {
     };
   }
 
-  const c = parseContraint;
+  const c = parseConstraint;
 
   it("can determine whether a version satifies a half-open constraint", () => {
     const c: IConstraint = {

--- a/test/utils/sourceTreeParser.ts
+++ b/test/utils/sourceTreeParser.ts
@@ -53,7 +53,6 @@ export class SourceTreeParser {
     const program = new ElmWorkspace(URI.file(baseUri), {
       readFile: (uri: string): Promise<string> =>
         Promise.resolve(readFile(uri)),
-      readFileSync: readFile,
       readDirectory: (uri: string): Promise<string[]> => {
         return Promise.resolve(
           path.normalizeUri(uri) ===


### PR DESCRIPTION
First, try using package.elm-lang.org to solve dependency versions. This way, we can solve the dependencies without throwing an error if missing. It will show a notification error for any missing packages, but everything else will continue to work. Also run `elm make` on initialize, so theoretically it would never have missing packages. If we can't solve the packages (meaning they hand edited dependency versions in elm.json), the server will not start, but neither will the compiler. I think this is fine coupled with #402, because once they fix elm.json, we will try to reload. Closes #344.