### PR TITLE
Don't crash server if it fails to initialize

### DIFF
--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -146,6 +146,10 @@ export class DiagnosticsProvider {
         );
       } else {
         this.workspaces.forEach((workspace) => {
+          if (!workspace.getForest(false)) {
+            return;
+          }
+
           workspace.getForest().treeMap.forEach((treeContainer) => {
             if (treeContainer.writeable) {
               this.updateDiagnostics(
@@ -210,6 +214,10 @@ export class DiagnosticsProvider {
 
   private requestAllDiagnostics(): void {
     this.workspaces.forEach((workspace) => {
+      if (!workspace.getForest(false)) {
+        return;
+      }
+
       workspace.getForest().treeMap.forEach(({ uri, writeable }) => {
         if (writeable) {
           this.pendingDiagnostics.set(uri, Date.now());


### PR DESCRIPTION
I found the source of the crash. Now individual requests will fail, but the entire server will not crash. Closes #485.

I was trying to send error diagnostics to `elm.json`, but it was not working. Do you think because it is not an `.elm` file, VSCode doesn't accept them?