### PR TITLE
Minor completion improvements

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -898,6 +898,13 @@ export class CompletionProvider {
     return this.createCompletion(options);
   }
 
+  private createVariableCompletion(
+    options: ICompletionOptions,
+  ): CompletionItem {
+    options.kind = CompletionItemKind.Variable;
+    return this.createCompletion(options);
+  }
+
   private createFieldOrParameterCompletion(
     markdownDocumentation: string | undefined,
     label: string,
@@ -1011,30 +1018,26 @@ export class CompletionProvider {
           }
         });
       }
-      if (
-        node.parent.type === "case_of_branch" &&
-        node.parent.firstNamedChild &&
-        node.parent.firstNamedChild.type === "pattern" &&
-        node.parent.firstNamedChild.firstNamedChild &&
-        node.parent.firstNamedChild.firstNamedChild.type === "union_pattern" &&
-        node.parent.firstNamedChild.firstNamedChild.childCount > 1 // Ignore cases of case branches with no params
-      ) {
-        const caseBranchVariableNodes = TreeUtils.findAllNamedChildrenOfType(
-          "lower_pattern",
-          node.parent.firstNamedChild.firstNamedChild,
-        );
-        if (caseBranchVariableNodes) {
-          caseBranchVariableNodes.forEach((a) => {
-            const markdownDocumentation = HintHelper.createHintFromDefinitionInCaseBranch();
-            result.push(
-              this.createFunctionCompletion({
-                markdownDocumentation,
-                label: a.text,
-                range,
-                sortPrefix,
-              }),
-            );
-          });
+      if (node.parent.type === "case_of_branch") {
+        const pattern = node.parent.childForFieldName("pattern");
+
+        if (pattern) {
+          const caseBranchVariableNodes = pattern.descendantsOfType(
+            "lower_pattern",
+          );
+          if (caseBranchVariableNodes) {
+            caseBranchVariableNodes.forEach((a) => {
+              const markdownDocumentation = HintHelper.createHintFromDefinitionInCaseBranch();
+              result.push(
+                this.createVariableCompletion({
+                  markdownDocumentation,
+                  label: a.text,
+                  range,
+                  sortPrefix,
+                }),
+              );
+            });
+          }
         }
       }
       if (
@@ -1048,11 +1051,12 @@ export class CompletionProvider {
               child,
             );
             result.push(
-              this.createFieldOrParameterCompletion(
+              this.createVariableCompletion({
                 markdownDocumentation,
-                child.text,
+                label: child.text,
                 range,
-              ),
+                sortPrefix,
+              }),
             );
 
             const annotationTypeNode = TreeUtils.getTypeOrTypeAliasOfFunctionParameter(

--- a/src/util/types/typeInference.ts
+++ b/src/util/types/typeInference.ts
@@ -2007,6 +2007,7 @@ export class InferenceScope {
         this.bindPattern(field, TUnknown, isParameter);
       });
 
+      this.expressionTypes.set(pattern, type);
       return;
     }
 

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -1410,4 +1410,55 @@ func2 =
 
     await testCompletions(source2, ["func", "test"], "partialMatch");
   });
+
+  it("Record completions in record patterns", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func : { prop1: String, prop2: Int } -> String
+func {{-caret-}} =
+    ""
+`;
+
+    await testCompletions(source, ["prop1", "prop2"], "exactMatch");
+
+    const source2 = `
+--@ Test.elm
+module Test exposing (..)
+
+func : { prop1: String, prop2: Int } -> String
+func {p{-caret-}} =
+    ""
+`;
+
+    await testCompletions(source2, ["prop1", "prop2"], "exactMatch");
+
+    const source3 = `
+--@ Test.elm
+module Test exposing (..)
+
+func =
+    let
+      {{-caret-}} = { prop1 = "", prop2 = 2 }
+    in
+    ""
+`;
+
+    await testCompletions(source3, ["prop1", "prop2"], "exactMatch");
+  });
+
+  it("Case branch patterns should have completions", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func model =
+    case model of 
+      Just { details } ->
+        d{-caret-}
+`;
+
+    await testCompletions(source, ["details"]);
+  });
 });


### PR DESCRIPTION
Fixes for some things that have been bugging me.

- Fix union constructor auto imports
- Prefer `Int` over `Basics.Int` for Basics module
- No completions for lower patterns (param names)
- Record completions for record patterns
- Don't complete on import alias
- Improve case branch pattern completions