### PR TITLE
Separate elm-tooling.json handling

### DIFF
--- a/src/elmToolingJsonManager.ts
+++ b/src/elmToolingJsonManager.ts
@@ -1,0 +1,81 @@
+import path from "path";
+import { URI } from "vscode-uri";
+import { ITreeContainer } from "./forest";
+import { NonEmptyArray } from "./util/utils";
+import util from "util";
+import * as fs from "fs";
+
+const readFile = util.promisify(fs.readFile);
+
+export class ElmToolingJsonManager {
+  public async getEntrypoints(
+    workspaceRootPath: string,
+    sourceFile: ITreeContainer,
+  ): Promise<[NonEmptyArray<string>, string]> {
+    const elmToolingPath = path.join(workspaceRootPath, "elm-tooling.json");
+    const defaultRelativePathToFile = path.relative(
+      workspaceRootPath,
+      URI.parse(sourceFile.uri).fsPath,
+    );
+    return await readFile(elmToolingPath, {
+      encoding: "utf-8",
+    })
+      .then(JSON.parse)
+      .then(this.elmToolingEntrypointsDecoder.bind(this))
+      .then(
+        (entrypoints) => [
+          entrypoints,
+          `Using entrypoints from ${elmToolingPath}: ${JSON.stringify(
+            entrypoints,
+          )}`,
+        ],
+        (error: Error & { code?: string }) => {
+          const innerMessage =
+            error.code === "ENOENT"
+              ? `No elm-tooling.json found in ${workspaceRootPath}.`
+              : error.code === "EISDIR"
+              ? `Skipping ${elmToolingPath} because it is a directory, not a file.`
+              : error instanceof SyntaxError
+              ? `Skipping ${elmToolingPath} because it contains invalid JSON: ${error.message}.`
+              : `Skipping ${elmToolingPath} because: ${error.message}.`;
+          const fullMessage = `Using default entrypoint: ${defaultRelativePathToFile}. ${innerMessage}`;
+
+          return [[defaultRelativePathToFile], fullMessage];
+        },
+      );
+  }
+  private elmToolingEntrypointsDecoder(json: unknown): NonEmptyArray<string> {
+    if (typeof json === "object" && json !== null && !Array.isArray(json)) {
+      if ("entrypoints" in json) {
+        const { entrypoints } = json as { [key: string]: unknown };
+        if (Array.isArray(entrypoints) && entrypoints.length > 0) {
+          const result: Array<string> = [];
+          for (const [index, item] of entrypoints.entries()) {
+            if (typeof item === "string" && item.startsWith("./")) {
+              result.push(item);
+            } else {
+              throw new Error(
+                `Expected "entrypoints" to contain string paths starting with "./" but got: ${JSON.stringify(
+                  item,
+                )} at index ${index}`,
+              );
+            }
+          }
+          return [result[0], ...result.slice(1)];
+        } else {
+          throw new Error(
+            `Expected "entrypoints" to be a non-empty array but got: ${JSON.stringify(
+              json,
+            )}`,
+          );
+        }
+      } else {
+        throw new Error(`There is no "entrypoints" field.`);
+      }
+    } else {
+      throw new Error(
+        `Expected a JSON object but got: ${JSON.stringify(json)}`,
+      );
+    }
+  }
+}

--- a/src/elmToolingJsonManager.ts
+++ b/src/elmToolingJsonManager.ts
@@ -45,37 +45,40 @@ export class ElmToolingJsonManager {
       );
   }
   private elmToolingEntrypointsDecoder(json: unknown): NonEmptyArray<string> {
-    if (typeof json === "object" && json !== null && !Array.isArray(json)) {
-      if ("entrypoints" in json) {
-        const { entrypoints } = json as { [key: string]: unknown };
-        if (Array.isArray(entrypoints) && entrypoints.length > 0) {
-          const result: Array<string> = [];
-          for (const [index, item] of entrypoints.entries()) {
-            if (typeof item === "string" && item.startsWith("./")) {
-              result.push(item);
-            } else {
-              throw new Error(
-                `Expected "entrypoints" to contain string paths starting with "./" but got: ${JSON.stringify(
-                  item,
-                )} at index ${index}`,
-              );
-            }
-          }
-          return [result[0], ...result.slice(1)];
-        } else {
-          throw new Error(
-            `Expected "entrypoints" to be a non-empty array but got: ${JSON.stringify(
-              json,
-            )}`,
-          );
-        }
-      } else {
-        throw new Error(`There is no "entrypoints" field.`);
-      }
-    } else {
+    if (typeof json !== "object" || json === null || Array.isArray(json)) {
       throw new Error(
         `Expected a JSON object but got: ${JSON.stringify(json)}`,
       );
     }
+
+    if (!("entrypoints" in json)) {
+      throw new Error(`There is no "entrypoints" field.`);
+    }
+
+    const { entrypoints } = json as { [key: string]: unknown };
+
+    if (!Array.isArray(entrypoints) || entrypoints.length === 0) {
+      throw new Error(
+        `Expected "entrypoints" to be a non-empty array but got: ${JSON.stringify(
+          json,
+        )}`,
+      );
+    }
+
+    const result: Array<string> = [];
+
+    for (const [index, item] of entrypoints.entries()) {
+      if (typeof item !== "string" || !item.startsWith("./")) {
+        throw new Error(
+          `Expected "entrypoints" to contain string paths starting with "./" but got: ${JSON.stringify(
+            item,
+          )} at index ${index}`,
+        );
+      }
+
+      result.push(item);
+    }
+
+    return result as NonEmptyArray<string>;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import {
 } from "vscode-languageserver";
 import { URI, Utils } from "vscode-uri";
 import { CapabilityCalculator } from "./capabilityCalculator";
+import { ElmToolingJsonManager } from "./elmToolingJsonManager";
 import { ElmWorkspace, IElmWorkspace } from "./elmWorkspace";
 import {
   CodeActionProvider,
@@ -77,6 +78,9 @@ export class Server implements ILanguageServer {
         });
         container.register("ElmWorkspaces", {
           useValue: elmWorkspaces,
+        });
+        container.register<ElmToolingJsonManager>("ElmToolingJsonManager", {
+          useValue: new ElmToolingJsonManager(),
         });
       } else {
         this.connection.window.showErrorMessage(

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -1,5 +1,7 @@
 import { Range } from "vscode-languageserver";
 
+export type NonEmptyArray<T> = [T, ...T[]];
+
 export class Utils {
   public static notUndefined<T>(x: T | undefined): x is T {
     return x !== undefined;

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -7,6 +7,9 @@ import { DocumentEvents } from "../src/util/documentEvents";
 
 container.register("Connection", { useValue: mockDeep<Connection>() });
 container.register("ElmWorkspaces", { useValue: [] });
+container.register("ElmToolingJsonManager", {
+  useValue: {},
+});
 container.register("Settings", {
   useValue: new Settings({} as any, {}),
 });


### PR DESCRIPTION
This separates the elm-tooling.json handling, preparing us to load more values.
Should also allow starting to cache these calls at some point.