### PR TITLE
Fix function references

### DIFF
--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -29,14 +29,17 @@ export class References {
         switch (definitionNode.nodeType) {
           case "Function":
             {
-              const annotationNameNode = this.getFunctionAnnotationNameNodeFromDefinition(
-                definitionNode.node,
-              );
-              if (annotationNameNode && refSourceTree.writeable) {
-                references.push({
-                  node: annotationNameNode,
-                  uri: definitionNode.uri,
-                });
+              if (definitionNode.node.parent) {
+                const annotationNameNode = TreeUtils.getTypeAnnotation(
+                  definitionNode.node.parent,
+                )?.childForFieldName("name");
+
+                if (annotationNameNode && refSourceTree.writeable) {
+                  references.push({
+                    node: annotationNameNode,
+                    uri: definitionNode.uri,
+                  });
+                }
               }
 
               const functionNameNode = TreeUtils.getFunctionNameNodeFromDefinition(
@@ -753,21 +756,6 @@ export class References {
 
   private static findAllRecordBaseIdentifiers(node: SyntaxNode): SyntaxNode[] {
     return TreeUtils.descendantsOfType(node, "record_base_identifier");
-  }
-
-  private static getFunctionAnnotationNameNodeFromDefinition(
-    node: SyntaxNode,
-  ): SyntaxNode | undefined {
-    if (
-      node.parent &&
-      node.parent.previousNamedSibling &&
-      node.parent.previousNamedSibling.type === "type_annotation" &&
-      node.parent.previousNamedSibling.firstChild &&
-      node.parent.previousNamedSibling.firstChild.type ===
-        "lower_case_identifier"
-    ) {
-      return node.parent.previousNamedSibling.firstChild;
-    }
   }
 
   private static findFieldUsages(tree: Tree, fieldName: string): SyntaxNode[] {

--- a/src/util/types/typeChecker.ts
+++ b/src/util/types/typeChecker.ts
@@ -571,7 +571,7 @@ export function createTypeChecker(workspace: IElmWorkspace): TypeChecker {
       // The function name should resolve to itself
       if (nodeParent.firstNamedChild?.text === nodeText) {
         return {
-          node: nodeParent.parent,
+          node: nodeParent,
           nodeType: "Function",
           uri: treeContainer.uri,
         };

--- a/test/referencesProviderTests/functionReferences.test.ts
+++ b/test/referencesProviderTests/functionReferences.test.ts
@@ -104,8 +104,7 @@ bar = foo
     await testBase.testReferences(source);
   });
 
-  // getFunctionAnnotationNameNodeFromDefinition doesn't find the annotation due to the comment inbetween
-  xit(`function annotation gets a reference`, async () => {
+  it(`function annotation gets a reference`, async () => {
     const source = `
 
 --@ Module.elm


### PR DESCRIPTION
These were broke which caused function renames to be broke.