### PR TITLE
Add install package code action when import is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ This server contributes the following settings:
 - `elmLS.elmFormatPath`: The path to your `elm-format` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmTestPath`: The path to your `elm-test` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.disableElmLSDiagnostics`: Enable/Disable linting diagnostics from the language server.
+- `elmLS.skipInstallPackageConfirmation`: Skip confirmation for the Install Package code action.
 
 Settings may need a restart to be applied.
 

--- a/src/capabilityCalculator.ts
+++ b/src/capabilityCalculator.ts
@@ -3,6 +3,7 @@ import {
   ServerCapabilities,
   TextDocumentSyncKind,
 } from "vscode-languageserver";
+import { CommandManager } from "./commandManager";
 import * as ElmMakeDiagnostics from "./providers/diagnostics/elmMakeDiagnostics";
 
 export class CapabilityCalculator {
@@ -29,7 +30,10 @@ export class CapabilityCalculator {
       documentFormattingProvider: true,
       documentSymbolProvider: { label: "Elm" },
       executeCommandProvider: {
-        commands: [ElmMakeDiagnostics.CODE_ACTION_ELM_MAKE],
+        commands: [
+          ElmMakeDiagnostics.CODE_ACTION_ELM_MAKE,
+          ...CommandManager.commands,
+        ],
       },
       foldingRangeProvider: true,
       hoverProvider: true,

--- a/src/commandManager.ts
+++ b/src/commandManager.ts
@@ -1,0 +1,34 @@
+import { Connection } from "vscode-languageserver";
+
+export class CommandManager {
+  public static commands: string[] = [];
+  private static handlers = new Map<
+    string,
+    (...args: any[]) => void | Promise<void>
+  >();
+
+  public static register(
+    command: string,
+    handler: (...args: any[]) => void | Promise<void>,
+  ): void {
+    this.commands.push(command);
+    this.handlers.set(command, handler);
+  }
+
+  /**
+   * Initialize all command handlers for the connection
+   */
+  public static initHandlers(connection: Connection): void {
+    connection.onExecuteCommand((params) => {
+      const handler = this.handlers.get(params.command);
+
+      if (handler) {
+        if (params.arguments) {
+          void handler(...params.arguments);
+        } else {
+          void handler();
+        }
+      }
+    });
+  }
+}

--- a/src/elmPackageCache.ts
+++ b/src/elmPackageCache.ts
@@ -3,6 +3,8 @@ import * as utils from "./util/elmUtils";
 import { ElmJson } from "./elmWorkspace";
 import { promisify } from "util";
 import { IConstraint, IVersion } from "./util/elmUtils";
+import { MultiMap } from "./util/multiMap";
+import * as path from "./util/path";
 
 const readDir = promisify(readdir);
 
@@ -17,19 +19,38 @@ export interface IElmPackageCache {
     packageName: string,
     version: IVersion,
   ): Promise<Map<string, IConstraint>>;
+  loadAllPackageModules(): Promise<void>;
 }
 
 export class ElmPackageCache implements IElmPackageCache {
-  private versionsCache = new Map<string, IVersion[]>();
-  private dependenciesCache = new Map<string, Map<string, IConstraint>>();
+  private static versionsCache = new Map<string, IVersion[]>();
+  private static dependenciesCache = new Map<
+    string,
+    Map<string, IConstraint>
+  >();
+  private static moduleToPackages = new MultiMap<string, string>();
 
-  constructor(
-    private packagesRoot: string,
-    private loadElmJson: (elmJsonPath: string) => Promise<ElmJson>,
-  ) {}
+  private static _packagesRoot: string;
+
+  public static set packagesRoot(newPackagesRoot: string) {
+    // If we somehow got a different packages root (they changed elm versions and restarted the server)
+    // Clear all caches
+    if (this._packagesRoot !== newPackagesRoot) {
+      this.versionsCache.clear();
+      this.dependenciesCache.clear();
+      this.moduleToPackages.clear();
+      this._packagesRoot = newPackagesRoot;
+    }
+  }
+
+  public static get packagesRoot(): string {
+    return this._packagesRoot;
+  }
+
+  constructor(private loadElmJson: (elmJsonPath: string) => Promise<ElmJson>) {}
 
   public async getVersions(packageName: string): Promise<IVersion[]> {
-    const cached = this.versionsCache.get(packageName);
+    const cached = ElmPackageCache.versionsCache.get(packageName);
 
     if (cached) {
       return cached;
@@ -37,7 +58,7 @@ export class ElmPackageCache implements IElmPackageCache {
 
     const versions = await this.getVersionsFromFileSystem(packageName);
 
-    this.versionsCache.set(packageName, versions);
+    ElmPackageCache.versionsCache.set(packageName, versions);
 
     return versions;
   }
@@ -47,7 +68,7 @@ export class ElmPackageCache implements IElmPackageCache {
     version: IVersion,
   ): Promise<Map<string, IConstraint>> {
     const cacheKey = `${packageName}@${version.string}`;
-    const cached = this.dependenciesCache.get(cacheKey);
+    const cached = ElmPackageCache.dependenciesCache.get(cacheKey);
 
     if (cached) {
       return cached;
@@ -58,9 +79,63 @@ export class ElmPackageCache implements IElmPackageCache {
       version,
     );
 
-    this.dependenciesCache.set(cacheKey, dependencies);
+    ElmPackageCache.dependenciesCache.set(cacheKey, dependencies);
 
     return dependencies;
+  }
+
+  public async loadAllPackageModules(): Promise<void> {
+    if (ElmPackageCache.moduleToPackages.size > 0) {
+      // Don't load twice
+      return;
+    }
+
+    try {
+      const maintainers = await readDir(ElmPackageCache._packagesRoot, "utf8");
+
+      for (const maintainer of maintainers) {
+        try {
+          const packages = await readDir(
+            path.join(ElmPackageCache._packagesRoot, maintainer),
+          );
+
+          for (const packageName of packages) {
+            try {
+              const packageAndMaintainer = `${maintainer}/${packageName}`;
+              const versions = await this.getVersions(packageAndMaintainer);
+
+              const latestVersion = versions[versions.length - 1];
+
+              const elmJsonPath = `${ElmPackageCache._packagesRoot}${packageAndMaintainer}/${latestVersion.string}/elm.json`;
+              const elmJson = await this.loadElmJson(elmJsonPath);
+
+              if (elmJson.type === "package") {
+                const exposedModules = utils.flattenExposedModules(
+                  elmJson["exposed-modules"],
+                );
+
+                exposedModules.forEach((exposedModule) => {
+                  ElmPackageCache.moduleToPackages.set(
+                    exposedModule,
+                    packageAndMaintainer,
+                  );
+                });
+              }
+            } catch {
+              // Could fail if `packageName` is not a directory
+            }
+          }
+        } catch {
+          // Could fail if `maintainer` is not a directory (elm cache files)
+        }
+      }
+    } catch {
+      // Could fail if packages root is invalid
+    }
+  }
+
+  public static getPackagesWithModule(moduleName: string): string[] {
+    return this.moduleToPackages.getAll(moduleName) ?? [];
   }
 
   private async getVersionsFromFileSystem(
@@ -72,7 +147,7 @@ export class ElmPackageCache implements IElmPackageCache {
       packageName.length,
     );
 
-    const pathToPackage = `${this.packagesRoot}${maintainer}/${name}/`;
+    const pathToPackage = `${ElmPackageCache._packagesRoot}${maintainer}/${name}/`;
     const folders = await readDir(pathToPackage, "utf8");
 
     const allVersions: IVersion[] = [];
@@ -96,7 +171,7 @@ export class ElmPackageCache implements IElmPackageCache {
     packageName: string,
     version: IVersion,
   ): Promise<Map<string, IConstraint>> {
-    const elmJsonPath = `${this.packagesRoot}${packageName}/${version.string}/elm.json`;
+    const elmJsonPath = `${ElmPackageCache._packagesRoot}${packageName}/${version.string}/elm.json`;
     const elmJson = await this.loadElmJson(elmJsonPath);
 
     return this.parseDependencies(elmJson);

--- a/src/providers/codeAction/importCodeAction.ts
+++ b/src/providers/codeAction/importCodeAction.ts
@@ -6,7 +6,6 @@ import { ImportUtils, IPossibleImport } from "../../util/importUtils";
 import { RefactorEditUtils } from "../../util/refactorEditUtils";
 import { TreeUtils } from "../../util/treeUtils";
 import { Diagnostics } from "../../util/types/diagnostics";
-import { findDefinition } from "../../util/types/expressionTree";
 import { CodeActionProvider } from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 

--- a/src/providers/codeAction/index.ts
+++ b/src/providers/codeAction/index.ts
@@ -4,3 +4,4 @@ import "./addTypeAnnotationCodeAction";
 import "./extractFunctionCodeAction";
 import "./exposeUnexposeCodeAction";
 import "./moveFunctionCodeAction";
+import "./installPackageCodeAction";

--- a/src/providers/codeAction/installPackageCodeAction.ts
+++ b/src/providers/codeAction/installPackageCodeAction.ts
@@ -1,0 +1,106 @@
+import { ExecaSyncReturnValue } from "execa";
+import { container } from "tsyringe";
+import { CodeAction, Connection } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import { CommandManager } from "../../commandManager";
+import { ElmPackageCache } from "../../elmPackageCache";
+import { execCmdSync } from "../../util/elmUtils";
+import { ElmWorkspaceMatcher } from "../../util/elmWorkspaceMatcher";
+import { Settings } from "../../util/settings";
+import { TreeUtils } from "../../util/treeUtils";
+import { Diagnostics } from "../../util/types/diagnostics";
+import { CodeActionProvider } from "../codeActionProvider";
+import { ICodeActionParams } from "../paramsExtensions";
+import { comparePackageRanking } from "../ranking";
+
+const errorCodes = [Diagnostics.ImportMissing.code];
+const fixId = "install_package";
+
+CodeActionProvider.registerCodeAction({
+  errorCodes,
+  fixId,
+  getCodeActions: (params: ICodeActionParams): CodeAction[] | undefined => {
+    const valueNode = TreeUtils.getNamedDescendantForRange(
+      params.sourceFile,
+      params.range,
+    );
+
+    const packages = ElmPackageCache.getPackagesWithModule(valueNode.text);
+
+    return packages.sort(comparePackageRanking).map((packageName) =>
+      CodeActionProvider.getCodeAction(
+        params,
+        `Install package "${packageName}"`,
+        [],
+        {
+          command: "elm.installPackage",
+          title: "Install Package",
+          arguments: [params.sourceFile.uri, packageName],
+        },
+      ),
+    );
+  },
+  getFixAllCodeAction: () => {
+    // We can't run multiple commands
+    return undefined;
+  },
+});
+
+CommandManager.register(
+  "elm.installPackage",
+  async (uri: string, packageName: string) => {
+    const settings = container.resolve<Settings>("Settings");
+    const connection = container.resolve<Connection>("Connection");
+
+    const program = new ElmWorkspaceMatcher((uri: string) =>
+      URI.parse(uri),
+    ).getProgramFor(uri);
+
+    const clientSettings = await settings.getClientSettings();
+
+    try {
+      execCmdSync(
+        clientSettings.elmPath,
+        "elm",
+        { cmdArguments: ["install", packageName] },
+        program.getRootPath().fsPath,
+        connection,
+        clientSettings.skipInstallPackageConfirmation ? "y\n" : undefined,
+      );
+    } catch (e) {
+      if (clientSettings.skipInstallPackageConfirmation) {
+        return;
+      }
+
+      const result: ExecaSyncReturnValue = <ExecaSyncReturnValue>e;
+
+      const message = result.stdout.replace("[Y/n]:", "").trim();
+
+      connection.window
+        .showInformationMessage(
+          message,
+          { title: "Yes", value: "y" },
+          { title: "No", value: "n" },
+        )
+        .then((choice) => {
+          if (choice) {
+            const cmdResult = execCmdSync(
+              clientSettings.elmPath,
+              "elm",
+              { cmdArguments: ["install", packageName] },
+              program.getRootPath().fsPath,
+              connection,
+              `${choice.value}\n`,
+            );
+
+            const message = cmdResult.stdout.replace(result.stdout, "").trim();
+
+            connection.window.showInformationMessage(message);
+          }
+        })
+        .catch((e) => {
+          connection.console.warn(e);
+        });
+    }
+  },
+);

--- a/src/providers/diagnostics/elmDiagnosticsHelper.ts
+++ b/src/providers/diagnostics/elmDiagnosticsHelper.ts
@@ -55,6 +55,10 @@ export class ElmDiagnosticsHelper {
       code = Diagnostics.MissingValue.code;
     }
 
+    if (issue.overview.startsWith("MODULE NOT FOUND")) {
+      code = Diagnostics.ImportMissing.code;
+    }
+
     return {
       range: lineRange,
       message: `${messagePrefix}${issue.details.replace(/\[\d+m/g, "")}`,

--- a/src/providers/ranking.ts
+++ b/src/providers/ranking.ts
@@ -1,4 +1,24 @@
-const RANKING_LIST = {
+export function comparePackageRanking(
+  package1: string,
+  package2: string,
+): number {
+  const aRanking = RANKING_LIST[package1];
+  const bRanking = RANKING_LIST[package2];
+
+  if (aRanking && bRanking) {
+    return aRanking.localeCompare(bRanking);
+  } else if (aRanking) {
+    return 1;
+  } else if (bRanking) {
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
+const RANKING_LIST: {
+  [index: string]: string;
+} = {
   "elm/core": "0001",
   "elm/html": "0002",
   "elm/browser": "0003",

--- a/src/util/elmUtils.ts
+++ b/src/util/elmUtils.ts
@@ -387,3 +387,13 @@ export function constraintIntersect(
 export function getModuleName(uri: string, sourceDir: string): string {
   return path.relative(sourceDir, uri).replace(".elm", "").split("/").join(".");
 }
+
+export function flattenExposedModules(
+  exposedModules: string[] | { [name: string]: string[] },
+): string[] {
+  if (Array.isArray(exposedModules)) {
+    return exposedModules;
+  }
+
+  return Object.values(exposedModules).reduce((a, b) => a.concat(b), []);
+}

--- a/src/util/importUtils.ts
+++ b/src/util/importUtils.ts
@@ -1,5 +1,5 @@
 import { ITreeContainer } from "../forest";
-import RANKING_LIST from "../providers/ranking";
+import { comparePackageRanking } from "../providers/ranking";
 import { TreeUtils, NodeType } from "./treeUtils";
 import { SyntaxNode } from "web-tree-sitter";
 import { IElmWorkspace } from "../elmWorkspace";
@@ -33,28 +33,13 @@ export class ImportUtils {
       }
     });
 
-    const ranking = RANKING_LIST as {
-      [index: string]: string | undefined;
-    };
-
     exposedValues.sort((a, b) => {
       if (!a.package && b.package) {
         return -1;
       } else if (a.package && !b.package) {
         return 1;
       } else if (a.package && b.package) {
-        const aRanking = ranking[a.package];
-        const bRanking = ranking[b.package];
-
-        if (aRanking && bRanking) {
-          return aRanking.localeCompare(bRanking);
-        } else if (aRanking) {
-          return 1;
-        } else if (bRanking) {
-          return -1;
-        } else {
-          return 0;
-        }
+        return comparePackageRanking(a.package, b.package);
       } else {
         if (!currentModule) {
           return 0;

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -8,6 +8,7 @@ export interface IClientSettings {
   trace: { server: string };
   extendedCapabilities?: IExtendedCapabilites;
   disableElmLSDiagnostics: boolean;
+  skipInstallPackageConfirmation: boolean;
 }
 
 export interface IExtendedCapabilites {
@@ -24,6 +25,7 @@ export class Settings {
     elmTestPath: "",
     trace: { server: "off" },
     disableElmLSDiagnostics: false,
+    skipInstallPackageConfirmation: false,
   };
   private connection: Connection;
 

--- a/test/solver.test.ts
+++ b/test/solver.test.ts
@@ -89,6 +89,9 @@ describe("module resolution solver", () => {
                 .find((p) => p.version.string === version.string)
                 ?.dependencies ?? new Map(),
             ),
+          loadAllPackageModules: () => {
+            return Promise.resolve();
+          },
         },
         new Map(deps),
       ),


### PR DESCRIPTION
Fixes #434. The current strategy is load all local packages from the cache on workspace init, after a 5 second delay. This happened pretty fast for me, even with a large cache. Even if it did take more time, it shouldn't affect performance very much since it is all async. I initially had a progress indicator show, but it was too quick to be worth it. 

I also have it pass a `y\n` input to the command so that is automatically says yes to the cmd prompt. We may want to think about this more. I think we should definitely show a notification of what the command did. Maybe we should even run the command first without the `y\n` to see what it will do, then prompt the user with a notification with a yes/no choice. 