### PR TITLE
Adopt file events APIs

### DIFF
--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -40,6 +40,38 @@ export class CapabilityCalculator {
       selectionRangeProvider: true,
       textDocumentSync: TextDocumentSyncKind.Incremental,
       workspaceSymbolProvider: true,
+      workspace: {
+        fileOperations: {
+          willCreate: {
+            filters: [
+              {
+                scheme: "file",
+                pattern: { glob: "**/*.elm", matches: "file" },
+              },
+            ],
+          },
+          willRename: {
+            filters: [
+              {
+                scheme: "file",
+                pattern: { glob: "**/*.elm", matches: "file" },
+              },
+              {
+                scheme: "file",
+                pattern: { glob: "**/", matches: "folder" },
+              },
+            ],
+          },
+          willDelete: {
+            filters: [
+              {
+                scheme: "file",
+                pattern: { glob: "**/*.elm", matches: "file" },
+              },
+            ],
+          },
+        },
+      },
     };
   }
 }

--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -184,7 +184,7 @@ export class ElmWorkspace implements IElmWorkspace {
     return [
       ...this.rootProject.sourceDirectories,
       ...this.rootProject.testDirectories,
-    ].find((elmFolder) => uri.includes(elmFolder));
+    ].find((elmFolder) => uri.startsWith(elmFolder));
   }
 
   public getSourceFile(uri: string): ITreeContainer | undefined {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -42,26 +42,6 @@ export const UnexposeRequest = new RequestType<
   void
 >("elm/unexpose");
 
-export interface IOnDidCreateFilesParams {
-  readonly files: ReadonlyArray<URI>;
-}
-
-export interface IOnDidRenameFilesParams {
-  readonly files: ReadonlyArray<{ oldUri: URI; newUri: URI }>;
-}
-
-export const OnDidCreateFilesRequest = new RequestType<
-  IOnDidCreateFilesParams,
-  void,
-  void
->("elm/ondidCreateFiles");
-
-export const OnDidRenameFilesRequest = new RequestType<
-  IOnDidRenameFilesParams,
-  void,
-  void
->("elm/ondidRenameFiles");
-
 export interface IGetDiagnosticsParams {
   files: string[];
   delay: number;

--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -19,6 +19,7 @@ import {
   IDidChangeTextDocumentParams,
   IDidOpenTextDocumentParams,
 } from "./paramsExtensions";
+import { Utils } from "../util/utils";
 
 export class ASTProvider {
   private connection: Connection;
@@ -154,7 +155,10 @@ export class ASTProvider {
     change: { text: string; range: Range },
     text: string,
   ): Edit {
-    const [startIndex, endIndex] = this.getIndexesFromRange(change.range, text);
+    const [startIndex, endIndex] = Utils.getIndicesFromRange(
+      change.range,
+      text,
+    );
 
     return {
       startIndex,
@@ -175,26 +179,6 @@ export class ASTProvider {
       line: lines.length - 1,
       character: lines[lines.length - 1].length,
     };
-  }
-
-  private getIndexesFromRange(range: Range, text: string): [number, number] {
-    let startIndex = range.start.character;
-    let endIndex = range.end.character;
-
-    const regex = new RegExp(/\r\n|\r|\n/);
-    const eolResult = regex.exec(text);
-
-    const lines = text.split(regex);
-    const eol = eolResult && eolResult.length > 0 ? eolResult[0] : "";
-
-    for (let i = 0; i < range.end.line; i++) {
-      if (i < range.start.line) {
-        startIndex += lines[i].length + eol.length;
-      }
-      endIndex += lines[i].length + eol.length;
-    }
-
-    return [startIndex, endIndex];
   }
 
   private addPositions(pos1: Position, pos2: Position): Position {

--- a/src/providers/handlers/fileEventsHandler.ts
+++ b/src/providers/handlers/fileEventsHandler.ts
@@ -158,7 +158,9 @@ export class FileEventsHandler {
     file: string,
     elmWorkspace: IElmWorkspace,
   ): string | undefined {
-    const sourceDir = elmWorkspace.getSourceDirectoryOfFile(file);
+    const sourceDir = elmWorkspace.getSourceDirectoryOfFile(
+      URI.parse(file).fsPath,
+    );
 
     // The file is not in a source dir (shouldn't happen)
     if (!sourceDir) {

--- a/src/providers/handlers/fileEventsHandler.ts
+++ b/src/providers/handlers/fileEventsHandler.ts
@@ -155,11 +155,11 @@ export class FileEventsHandler {
   }
 
   private getModuleNameFromFile(
-    file: string,
+    uri: string,
     elmWorkspace: IElmWorkspace,
   ): string | undefined {
     const sourceDir = elmWorkspace.getSourceDirectoryOfFile(
-      URI.parse(file).fsPath,
+      URI.parse(uri).fsPath,
     );
 
     // The file is not in a source dir (shouldn't happen)
@@ -167,7 +167,7 @@ export class FileEventsHandler {
       return;
     }
 
-    return getModuleName(file, URI.file(sourceDir).toString());
+    return getModuleName(uri, URI.file(sourceDir).toString());
   }
 
   private mergeWorkspaceEdit(

--- a/src/providers/paramsExtensions.ts
+++ b/src/providers/paramsExtensions.ts
@@ -7,6 +7,9 @@ import {
   DidOpenTextDocumentParams,
   DocumentFormattingParams,
   DocumentSymbolParams,
+  FileCreate,
+  FileDelete,
+  FileRename,
   FoldingRangeParams,
   PrepareRenameParams,
   ReferenceParams,
@@ -31,3 +34,6 @@ export type IDocumentFormattingParams = DocumentFormattingParams & IParams;
 export type IDidChangeTextDocumentParams = DidChangeTextDocumentParams &
   IParams;
 export type IDidOpenTextDocumentParams = DidOpenTextDocumentParams & IParams;
+export type ICreateFileParams = FileCreate & IParams;
+export type IRenameFileParams = FileRename & IParams;
+export type IDeleteFileParams = FileDelete & IParams;

--- a/src/providers/renameProvider.ts
+++ b/src/providers/renameProvider.ts
@@ -134,7 +134,7 @@ export class RenameProvider {
     const edits: { [uri: string]: TextEdit[] } = {};
     let originalName = affectedNodes?.originalNode.text ?? "";
 
-    // Adjust the case of Module.App.func
+    // Helps us to rename fully qualified functions without changing the last part
     if (
       affectedNodes?.originalNode.type === "upper_case_identifier" &&
       (affectedNodes.originalNode.parent?.type === "value_qid" ||

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import {
   WorkspaceSymbolProvider,
 } from "./providers";
 import { ElmLsDiagnostics } from "./providers/diagnostics/elmLsDiagnostics";
+import { FileEventsHandler } from "./providers/handlers/fileEventsHandler";
 import { Settings } from "./util/settings";
 
 export interface ILanguageServer {
@@ -163,6 +164,7 @@ export class Server implements ILanguageServer {
     new CodeLensProvider();
     new SelectionRangeProvider();
     new RenameProvider();
+    new FileEventsHandler();
   }
 
   private getElmJsonFolder(uri: string): URI {

--- a/src/util/elmUtils.ts
+++ b/src/util/elmUtils.ts
@@ -1,5 +1,5 @@
 import execa, { ExecaReturnValue } from "execa";
-import * as path from "path";
+import * as path from "./path";
 import { Connection, CompletionItemKind } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { IElmPackageCache } from "../elmPackageCache";
@@ -380,4 +380,12 @@ export function constraintIntersect(
     lowerOperator: newLowerOp,
     upperOperator: newUpperOp,
   };
+}
+
+export function getModuleName(file: string, sourceDir: string): string {
+  return path
+    .relative(sourceDir, file)
+    .replace(".elm", "")
+    .split("/")
+    .join(".");
 }

--- a/src/util/elmUtils.ts
+++ b/src/util/elmUtils.ts
@@ -382,10 +382,6 @@ export function constraintIntersect(
   };
 }
 
-export function getModuleName(file: string, sourceDir: string): string {
-  return path
-    .relative(sourceDir, file)
-    .replace(".elm", "")
-    .split("/")
-    .join(".");
+export function getModuleName(uri: string, sourceDir: string): string {
+  return path.relative(sourceDir, uri).replace(".elm", "").split("/").join(".");
 }

--- a/src/util/elmWorkspaceMatcher.ts
+++ b/src/util/elmWorkspaceMatcher.ts
@@ -82,7 +82,7 @@ export class ElmWorkspaceMatcher<ParamType> {
       // first look for a workspace where the file has been parsed to a tree
       this.elmWorkspaces.find((ws) => ws.hasDocument(uri)) ||
       // fallback: find a workspace where the file is in the source-directories
-      this.elmWorkspaces.find((ws) => ws.hasPath(uri));
+      this.elmWorkspaces.find((ws) => ws.isInSourceDirectory(uri.fsPath));
 
     if (!workspace) {
       throw new NoWorkspaceContainsError(this.getUriFor(param));

--- a/src/util/renameUtils.ts
+++ b/src/util/renameUtils.ts
@@ -6,7 +6,7 @@ import { TreeUtils } from "./treeUtils";
 
 export class RenameUtils {
   static getRenameAffectedNodes(
-    elmWorkspace: IElmWorkspace,
+    program: IElmWorkspace,
     uri: string,
     position: Position,
   ):
@@ -18,27 +18,23 @@ export class RenameUtils {
         }[];
       }
     | undefined {
-    const forest = elmWorkspace.getForest();
-    const checker = elmWorkspace.getTypeChecker();
-    const treeContainer = forest.getByUri(uri);
+    const checker = program.getTypeChecker();
+    const sourceFile = program.getSourceFile(uri);
 
-    if (treeContainer) {
+    if (sourceFile) {
       const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
-        treeContainer.tree.rootNode,
+        sourceFile.tree.rootNode,
         position,
       );
 
-      const definitionNode = checker.findDefinition(
-        nodeAtPosition,
-        treeContainer,
-      );
+      const definitionNode = checker.findDefinition(nodeAtPosition, sourceFile);
 
       if (definitionNode) {
-        const refTree = forest.getByUri(definitionNode.uri);
+        const refTree = program.getSourceFile(definitionNode.uri);
         if (refTree && refTree.writeable) {
           return {
             originalNode: nodeAtPosition,
-            references: References.find(definitionNode, elmWorkspace),
+            references: References.find(definitionNode, program),
           };
         }
         if (refTree && !refTree.writeable) {

--- a/src/util/types/typeChecker.ts
+++ b/src/util/types/typeChecker.ts
@@ -29,7 +29,6 @@ import { Utils } from "../utils";
 import { TypeExpression } from "./typeExpression";
 import { ICancellationToken } from "../../cancellation";
 import { Diagnostic, Diagnostics, error } from "./diagnostics";
-import { node } from "execa";
 
 export let bindTime = 0;
 export function resetBindTime(): void {

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -50,4 +50,27 @@ export class Utils {
     }
     return true;
   }
+
+  public static getIndicesFromRange(
+    range: Range,
+    text: string,
+  ): [number, number] {
+    let startIndex = range.start.character;
+    let endIndex = range.end.character;
+
+    const regex = new RegExp(/\r\n|\r|\n/);
+    const eolResult = regex.exec(text);
+
+    const lines = text.split(regex);
+    const eol = eolResult && eolResult.length > 0 ? eolResult[0] : "";
+
+    for (let i = 0; i < range.end.line; i++) {
+      if (i < range.start.line) {
+        startIndex += lines[i].length + eol.length;
+      }
+      endIndex += lines[i].length + eol.length;
+    }
+
+    return [startIndex, endIndex];
+  }
 }

--- a/test/definitionProviderTests/moduleResolveDefinition.test.ts
+++ b/test/definitionProviderTests/moduleResolveDefinition.test.ts
@@ -133,7 +133,7 @@ import Module
 import Module.Model
       
 func = Module.Model.func
-      --^Module.elm
+      --^Module/Model.elm
 `;
     await testBase.testDefinition(source2);
   });

--- a/test/definitionProviderTests/moduleResolveDefinition.test.ts
+++ b/test/definitionProviderTests/moduleResolveDefinition.test.ts
@@ -113,6 +113,7 @@ func = Module.Model.func
     const source2 = `
 --@ Module/Model.elm
 module Module.Model exposing (..)
+--X
 
 type alias Model = {
   var: String
@@ -120,7 +121,6 @@ type alias Model = {
 
 --@ Module.elm
 module Module exposing (..)
---X
 
 type alias Model = {
   var: String

--- a/test/fileEventsHandler.test.ts
+++ b/test/fileEventsHandler.test.ts
@@ -1,0 +1,285 @@
+import { mockDeep } from "jest-mock-extended";
+import path from "path";
+import { container } from "tsyringe";
+import {
+  CancellationTokenSource,
+  Connection,
+  CreateFilesParams,
+  DeleteFilesParams,
+  HandlerResult,
+  RenameFilesParams,
+  RequestHandler,
+  WorkspaceEdit,
+} from "vscode-languageserver";
+import { TextEdit } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
+import { IElmWorkspace } from "../src/elmWorkspace";
+import { FileEventsHandler } from "../src/providers/handlers/fileEventsHandler";
+import { getSourceFiles } from "./utils/sourceParser";
+import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+
+describe("test fileEventsHandler", () => {
+  const treeParser = new SourceTreeParser();
+
+  let createFilesHandler: RequestHandler<
+    CreateFilesParams,
+    WorkspaceEdit | null,
+    never
+  >;
+  let renameFilesHandler: RequestHandler<
+    RenameFilesParams,
+    WorkspaceEdit | null,
+    never
+  >;
+  let deleteFilesHandler: RequestHandler<
+    DeleteFilesParams,
+    WorkspaceEdit | null,
+    never
+  >;
+
+  container.register("Connection", {
+    useValue: mockDeep<Connection>({
+      workspace: {
+        onWillCreateFiles: (handler) => (createFilesHandler = handler),
+        onWillRenameFiles: (handler) => (renameFilesHandler = handler),
+        onWillDeleteFiles: (handler) => (deleteFilesHandler = handler),
+      },
+    }),
+  });
+
+  new FileEventsHandler();
+
+  const token = new CancellationTokenSource().token;
+
+  async function createProgram(source: string): Promise<IElmWorkspace> {
+    await treeParser.init();
+
+    const program = await treeParser.getProgram(getSourceFiles(source));
+    const workspaces = container.resolve<IElmWorkspace[]>("ElmWorkspaces");
+    workspaces.splice(0, workspaces.length);
+    workspaces.push(program);
+
+    return program;
+  }
+
+  async function getEditFromResult(
+    result: HandlerResult<WorkspaceEdit | null, never>,
+  ): Promise<WorkspaceEdit> {
+    return new Promise((resolve, reject) => {
+      if (!result) {
+        reject();
+        return;
+      }
+
+      if ("then" in result) {
+        (<any>result).then((edit: unknown) => {
+          if (WorkspaceEdit.is(edit)) {
+            resolve(edit);
+          } else {
+            reject();
+          }
+        });
+      } else if (WorkspaceEdit.is(result)) {
+        resolve(result);
+      } else {
+        reject();
+      }
+    });
+  }
+
+  function uri(uri: string, base = baseUri): string {
+    return URI.file(path.join(base, uri)).toString();
+  }
+
+  it("handles file create event", async () => {
+    await createProgram("");
+    const newPath = uri("New/Module.elm");
+    const result = createFilesHandler({ files: [{ uri: newPath }] }, token);
+
+    const edit = await getEditFromResult(result);
+
+    if (!edit.changes) {
+      fail();
+    }
+
+    expect(edit.changes[newPath][0]).toEqual<TextEdit>({
+      newText: "module New.Module exposing (..)",
+      range: {
+        start: {
+          line: 0,
+          character: 0,
+        },
+        end: {
+          line: 0,
+          character: 0,
+        },
+      },
+    });
+  });
+
+  it("handles multiple files create event", async () => {
+    await createProgram("");
+    const newPath = uri("New/Module.elm");
+    const newPath2 = uri("New/Another/Module.elm");
+    const result = createFilesHandler(
+      { files: [{ uri: newPath }, { uri: newPath2 }] },
+      token,
+    );
+
+    const edit = await getEditFromResult(result);
+
+    if (!edit.changes) {
+      fail();
+    }
+
+    expect(edit.changes[newPath][0]).toEqual<TextEdit>({
+      newText: "module New.Module exposing (..)",
+      range: {
+        start: {
+          line: 0,
+          character: 0,
+        },
+        end: {
+          line: 0,
+          character: 0,
+        },
+      },
+    });
+
+    expect(edit.changes[newPath2][0]).toEqual<TextEdit>({
+      newText: "module New.Another.Module exposing (..)",
+      range: {
+        start: {
+          line: 0,
+          character: 0,
+        },
+        end: {
+          line: 0,
+          character: 0,
+        },
+      },
+    });
+  });
+
+  it("handles file rename event", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func = ""
+		`;
+    const program = await createProgram(source);
+    const oldPath = uri("Test.elm");
+    const newPath = uri("Moved/Module.elm");
+    const result = renameFilesHandler(
+      { files: [{ oldUri: oldPath, newUri: newPath }] },
+      token,
+    );
+
+    const edit = await getEditFromResult(result);
+
+    if (!edit.changes) {
+      fail();
+    }
+
+    expect(edit.changes[oldPath][0]).toEqual<TextEdit>({
+      newText: "Moved.Module",
+      range: {
+        start: {
+          line: 0,
+          character: 7,
+        },
+        end: {
+          line: 0,
+          character: 11,
+        },
+      },
+    });
+
+    expect(program.getSourceFile(newPath)).not.toBeUndefined();
+  });
+
+  it("handles folder rename event", async () => {
+    const source = `
+--@ Folder/TestA.elm
+module Folder.TestA exposing (..)
+
+func = ""
+
+--@ Folder/TestB.elm
+module Folder.TestB exposing (..)
+
+func = ""
+
+--@ Other/TestC.elm
+module Other.TestC exposing (..)
+
+func = ""
+		`;
+    const program = await createProgram(source);
+    const oldPath = uri("Folder");
+    const newPath = uri("Moved");
+    const testAPath = uri("Folder/TestA.elm");
+    const testBPath = uri("Folder/TestB.elm");
+    const testCPath = uri("Other/TestC.elm");
+    const result = renameFilesHandler(
+      { files: [{ oldUri: oldPath, newUri: newPath }] },
+      token,
+    );
+
+    const edit = await getEditFromResult(result);
+
+    if (!edit.changes) {
+      fail();
+    }
+
+    expect(edit.changes[testAPath][0]).toEqual<TextEdit>({
+      newText: "Moved.TestA",
+      range: {
+        start: {
+          line: 0,
+          character: 7,
+        },
+        end: {
+          line: 0,
+          character: 19,
+        },
+      },
+    });
+    expect(edit.changes[testBPath][0]).toEqual<TextEdit>({
+      newText: "Moved.TestB",
+      range: {
+        start: {
+          line: 0,
+          character: 7,
+        },
+        end: {
+          line: 0,
+          character: 19,
+        },
+      },
+    });
+
+    expect(edit.changes[testCPath]).toBeUndefined();
+
+    expect(program.getSourceFile(uri("Moved/TestA.elm"))).not.toBeUndefined();
+    expect(program.getSourceFile(uri("Moved/TestB.elm"))).not.toBeUndefined();
+  });
+
+  it("handles file delete event", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func = ""
+		`;
+    const program = await createProgram(source);
+    const deleteUri = uri("Test.elm");
+
+    expect(program.getSourceFile(deleteUri)).not.toBeUndefined();
+    const result = deleteFilesHandler({ files: [{ uri: deleteUri }] }, token);
+
+    expect(result).toBeNull();
+    expect(program.getSourceFile(deleteUri)).toBeUndefined();
+  });
+});

--- a/test/referencesProviderTests/moduleReferences.test.ts
+++ b/test/referencesProviderTests/moduleReferences.test.ts
@@ -1,0 +1,60 @@
+import { ReferencesProviderTestBase } from "./referencesProviderTestBase";
+
+describe("moduleReferences", () => {
+  const testBase = new ReferencesProviderTestBase();
+
+  it(`module references in other files`, async () => {
+    const source = `
+
+--@ Module.elm
+module Module exposing (foo)
+        --^
+foo = 42
+
+--@ Bar.elm
+module Bar exposing (..)
+
+import Module exposing (foo)
+       --X
+
+bar = foo
+
+--@ FooExtra.elm
+module FooExtra exposing (..)
+
+import Module
+       --X
+
+func = Module.foo
+       --X
+`;
+    await testBase.testReferences(source);
+  });
+
+  it(`module references in other files used with alias`, async () => {
+    const source = `
+
+--@ Module/Foo.elm
+module Module.Foo exposing (foo)
+        --^
+foo = 42
+
+--@ Bar.elm
+module Bar exposing (..)
+
+import Module.Foo as Foo exposing (foo)
+        --X
+
+bar = foo
+
+--@ FooExtra.elm
+module FooExtra exposing (..)
+
+import Module.Foo as Foo
+        --X
+
+func = Foo.foo
+`;
+    await testBase.testReferences(source);
+  });
+});

--- a/test/renameProvider.test.ts
+++ b/test/renameProvider.test.ts
@@ -1,0 +1,201 @@
+import {
+  TextEdit,
+  WorkspaceEdit,
+  Range,
+  Position,
+} from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import { RenameProvider } from "../src/providers";
+import {
+  IPrepareRenameParams,
+  IRenameParams,
+} from "../src/providers/paramsExtensions";
+import * as path from "../src/util/path";
+import { getTargetPositionFromSource } from "./utils/sourceParser";
+import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+
+class MockRenameProvider extends RenameProvider {
+  public onPrepareRenameRequest(params: IPrepareRenameParams): Range | null {
+    return this.handlePrepareRenameRequest(params);
+  }
+
+  public onRenameRequest(
+    params: IRenameParams,
+  ): WorkspaceEdit | null | undefined {
+    return this.handleRenameRequest(params);
+  }
+}
+
+describe("renameProvider", () => {
+  const treeParser = new SourceTreeParser();
+  const renameProvider = new MockRenameProvider();
+
+  async function testPrepareRename(
+    source: string,
+    expectedRange: Range,
+  ): Promise<void> {
+    await treeParser.init();
+
+    const testUri = URI.file(baseUri + "Test.elm").toString();
+    const result = getTargetPositionFromSource(source);
+
+    if (!result) {
+      throw new Error("Could not get sources");
+    }
+
+    const program = await treeParser.getProgram(result.sources);
+
+    const sourceFile = program.getSourceFile(testUri);
+
+    if (!sourceFile) {
+      throw new Error("Could not get source file");
+    }
+
+    const renameRange = renameProvider.onPrepareRenameRequest({
+      program,
+      sourceFile,
+      position: result.position,
+      textDocument: { uri: testUri },
+    });
+
+    expect(renameRange).toEqual(expectedRange);
+  }
+
+  async function testRename(
+    source: string,
+    newName: string,
+    expectedEdits: TextEdit[][],
+  ): Promise<void> {
+    await treeParser.init();
+
+    const testUri = URI.file(baseUri + "Test.elm").toString();
+    const result = getTargetPositionFromSource(source);
+
+    if (!result) {
+      throw new Error("Could not get sources");
+    }
+
+    const program = await treeParser.getProgram(result.sources);
+
+    const sourceFile = program.getSourceFile(testUri);
+
+    if (!sourceFile) {
+      throw new Error("Could not get source file");
+    }
+
+    const renameEdit = renameProvider.onRenameRequest({
+      program,
+      sourceFile,
+      position: result.position,
+      textDocument: { uri: testUri },
+      newName,
+    });
+
+    const changes = Object.keys(result.sources).reduce<{
+      [uri: string]: TextEdit[];
+    }>((prev, cur, index) => {
+      prev[URI.file(path.join(baseUri, cur)).toString()] = expectedEdits[index];
+      return prev;
+    }, {});
+
+    expect(renameEdit?.changes).toEqual(changes);
+  }
+
+  it("renaming a qualified value function part", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Module.App
+
+func = Module.App.foo
+                 --^
+
+--@ Module/App.elm
+module Module.App exposing (foo)
+
+foo = ""		
+`;
+
+    const renameRange = Range.create(
+      Position.create(4, 18),
+      Position.create(4, 21),
+    );
+    await testPrepareRename(source, renameRange);
+
+    const newName = "bar";
+    await testRename(source, newName, [
+      [TextEdit.replace(renameRange, newName)],
+      [
+        TextEdit.replace(
+          Range.create(Position.create(2, 0), Position.create(2, 3)),
+          newName,
+        ),
+        TextEdit.replace(
+          Range.create(Position.create(0, 28), Position.create(0, 31)),
+          newName,
+        ),
+      ],
+    ]);
+  });
+
+  it("renaming a qualified value module part", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Module.App
+
+func = Module.App.foo
+             --^
+
+--@ Module/App.elm
+module Module.App exposing (foo)
+
+foo = ""		
+`;
+
+    const renameRange = Range.create(
+      Position.create(4, 7),
+      Position.create(4, 17),
+    );
+
+    const newName = "Module.NewApp";
+    const expectedEdits = [
+      [
+        TextEdit.replace(
+          Range.create(Position.create(2, 7), Position.create(2, 17)),
+          newName,
+        ),
+        TextEdit.replace(renameRange, newName),
+      ],
+      [
+        TextEdit.replace(
+          Range.create(Position.create(0, 7), Position.create(0, 17)),
+          newName,
+        ),
+      ],
+    ];
+
+    await testPrepareRename(source, renameRange);
+    await testRename(source, newName, expectedEdits);
+
+    const source2 = `
+--@ Test.elm
+module Test exposing (..)
+
+import Module.App
+
+func = Module.App.foo
+        --^
+
+--@ Module/App.elm
+module Module.App exposing (foo)
+
+foo = ""		
+`;
+
+    await testPrepareRename(source2, renameRange);
+    await testRename(source2, newName, expectedEdits);
+  });
+});

--- a/test/utils/sourceTreeParser.ts
+++ b/test/utils/sourceTreeParser.ts
@@ -2,6 +2,7 @@ import { readFile } from "fs";
 import globby from "globby";
 import { container } from "tsyringe";
 import { promisify } from "util";
+import { TextEdit } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
 import Parser from "web-tree-sitter";
 import {
@@ -10,6 +11,7 @@ import {
   IProgramHost,
 } from "../../src/elmWorkspace";
 import * as path from "../../src/util/path";
+import { Utils } from "../../src/util/utils";
 
 export const baseUri = path.join(__dirname, "../sources/src/");
 
@@ -96,4 +98,49 @@ export function createProgramHost(): IProgramHost {
       return;
     },
   };
+}
+
+export function applyEditsToSource(source: string, edits: TextEdit[]): string {
+  let result = source;
+
+  let indexOffset = 0;
+  edits
+    .map((edit) => {
+      const [startIndex, endIndex] = Utils.getIndicesFromRange(
+        edit.range,
+        source,
+      );
+      return { ...edit, startIndex, endIndex };
+    })
+    .sort((a, b) => a.startIndex - b.startIndex)
+    .forEach((edit) => {
+      const startIndex = edit.startIndex + indexOffset;
+      const endIndex = edit.endIndex + indexOffset;
+
+      indexOffset += edit.newText.length - (endIndex - startIndex);
+
+      result =
+        result.substring(0, startIndex) +
+        edit.newText +
+        result.substring(endIndex, result.length);
+    });
+
+  return result;
+}
+
+/**
+ * Remove lines with any comment
+ */
+export function stripCommentLines(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => !RegExp(/--/).exec(line))
+    .join("\n");
+}
+
+export function trimTrailingWhitespace(source: string): string {
+  return source
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n");
 }


### PR DESCRIPTION
Adopt the new file events APIs and adjusted some behavior for module renaming so that it works consistently now. `Module.App.func` references are now included as a module reference for `Module.App`, thus being renamed if the module/file is renamed. Also, if you try to rename on the `Module` or `App` part, you will be renaming the module `Module.App` (different from before). Renaming the function part will still rename the function. 

Also added the ability to rename a directory and have all containing files updated. 