### PR TITLE
Ignore different case of import_clause being recognized as a reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-prettier": "^3.3.1",
         "jest": "^26.6.3",
+        "jest-diff": "^26.6.2",
         "jest-mock-extended": "^1.0.13",
         "prettier": "^2.2.1",
         "tree-sitter-cli": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
+    "jest-diff": "^26.6.2",
     "jest-mock-extended": "^1.0.13",
     "prettier": "^2.2.1",
     "tree-sitter-cli": "^0.19.3",

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -532,7 +532,8 @@ export class ElmLsDiagnostics {
       .filter(
         (match) =>
           match.captures.length > 0 &&
-          match.captures[0].node.parent?.type !== "import_clause",
+          match.captures[0].node.parent?.type !== "import_clause" &&
+          match.captures[0].node.parent?.parent?.type !== "import_clause",
       )
       .map((match) => match.captures.map((n) => n.node.text).join("."));
 

--- a/test/codeActionTests/codeActionTestBase.ts
+++ b/test/codeActionTests/codeActionTestBase.ts
@@ -9,7 +9,6 @@ import {
   DiagnosticsProvider,
 } from "../../src/providers";
 import { ElmLsDiagnostics } from "../../src/providers/diagnostics/elmLsDiagnostics";
-import { DiagnosticKind } from "../../src/providers/diagnostics/fileDiagnostics";
 import { ICodeActionParams } from "../../src/providers/paramsExtensions";
 import { Utils } from "../../src/util/utils";
 import {
@@ -23,6 +22,7 @@ import {
   applyEditsToSource,
   stripCommentLines,
 } from "../utils/sourceTreeParser";
+import diffDefault from "jest-diff";
 
 function codeActionEquals(a: CodeAction, b: CodeAction): boolean {
   return a.title === b.title;
@@ -131,11 +131,7 @@ export async function testCodeAction(
   );
 
   if (debug && !codeActionsExist) {
-    console.log(
-      `Expecting ${JSON.stringify(expectedCodeActions)}, got ${JSON.stringify(
-        codeActions,
-      )}`,
-    );
+    console.log(diffDefault(expectedCodeActions, codeActions));
   }
 
   expect(codeActionsExist).toBeTruthy();

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -15,6 +15,7 @@ import {
   getTargetPositionFromSource,
 } from "../utils/sourceParser";
 import { baseUri, SourceTreeParser } from "../utils/sourceTreeParser";
+import diffDefault from "jest-diff";
 
 const basicsSources = `
 --@ Basics.elm
@@ -140,11 +141,7 @@ describe("test elm diagnostics", () => {
     );
 
     if (debug && !diagnosticsEqual) {
-      console.log(
-        `Expecting ${JSON.stringify(expected)}, got ${JSON.stringify(
-          diagnostics,
-        )}`,
-      );
+      console.log(diffDefault(expected, diagnostics));
     }
 
     expect(diagnosticsEqual).toBeTruthy();

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -26,11 +26,11 @@ describe("ElmLsDiagnostics", () => {
     await treeParser.init();
     elmDiagnostics = new ElmLsDiagnostics();
 
-    const sources = getSourceFiles(source)
+    const sources = getSourceFiles(source);
     const program = await treeParser.getProgram(sources);
 
-    let diagnostics : Array<IDiagnostic> = []
-    for ( const fileName in sources) {
+    let diagnostics: Array<IDiagnostic> = [];
+    for (const fileName in sources) {
       const filePath = URI.file(baseUri + fileName).toString();
       const sourceFile = program.getSourceFile(filePath);
 
@@ -38,9 +38,10 @@ describe("ElmLsDiagnostics", () => {
         fail();
       }
 
-      diagnostics = diagnostics.concat(elmDiagnostics
-        .createDiagnostics(sourceFile, program)
-        .filter((diagnostic) => diagnostic.data.code === code)
+      diagnostics = diagnostics.concat(
+        elmDiagnostics
+          .createDiagnostics(sourceFile, program)
+          .filter((diagnostic) => diagnostic.data.code === code),
       );
     }
 
@@ -422,6 +423,32 @@ foo = (+) 1 2
             end: { line: 3, character: 15 },
           },
           "B",
+        ),
+      ]);
+    });
+
+    it("no usage on both imports even if name is similar", async () => {
+      const source = `
+module Session exposing (..)
+
+import Json.Decode
+import Json.Decode.Pipeline
+			`;
+
+      await testDiagnostics(source, "unused_import", [
+        diagnosticWithRangeAndName(
+          {
+            start: { line: 3, character: 0 },
+            end: { line: 3, character: 18 },
+          },
+          "Json.Decode",
+        ),
+        diagnosticWithRangeAndName(
+          {
+            start: { line: 4, character: 0 },
+            end: { line: 4, character: 27 },
+          },
+          "Json.Decode.Pipeline",
         ),
       ]);
     });
@@ -1664,7 +1691,7 @@ text en it language =
     });
 
     it("used in a different file", async () => {
-      const source =`
+      const source = `
 --@ Main.elm
 module Main exposing (..)
 

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -10,6 +10,7 @@ import { diagnosticsEquals } from "../../src/providers/diagnostics/fileDiagnosti
 import { Utils } from "../../src/util/utils";
 import { getSourceFiles } from "../utils/sourceParser";
 import { baseUri, SourceTreeParser } from "../utils/sourceTreeParser";
+import diffDefault from "jest-diff";
 
 describe("ElmLsDiagnostics", () => {
   let elmDiagnostics: ElmLsDiagnostics;
@@ -52,11 +53,7 @@ describe("ElmLsDiagnostics", () => {
     );
 
     if (debug && !diagnosticsEqual) {
-      console.log(
-        `Expecting ${JSON.stringify(expectedDiagnostics)}, got ${JSON.stringify(
-          diagnostics,
-        )}`,
-      );
+      console.log(diffDefault(expectedDiagnostics, diagnostics));
     }
 
     expect(diagnosticsEqual).toBeTruthy();


### PR DESCRIPTION
Add test unused import on similar names

Closes https://github.com/elm-tooling/elm-language-server/issues/554