### PR TITLE
Handle initial onOpen events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { createConnection } from "vscode-languageserver/node";
 import Parser from "web-tree-sitter";
 import { getCancellationStrategyFromArgv } from "./cancellation";
 import { CapabilityCalculator } from "./capabilityCalculator";
+import { ASTProvider } from "./providers";
 import { ILanguageServer } from "./server";
 import { DocumentEvents } from "./util/documentEvents";
 import { Settings } from "./util/settings";
@@ -75,6 +76,10 @@ connection.onInitialize(
     const { Server } = await import("./server");
     server = new Server(params, progress);
     await server.init();
+
+    container.register(ASTProvider, {
+      useValue: new ASTProvider(),
+    });
 
     return server.capabilities;
   },

--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -73,7 +73,9 @@ export class ASTProvider {
     // Source file could be undefined here
     let tree: Tree = params.sourceFile?.tree;
 
+    let hasContentChanges = false;
     if ("contentChanges" in params) {
+      hasContentChanges = true;
       for (const change of params.contentChanges) {
         if ("range" in change) {
           tree?.edit(this.getEditFromChange(change, tree.rootNode.text));
@@ -93,7 +95,10 @@ export class ASTProvider {
       this.documentEvents.get(document.uri)?.getText() ??
       readFileSync(URI.parse(document.uri).fsPath, "utf8");
 
-    const newTree = this.parser.parse(newText, tree);
+    const newTree = this.parser.parse(
+      newText,
+      hasContentChanges ? tree : undefined,
+    );
 
     let changedDeclaration: SyntaxNode | undefined;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,6 @@ import { URI, Utils } from "vscode-uri";
 import { CapabilityCalculator } from "./capabilityCalculator";
 import { ElmWorkspace, IElmWorkspace } from "./elmWorkspace";
 import {
-  ASTProvider,
   CodeActionProvider,
   CodeLensProvider,
   CompletionProvider,
@@ -130,10 +129,6 @@ export class Server implements ILanguageServer {
 
     container.register("ClientSettings", {
       useValue: clientSettings,
-    });
-
-    container.register(ASTProvider, {
-      useValue: new ASTProvider(),
     });
 
     container.register(DiagnosticsProvider, {


### PR DESCRIPTION
Closes #436. Register `astProvider` sooner so that it receives the initial onOpen events. Never do an incremental parse on open events, so that it always starts correct. Since we were already parsing on open events before (just not initial), switching to a full parse shouldn't be a big problem for performance.  