### PR TITLE
Handle removing all import values better

### DIFF
--- a/src/positionUtil.ts
+++ b/src/positionUtil.ts
@@ -30,14 +30,27 @@ export class PositionUtil {
   }
 }
 
-export function comparePosition(pos1: VSPosition, pos2: TSPosition): number {
-  if (pos1.line === pos2.row && pos1.character === pos2.column) {
+export function comparePosition(
+  _pos1: VSPosition | TSPosition,
+  _pos2: VSPosition | TSPosition,
+): number {
+  // Convert TSPosition to VSPosition
+  const pos1 =
+    "row" in _pos1
+      ? PositionUtil.FROM_TS_POSITION(_pos1).toVSPosition()
+      : _pos1;
+  const pos2 =
+    "row" in _pos2
+      ? PositionUtil.FROM_TS_POSITION(_pos2).toVSPosition()
+      : _pos2;
+
+  if (pos1.line === pos2.line && pos1.character === pos2.character) {
     return 0;
   }
 
   if (
-    pos1.line < pos2.row ||
-    (pos1.line === pos2.row && pos1.character < pos2.column)
+    pos1.line < pos2.line ||
+    (pos1.line === pos2.line && pos1.character < pos2.character)
   ) {
     return -1;
   }

--- a/src/providers/codeActionLs/removeUnusedCodeAction.ts
+++ b/src/providers/codeActionLs/removeUnusedCodeAction.ts
@@ -59,7 +59,7 @@ function getEditsForDiagnostic(
   sourceFile: ISourceFile,
   importsMap?: Map<string, Set<string>>,
 ): { title?: string; edits: TextEdit[] } {
-  const addImportToSet = (module: string, value: string) => {
+  const addImportToSet = (module: string, value: string): void => {
     if (!importsMap) {
       return;
     }

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -3,6 +3,7 @@ import {
   CancellationToken,
   Connection,
   Diagnostic as LspDiagnostic,
+  DiagnosticSeverity,
   FileChangeType,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -57,6 +58,18 @@ export function convertFromCompilerDiagnostic(diag: Diagnostic): IDiagnostic {
       uri: diag.uri,
       code: diag.code,
     },
+    tags: diag.tags,
+  };
+}
+
+export function convertToCompilerDiagnostic(diag: IDiagnostic): Diagnostic {
+  return {
+    message: diag.message,
+    source: diag.source,
+    severity: diag.severity ?? DiagnosticSeverity.Warning,
+    range: diag.range,
+    code: diag.data.code,
+    uri: diag.data.uri,
     tags: diag.tags,
   };
 }
@@ -228,6 +241,20 @@ export class DiagnosticsProvider {
     }
 
     return this.currentDiagnostics.get(uri)?.get() ?? [];
+  }
+
+  /**
+   * Used for tests only
+   */
+  public forceElmLsDiagnosticsUpdate(
+    sourceFile: ISourceFile,
+    program: IProgram,
+  ): void {
+    this.updateDiagnostics(
+      sourceFile.uri,
+      DiagnosticKind.ElmLS,
+      this.elmLsDiagnostics.createDiagnostics(sourceFile, program),
+    );
   }
 
   private requestDiagnostics(uri: string): void {

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -848,7 +848,7 @@ export class ElmLsDiagnostics {
     return diagnostics;
   }
 
-  getSingleFieldRecordDiagnostics(
+  private getSingleFieldRecordDiagnostics(
     tree: Tree,
     uri: string,
     program: IProgram,

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -168,6 +168,29 @@ export class RefactorEditUtils {
     }
   }
 
+  public static removeImportExposingList(
+    tree: Tree,
+    moduleName: string,
+  ): TextEdit | undefined {
+    const importClause = TreeUtils.findImportClauseByName(tree, moduleName);
+    const exposingList = importClause?.childForFieldName("exposing");
+
+    if (exposingList) {
+      return TextEdit.del(
+        Range.create(
+          Position.create(
+            exposingList.startPosition.row,
+            exposingList.startPosition.column - 1,
+          ),
+          Position.create(
+            exposingList.endPosition.row,
+            exposingList.endPosition.column,
+          ),
+        ),
+      );
+    }
+  }
+
   public static addImport(
     tree: Tree,
     moduleName: string,
@@ -383,12 +406,14 @@ export class RefactorEditUtils {
       let startPosition = exposedNode.startPosition;
       let endPosition = exposedNode.endPosition;
 
-      if (exposedNode.previousSibling?.text === ",") {
+      if (
+        exposedNode.previousSibling?.text === "," &&
+        exposedNode.nextSibling?.text === ")"
+      ) {
         startPosition = exposedNode.previousSibling.startPosition;
       }
 
       if (
-        exposedNode.previousSibling?.text !== "," &&
         exposedNode.nextSibling?.text === "," &&
         exposedNode.nextSibling?.nextSibling
       ) {

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -127,6 +127,7 @@ export class RefactorEditUtils {
     tree: Tree,
     moduleName: string,
     valueName: string,
+    forceRemoveLastComma = false,
   ): TextEdit | undefined {
     const importClause = TreeUtils.findImportClauseByName(tree, moduleName);
 
@@ -163,6 +164,7 @@ export class RefactorEditUtils {
         return this.removeValueFromExposingList(
           exposedValuesAndTypes,
           valueName,
+          forceRemoveLastComma,
         );
       }
     }
@@ -397,6 +399,7 @@ export class RefactorEditUtils {
   private static removeValueFromExposingList(
     exposedNodes: SyntaxNode[],
     valueName: string,
+    forceRemoveLastComma = false,
   ): TextEdit | undefined {
     const exposedNode = exposedNodes.find(
       (node) => node.text === valueName || node.text === `${valueName}(..)`,
@@ -408,7 +411,7 @@ export class RefactorEditUtils {
 
       if (
         exposedNode.previousSibling?.text === "," &&
-        exposedNode.nextSibling?.text === ")"
+        (exposedNode.nextSibling?.text === ")" || forceRemoveLastComma)
       ) {
         startPosition = exposedNode.previousSibling.startPosition;
       }

--- a/test/codeActionTests/codeActionTestBase.ts
+++ b/test/codeActionTests/codeActionTestBase.ts
@@ -100,7 +100,7 @@ export async function testCodeAction(
     useValue: new DiagnosticsProvider(),
   });
 
-  // Needed be codeActionProvider uses these diagnostics
+  // Needed by codeActionProvider which uses these diagnostics
   container
     .resolve(DiagnosticsProvider)
     .forceElmLsDiagnosticsUpdate(sourceFile, program);

--- a/test/codeActionTests/removeUnusedCodeAction.test.ts
+++ b/test/codeActionTests/removeUnusedCodeAction.test.ts
@@ -1,0 +1,223 @@
+import { testCodeAction } from "./codeActionTestBase";
+
+describe("remove unused code action", () => {
+  it("removing an import at the start of exposing list", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe, Result(..))
+                    --^
+
+func = ""
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, Maybe, Result(..))
+
+func = ""
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value `foo`" }],
+      expectedSource,
+    );
+  });
+
+  it("removing an import in the middle of exposing list", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe, Result(..))
+                               --^
+
+func = ""
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Result(..))
+
+func = ""
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value `Maybe`" }],
+      expectedSource,
+    );
+  });
+
+  it("removing an import at the end of exposing list", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe, Result)
+                                      --^
+
+func = ""
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe)
+
+func = ""
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value `Result`" }],
+      expectedSource,
+    );
+  });
+
+  it("removing an import at the end of exposing list", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe, Result)
+                                      --^
+
+func = ""
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe)
+
+func = ""
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value `Result`" }],
+      expectedSource,
+    );
+  });
+
+  it("removing all imports in exposing list", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe, Result)
+                    --^
+
+func = ""
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo
+
+func = ""
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing all imports in exposing list except the first", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar, Maybe, Result)
+                         --^
+
+func = foo
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo)
+
+func = foo
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing all imports in exposing list except the middle", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, Maybe, foo, Result)
+                    --^
+
+func = foo
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo)
+
+func = foo
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing all imports in exposing list except the end", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, Maybe, Result, foo)
+                    --^
+
+func = foo
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo)
+
+func = foo
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+});

