### PR TITLE
Use elm-tooling-cli to install third party bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the language server implementation for the Elm programming language.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Installation](#installation)
@@ -75,21 +76,24 @@ npm link
 nix-env -i -A nixpkgs.elmPackages.elm-language-server
 ```
 
+You might want to set `elmLS.useElmToolingJsonForTools` to `false`. This prevents us trying to install the dependencies via `elm-tooling-cli`.
+
 ## Requirements
 
-You will need to install `elm` and `elm-test` to get all diagnostics and `elm-format` for formatting. Alternatively you can also just install these to your local npm `package.json`.
+You will need to provide `elm` and `elm-test` to get all diagnostics and `elm-format` for formatting.
+Normally your editor should prompt you to install everything that's needed. If you set `elmLS.useElmToolingJsonForTools` to `false`, you will need to handle this on your own.
+
+Alternatively you can also just install these to your local npm `package.json`.
 
 ```sh
 npm install -g elm elm-test elm-format
 ```
 
-Or use local versions from your `node_modules` directory, if you want to do that you need to set the paths, via the settings (e.g. set `elmPath` to `./node_modules/.bin/elm`).
-
 ## Configuration
 
 Create an [elm-tooling.json](https://elm-tooling.github.io/elm-tooling-cli/spec) file next to your `elm.json` to configure the language server.
 
-Currently there’s just one thing that you can configure: entrypoints. The language server runs `elm make` to get type errors. By default `elm make` is run on the current file only. To get errors for the entire project you can specify your entrypoint files – basically, those with `main =` in them. Then the language server will run `elm make` on those instead.
+Currently there’s just one thing that we use: entrypoints. The language server runs `elm make` to get type errors. By default `elm make` is run on the current file only. To get errors for the entire project you can specify your entrypoint files – basically, those with `main =` in them. Then the language server will run `elm make` on those instead.
 
 Example `elm-tooling.json`:
 
@@ -322,6 +326,7 @@ You should now be able to use the integrations from Sublime. You might want to r
 - [elm-format](https://github.com/avh4/elm-format)
 - [elm-test](https://github.com/rtfeldman/node-test-runner)
 - [tree-sitter-elm](https://github.com/Razzeee/tree-sitter-elm)
+- [elm-tooling-cli](https://github.com/elm-tooling/elm-tooling-cli)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This is the language server implementation for the Elm programming language.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 **Table of Contents**
 
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the language server implementation for the Elm programming language.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Installation](#installation)
@@ -137,6 +138,7 @@ This server contributes the following settings:
 - `elmLS.elmTestPath`: The path to your `elm-test` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.disableElmLSDiagnostics`: Enable/Disable linting diagnostics from the language server.
 - `elmLS.skipInstallPackageConfirmation`: Skip confirmation for the Install Package code action.
+- `elmLS.useElmToolingJsonForTools`: Don't rely on elm-tooling-cli to get our tooling - should be only relevant for projects that don't use npm at all.
 
 Settings may need a restart to be applied.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2100,6 +2100,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "elm-tooling": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.0.0.tgz",
+      "integrity": "sha512-muWYP2nO7Q1hxWy4LDhkG5TS3uPgI1vLM8Xft2lvVNlIXIlbHcSysflSVn5tAXm6ato72Ghc7aFNVb2OMWIqfQ=="
+    },
     "emittery": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.0",
+    "elm-tooling": "^1.0.0",
     "escape-string-regexp": "^4.0.0",
     "execa": "^5.0.0",
     "fast-diff": "^1.2.0",

--- a/src/elmWorkspace.ts
+++ b/src/elmWorkspace.ts
@@ -369,6 +369,7 @@ export class ElmWorkspace implements IElmWorkspace {
         try {
           await runElmToolingCliInstall(options);
         } catch (error) {
+          this.connection.window.showErrorMessage(`${error}`);
           this.connection.console.error(`Unexpected error ${error}`);
         }
       } else {
@@ -384,7 +385,7 @@ export class ElmWorkspace implements IElmWorkspace {
               const initExitCode = await elmToolingCli(["init"], options);
 
               if (initExitCode !== 0) {
-                throw "elm-tooling  init failed";
+                throw "Creating a new 'elm-tooling.json' failed";
               }
 
               await runElmToolingCliInstall(options);
@@ -411,6 +412,7 @@ export class ElmWorkspace implements IElmWorkspace {
             }
           })
           .catch((error) => {
+            this.connection.window.showErrorMessage(`${error}`);
             this.connection.console.error(`Unexpected error "${error}"`);
           });
       }
@@ -812,6 +814,6 @@ async function runElmToolingCliInstall(options: {
 }): Promise<void> {
   const installExitCode = await elmToolingCli(["install"], options);
   if (installExitCode !== 0) {
-    throw "elm-tooling install failed";
+    throw "Failed to install one of the dependencies";
   }
 }

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -9,6 +9,7 @@ export interface IClientSettings {
   extendedCapabilities?: IExtendedCapabilites;
   disableElmLSDiagnostics: boolean;
   skipInstallPackageConfirmation: boolean;
+  useElmToolingJsonForTools: boolean;
 }
 
 export interface IExtendedCapabilites {
@@ -26,6 +27,7 @@ export class Settings {
     trace: { server: "off" },
     disableElmLSDiagnostics: false,
     skipInstallPackageConfirmation: false,
+    useElmToolingJsonForTools: true,
   };
   private connection: Connection;
 

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -2,13 +2,19 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import { Connection } from "vscode-languageserver";
 import { mockDeep } from "jest-mock-extended";
-import { Settings } from "../src/util/settings";
+import { IClientSettings, Settings } from "../src/util/settings";
 import { DocumentEvents } from "../src/util/documentEvents";
 
 container.register("Connection", { useValue: mockDeep<Connection>() });
 container.register("ElmWorkspaces", { useValue: [] });
 container.register("Settings", {
-  useValue: new Settings({} as any, {}),
+  useValue: new Settings(
+    {
+      // skip this code path, as mocking the promise from showInformationMessage is no fun
+      useElmToolingJsonForTools: false,
+    } as IClientSettings,
+    {},
+  ),
 });
 container.register("ClientSettings", {
   useValue: {},

--- a/test/utils/sourceTreeParser.ts
+++ b/test/utils/sourceTreeParser.ts
@@ -63,7 +63,7 @@ export class SourceTreeParser {
       );
     };
 
-    // Seperate test sources
+    // Separate test sources
     const testSources: { [K: string]: string } = {};
     for (const key in sources) {
       if (key.startsWith("tests/")) {


### PR DESCRIPTION
This already seems pretty good to me, probably still some corner cases left.

- [ ] we can't install a test runner like this, yet - will have to wait for `elm-test-rs`
- [x] can we just call install every time? should we check if we can already find the bin and skip or check if the versions matches?
- [x] update readme
- [x] error when download fails