### PR TITLE
Fix maintainerAndPackageName not being set

### DIFF
--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -492,6 +492,7 @@ export class ElmWorkspace implements IElmWorkspace {
           this.flatternExposedModules(elmJson["exposed-modules"]),
         ),
         moduleToUriMap: new Map<string, string>(),
+        maintainerAndPackageName: elmJson.name,
         testModuleToUriMap: new Map<string, string>(),
       } as IElmPackage;
     }
@@ -540,6 +541,7 @@ export class ElmWorkspace implements IElmWorkspace {
           this.flatternExposedModules(elmJson["exposed-modules"]),
         ),
         moduleToUriMap: new Map<string, string>(),
+        maintainerAndPackageName: elmJson.name,
         testModuleToUriMap: new Map<string, string>(),
       } as IElmPackage;
 


### PR DESCRIPTION
Not sure if or what problems this would have caused, but its definitely a regression. Not sure why TypeScript doesn't throw an error either.