--- a/test/codeActionTests/removeUnusedCodeAction.test.ts
+++ b/test/codeActionTests/removeUnusedCodeAction.test.ts
@@ -82,33 +82,6 @@ func = ""
     );
   });
 
-  it("removing an import at the end of exposing list", async () => {
-    const source = `
---@ Test.elm
-module Test exposing (..)
-
-import Foo exposing (foo, bar, Maybe, Result)
-                                      --^
-
-func = ""
-`;
-
-    const expectedSource = `
---@ Test.elm
-module Test exposing (..)
-
-import Foo exposing (foo, bar, Maybe)
-
-func = ""
-`;
-
-    await testCodeAction(
-      source,
-      [{ title: "Remove unused value `Result`" }],
-      expectedSource,
-    );
-  });
-
   it("removing all imports in exposing list", async () => {
     const source = `
 --@ Test.elm
@@ -211,6 +184,118 @@ module Test exposing (..)
 import Foo exposing (foo)
 
 func = foo
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing some imports in exposing list - 1st and 3rd", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (Maybe, foo, Result, bar)
+                    --^
+
+func = foo + bar
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (foo, bar)
+
+func = foo + bar
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing some imports in exposing list - 2nd and 4th", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, Maybe, foo, Result)
+                          --^
+
+func = foo + bar
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, foo)
+
+func = foo + bar
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing some imports in exposing list - last 2", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, foo, Maybe, Result)
+                              --^
+
+func = foo + bar
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, foo)
+
+func = foo + bar
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove all unused code" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing some imports in exposing list - first 2", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (Maybe, Result, bar, foo)
+                            --^
+
+func = foo + bar
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (bar, foo)
+
+func = foo + bar
 `;
 
     await testCodeAction(


### PR DESCRIPTION
Handle overlapping ranges when removing multiple import values at the same time. I also added special handling for the case when we remove all import values, it removes the exposing list. Still need to add tests and there is one case that still does not work.

- [x] When the last two (or more) values in a list are unused, an extra comma is left behind.
- [x] Add tests
