### PR TITLE
Improve unused import diagnostics

### DIFF
--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -701,6 +701,7 @@ export class ElmLsDiagnostics {
       .map((match) => match.captures[0].node);
 
     moduleAliases.forEach((moduleAlias) => {
+      // This case is handled by unused_import
       if (!moduleAlias.parent?.parent?.childForFieldName("exposing")) {
         return;
       }

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -8,6 +8,7 @@ import {
   Connection,
   DiagnosticSeverity,
   DiagnosticTag,
+  Position,
   Range,
   TextEdit,
 } from "vscode-languageserver";
@@ -529,6 +530,33 @@ export class ElmLsDiagnostics {
           }
         }
 
+        if (diagnostic.data.code === "unused_import") {
+          const node = TreeUtils.getNamedDescendantForPosition(
+            treeContainer.tree.rootNode,
+            diagnostic.range.end,
+          );
+
+          const moduleName = node.childForFieldName("moduleName");
+
+          result.push({
+            diagnostics: [diagnostic],
+            edit: {
+              changes: {
+                [uri]: [
+                  TextEdit.del(
+                    Range.create(
+                      diagnostic.range.start,
+                      Position.create(diagnostic.range.end.line + 1, 0),
+                    ),
+                  ),
+                ],
+              },
+            },
+            kind: CodeActionKind.QuickFix,
+            title: `Remove unused import \`${moduleName?.text ?? node.text}\``,
+          });
+        }
+
         if (diagnostic.data.code === "unused_alias") {
           const node = TreeUtils.getNamedDescendantForPosition(
             treeContainer.tree.rootNode,
@@ -576,11 +604,14 @@ export class ElmLsDiagnostics {
     const moduleImports = this.moduleImportsQuery
       .matches(tree.rootNode)
       .map((match) => match.captures[0].node)
-      .filter(
-        (node) =>
-          node.nextNamedSibling?.type !== "exposing_list" &&
-          node.nextNamedSibling?.type !== "as_clause",
-      );
+      .filter((node) => !node.parent?.childForFieldName("exposing"))
+      .map((node) => {
+        const alias = node.parent
+          ?.childForFieldName("asClause")
+          ?.childForFieldName("name");
+
+        return alias ? alias : node;
+      });
 
     // Would need to adjust tree-sitter (use fields) to get a better query
     moduleImports.forEach((moduleImport) => {
@@ -595,9 +626,13 @@ export class ElmLsDiagnostics {
         .map((match) => match.captures.map((n) => n.node.text).join("."))
         .filter((moduleReference) => moduleReference === moduleImport.text);
 
-      if (references.length === 0 && moduleImport.parent) {
+      const importNode =
+        moduleImport.parent?.type === "as_clause"
+          ? moduleImport.parent?.parent
+          : moduleImport.parent;
+      if (references.length === 0 && importNode) {
         diagnostics.push({
-          range: this.getNodeRange(moduleImport.parent),
+          range: this.getNodeRange(importNode),
           message: `Unused import \`${moduleImport.text}\``,
           severity: DiagnosticSeverity.Warning,
           source: "ElmLS",
@@ -666,6 +701,10 @@ export class ElmLsDiagnostics {
       .map((match) => match.captures[0].node);
 
     moduleAliases.forEach((moduleAlias) => {
+      if (!moduleAlias.parent?.parent?.childForFieldName("exposing")) {
+        return;
+      }
+
       const references = this.moduleAliasReferencesQuery
         .matches(tree.rootNode)
         .filter(Utils.notUndefined.bind(this))

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -459,6 +459,7 @@ foo = (+) 1 2
       ]);
     });
 
+    // This case is handled by unused_import
     it("unused alias but no exposing", async () => {
       const source = `
 module Foo exposing (..)
@@ -475,7 +476,7 @@ foo = 1
       const source = `
 module Foo exposing (..)
 
-import Bar as B
+import Bar as B exposing (..)
 
 foo = B.add 1
 			`;
@@ -487,7 +488,7 @@ foo = B.add 1
       const source = `
 module Main exposing (..)
 
-import X as Y
+import X as Y exposing (..)
 
 z a =
     case a of
@@ -502,7 +503,7 @@ z a =
       const source = `
 module Foo exposing (..)
 
-import Bar as B
+import Bar as B exposing (..)
 
 foo : B.Thing
 foo = bar
@@ -515,7 +516,7 @@ foo = bar
       const source = `
 module Foo exposing (..)
 
-import Bar as B
+import Bar as B exposing (..)
 
 foo = B.math.add 1
 			`;
@@ -528,7 +529,7 @@ foo = B.math.add 1
 module Foo exposing (..)
 
 
-import Bar as B
+import Bar as B exposing (..)
 
 type alias Thing = { name : B.Name }
 			`;

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -368,18 +368,6 @@ type alias Thing = { name : Bar.Name }
       await testDiagnostics(source, "unused_import", []);
     });
 
-    it("unused but has alias", async () => {
-      const source = `
-module Foo exposing (..)
-
-import Bar as B
-
-foo = 1
-			`;
-
-      await testDiagnostics(source, "unused_import", []);
-    });
-
     it("unused but has exposing", async () => {
       const source = `
 module Foo exposing (..)
@@ -411,6 +399,26 @@ foo = 1
         ),
       ]);
     });
+
+    it("no usage for alias", async () => {
+      const source = `
+module Foo exposing (..)
+
+import Bar as B
+
+foo = (+) 1 2
+			`;
+
+      await testDiagnostics(source, "unused_import", [
+        diagnosticWithRangeAndName(
+          {
+            start: { line: 3, character: 0 },
+            end: { line: 3, character: 15 },
+          },
+          "B",
+        ),
+      ]);
+    });
   });
 
   describe("unused import alias", () => {
@@ -431,11 +439,11 @@ foo = 1
       };
     };
 
-    it("no usage for alias", async () => {
+    it("no usage for alias with exposing", async () => {
       const source = `
 module Foo exposing (..)
 
-import Bar as B
+import Bar as B exposing (..)
 
 foo = (+) 1 2
 			`;
@@ -449,6 +457,18 @@ foo = (+) 1 2
           "B",
         ),
       ]);
+    });
+
+    it("unused alias but no exposing", async () => {
+      const source = `
+module Foo exposing (..)
+
+import Bar as B
+
+foo = 1
+			`;
+
+      await testDiagnostics(source, "unused_alias", []);
     });
 
     it("used as qualified", async () => {


### PR DESCRIPTION
Cleans up unused import diagnostics and adds a code action to remove unused import. Closes #486. 

With this new way, if `import Html as H` is unused, it is just an unused import, and the whole thing can be removed. If the alias in `import Html as H exposing (..)` is unused, we report an unused alias, because the import is still used.