### PR TITLE
Removes 'Unused Value Constructor' errors on modules that expose all of their contents

### DIFF
--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -995,14 +995,12 @@ export class ElmLsDiagnostics {
     // reference to the type, or through a '(..)' to expose everything, then
     // we won't mark the value constructor as unused. Ideally this should take
     // multiple files into account, then these conditions can be removed.
-    const exposingAll = !!tree
-      .rootNode
-      .descendantsOfType("module_declaration")
-      ?.[0]
-      ?.childForFieldName('exposing')
-      ?.childForFieldName('doubleDot')
+    const exposingAll = !!tree.rootNode
+      .descendantsOfType("module_declaration")?.[0]
+      ?.childForFieldName("exposing")
+      ?.childForFieldName("doubleDot");
 
-    if(exposingAll) {
+    if (exposingAll) {
       return diagnostics;
     }
 

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -996,7 +996,7 @@ export class ElmLsDiagnostics {
     // we won't mark the value constructor as unused. Ideally this should take
     // multiple files into account, then these conditions can be removed.
     const exposingAll = !!tree.rootNode
-      .descendantsOfType("module_declaration")?.[0]
+      .childForFieldName("moduleDeclaration")
       ?.childForFieldName("exposing")
       ?.childForFieldName("doubleDot");
 

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -992,7 +992,8 @@ export class ElmLsDiagnostics {
     const diagnostics: IDiagnostic[] = [];
 
     const exposingAll = this.patternReferencesQuery
-      .matches(tree.rootNode).some((result) => result.captures[0].name === "exposingAll");
+      .matches(tree.rootNode)
+      .some((result) => result.captures[0].name === "exposingAll");
 
     const unionVariants = this.unionVariantsQuery
       .matches(tree.rootNode)

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -1664,25 +1664,25 @@ text en it language =
     });
 
     it("used in a different file", async () => {
-      const source = `
-      --@ Main.elm
-      module Main exposing (..)
+      const source =`
+--@ Main.elm
+module Main exposing (..)
 
-      import B exposing (C(..))
+import B exposing (C(..))
 
-      f : Int -> C
-      f x =
-          if x > 1 then
-              Something
-          else
-              SomethingElse
+f : Int -> C
+f x =
+    if x > 1 then
+        Something
+    else
+        SomethingElse
 
-      --@ B.elm
-      module B exposing (..)
+--@ B.elm
+module B exposing (..)
 
-      type C
-          = Something
-          | SomethingElse
+type C
+    = Something
+    | SomethingElse
 			`;
 
       await testDiagnostics(source, "unused_value_constructor", []);


### PR DESCRIPTION
Before this commit, `elmLsDiagnostics` doesn't present the 'Unused Value Constructor' warning for modules that either use the Value somewhere(correct) or expose the parent type explicitly with the '(..)' operator to expose the variants(this is speculative because the type may not be used elsewhere even though it's exported). This change just expands that logic to also include cases where the module implicitly exposes the parent type and its variants, by using the '(..)' indicator to expose all contents of the module. 

Ideally this and the other speculative case should be removed in favor of a solution that considers whether the variants are actually used in other files, but this is something that I am not familiar enough with the codebase to do quite yet. However, the tests have been modified to prepare for such a solution and a test has been added to test the multiple file variant usage case, but in the meantime, that test also tests the single file 'expose all' case.

I'm personally much more in favor of considering multiple files for this warning, so if that's not a gargantuan effort, please point me in that direction and I'll create that pull request instead.