### PR TITLE
Standalone compiler API

### DIFF
--- a/src/compiler/utils/elmUtils.ts
+++ b/src/compiler/utils/elmUtils.ts
@@ -4,7 +4,7 @@ import { Connection, CompletionItemKind } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { IElmPackageCache } from "../elmPackageCache";
 import { IClientSettings } from "../../util/settings";
-import { ElmProject } from "../program";
+import { ElmProject, IProgramHost } from "../program";
 
 export const isWindows = process.platform === "win32";
 
@@ -25,7 +25,7 @@ export function execCmdSync(
   cmdStatic: string,
   options: IExecCmdOptions = {},
   cwd: string,
-  connection: Connection,
+  host: IProgramHost,
   input?: string,
 ): ExecaSyncReturnValue<string> {
   const cmd = cmdFromUser === "" ? cmdStatic : cmdFromUser;
@@ -41,9 +41,9 @@ export function execCmdSync(
       stripFinalNewline: false,
     });
   } catch (error) {
-    connection.console.warn(JSON.stringify(error));
+    host.logger.warn(JSON.stringify(error));
     if (error.errno && error.errno === "ENOENT") {
-      connection.window.showErrorMessage(
+      host.handleError(
         options.notFoundText
           ? options.notFoundText + ` I'm looking for '${cmd}' at '${cwd}'`
           : `Cannot find executable with name '${cmd}'`,
@@ -81,7 +81,7 @@ export function getEmptyTypes(): {
 export function getElmVersion(
   settings: IClientSettings,
   elmWorkspaceFolder: URI,
-  connection: Connection,
+  host: IProgramHost,
 ): string {
   const options = {
     cmdArguments: ["--version"],
@@ -94,12 +94,12 @@ export function getElmVersion(
     "elm",
     options,
     elmWorkspaceFolder.fsPath,
-    connection,
+    host,
   );
 
   const version = result.stdout.trim();
 
-  connection.console.info(`Elm version ${version} detected.`);
+  host.logger.info(`Elm version ${version} detected.`);
 
   return version;
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,1 +1,3 @@
 export * as Protocol from "./protocol";
+export { Program, IProgram, IProgramHost } from "./compiler/program";
+export { URI } from "vscode-uri";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,14 @@
+import { container } from "tsyringe";
+import Parser from "web-tree-sitter";
+import { IProgramHost } from "./compiler/program";
+import * as path from "path";
+
+export async function loadParser(host: IProgramHost): Promise<void> {
+  container.registerSingleton<Parser>("Parser", Parser);
+  await Parser.init();
+  const absolute = path.join(__dirname, "tree-sitter-elm.wasm");
+  const pathToWasm = path.relative(process.cwd(), absolute);
+  host.logger.info(`Loading Elm tree-sitter syntax from ${pathToWasm}`);
+  const language = await Parser.Language.load(pathToWasm);
+  container.resolve<Parser>("Parser").setLanguage(language);
+}

--- a/src/providers/codeAction/installPackageCodeAction.ts
+++ b/src/providers/codeAction/installPackageCodeAction.ts
@@ -12,6 +12,7 @@ import { Diagnostics } from "../../compiler/diagnostics";
 import { CodeActionProvider } from "../codeActionProvider";
 import { ICodeActionParams } from "../paramsExtensions";
 import { comparePackageRanking } from "../ranking";
+import { createNodeProgramHost, IProgramHost } from "../../compiler/program";
 
 const errorCodes = [Diagnostics.ImportMissing.code];
 const fixId = "install_package";
@@ -51,6 +52,7 @@ CommandManager.register(
   async (uri: string, packageName: string) => {
     const settings = container.resolve<Settings>("Settings");
     const connection = container.resolve<Connection>("Connection");
+    const host = createNodeProgramHost(connection);
 
     const program = new ElmWorkspaceMatcher((uri: string) =>
       URI.parse(uri),
@@ -64,7 +66,7 @@ CommandManager.register(
         "elm",
         { cmdArguments: ["install", packageName] },
         program.getRootPath().fsPath,
-        connection,
+        host,
         clientSettings.skipInstallPackageConfirmation ? "y\n" : undefined,
       );
     } catch (e) {
@@ -89,7 +91,7 @@ CommandManager.register(
               "elm",
               { cmdArguments: ["install", packageName] },
               program.getRootPath().fsPath,
-              connection,
+              host,
               `${choice.value}\n`,
             );
 

--- a/src/providers/diagnostics/elmMakeDiagnostics.ts
+++ b/src/providers/diagnostics/elmMakeDiagnostics.ts
@@ -19,6 +19,7 @@ import { IDiagnostic, IElmIssue } from "./diagnosticsProvider";
 import { ElmDiagnosticsHelper } from "./elmDiagnosticsHelper";
 import execa = require("execa");
 import { ElmToolingJsonManager } from "../../elmToolingJsonManager";
+import { createNodeProgramHost } from "../../compiler/program";
 
 const ELM_MAKE = "Elm";
 export const NAMING_ERROR = "NAMING ERROR";
@@ -242,7 +243,7 @@ export class ElmMakeDiagnostics {
         testOrMakeCommandWithOmittedSettings,
         options,
         workspaceRootPath,
-        this.connection,
+        createNodeProgramHost(this.connection),
       );
       return [];
     } catch (error) {

--- a/src/providers/documentFormatingProvider.ts
+++ b/src/providers/documentFormatingProvider.ts
@@ -12,6 +12,7 @@ import { ElmWorkspaceMatcher } from "../util/elmWorkspaceMatcher";
 import { Settings } from "../util/settings";
 import { TextDocumentEvents } from "../util/textDocumentEvents";
 import { IDocumentFormattingParams } from "./paramsExtensions";
+import { createNodeProgramHost } from "../compiler/program";
 
 type DocumentFormattingResult = Promise<TextEdit[] | undefined>;
 
@@ -51,7 +52,7 @@ export class DocumentFormattingProvider {
       "elm-format",
       options,
       elmWorkspaceRootPath.fsPath,
-      this.connection,
+      createNodeProgramHost(this.connection),
       text,
     );
     return Diff.getTextRangeChanges(text, format.stdout);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,10 +11,9 @@ import { URI, Utils } from "vscode-uri";
 import { CapabilityCalculator } from "./capabilityCalculator";
 import { ElmToolingJsonManager } from "./elmToolingJsonManager";
 import {
-  Program,
-  IProgram,
   createNodeProgramHost,
   IProgramHost,
+  createProgram,
 } from "./compiler/program";
 import {
   CodeActionProvider,
@@ -37,6 +36,7 @@ import { ElmLsDiagnostics } from "./providers/diagnostics/elmLsDiagnostics";
 import { FileEventsHandler } from "./providers/handlers/fileEventsHandler";
 import { Settings } from "./util/settings";
 import { TextDocumentEvents } from "./util/textDocumentEvents";
+import { CommandManager } from "./commandManager";
 
 export interface ILanguageServer {
   readonly capabilities: InitializeResult;
@@ -78,30 +78,8 @@ export class Server implements ILanguageServer {
           `Found ${topLevelElmJsons.size} unique elmWorkspaces for workspace ${globUri}`,
         );
 
-        const textDocuments = container.resolve(TextDocumentEvents);
-
-        const nodeProgramHost = createNodeProgramHost();
-
-        // First try to read from text documents buffer, then fallback to disk
-        const programHost: IProgramHost = {
-          ...nodeProgramHost,
-          readFile: (uri) => {
-            const textDocument = textDocuments.get(URI.file(uri).toString());
-
-            if (textDocument) {
-              return Promise.resolve(textDocument.getText());
-            }
-
-            return nodeProgramHost.readFile(uri);
-          },
-        };
-
-        const elmWorkspaces: Program[] = [];
-        topLevelElmJsons.forEach((elmWorkspace) => {
-          elmWorkspaces.push(new Program(elmWorkspace, programHost));
-        });
-        container.register("ElmWorkspaces", {
-          useValue: elmWorkspaces,
+        container.register("ElmWorkspacePaths", {
+          useValue: Array.from(topLevelElmJsons.values()),
         });
         container.register<ElmToolingJsonManager>("ElmToolingJsonManager", {
           useValue: new ElmToolingJsonManager(),
@@ -127,24 +105,67 @@ export class Server implements ILanguageServer {
   }
 
   public async init(): Promise<void> {
+    const textDocuments = container.resolve(TextDocumentEvents);
+
+    const nodeProgramHost = createNodeProgramHost();
+
+    // First try to read from text documents buffer, then fallback to disk
+    const programHost: IProgramHost = {
+      ...nodeProgramHost,
+      readFile: (uri) => {
+        const textDocument = textDocuments.get(URI.file(uri).toString());
+
+        if (textDocument) {
+          return Promise.resolve(textDocument.getText());
+        }
+
+        return nodeProgramHost.readFile(uri);
+      },
+      logger: this.connection.console,
+      handleError: this.connection.window.showErrorMessage.bind(this),
+      onServerDidRestart: async (handler) => {
+        const progress = await this.connection.window.createWorkDoneProgress();
+        progress.begin("Restarting Elm Language Server", 0);
+
+        await handler((percent) => {
+          progress.report(percent, `${percent.toFixed(0)}%`);
+        });
+
+        progress.done();
+      },
+    };
+
+    const settings = container.resolve(Settings);
+    const clientSettings = await settings.getClientSettings();
+
     this.progress.begin("Indexing Elm", 0);
-    const elmWorkspaces = container.resolve<IProgram[]>("ElmWorkspaces");
+    const elmWorkspacePaths = container.resolve<URI[]>("ElmWorkspacePaths");
     await Promise.all(
-      elmWorkspaces
+      elmWorkspacePaths
         .map((ws) => ({ ws, indexedPercent: 0 }))
         .map((indexingWs, _, all) =>
-          indexingWs.ws.init((percent: number) => {
-            // update progress for this workspace
-            indexingWs.indexedPercent = percent;
+          createProgram(
+            indexingWs.ws,
+            (percent: number) => {
+              // update progress for this workspace
+              indexingWs.indexedPercent = percent;
 
-            // report average progress across all workspaces
-            const avgIndexed =
-              all.reduce((sum, { indexedPercent }) => sum + indexedPercent, 0) /
-              all.length;
-            this.progress.report(avgIndexed, `${Math.round(avgIndexed)}%`);
-          }),
+              // report average progress across all workspaces
+              const avgIndexed =
+                all.reduce(
+                  (sum, { indexedPercent }) => sum + indexedPercent,
+                  0,
+                ) / all.length;
+              this.progress.report(avgIndexed, `${Math.round(avgIndexed)}%`);
+            },
+            programHost,
+            clientSettings,
+          ),
         ),
-    );
+    ).then((programs) => {
+      CommandManager.initHandlers(this.connection);
+      container.register("ElmWorkspaces", { useValue: programs });
+    });
     this.progress.done();
   }
 

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -18,9 +18,8 @@ export interface IExtendedCapabilites {
   clientInitiatedDiagnostics: boolean;
 }
 
-@injectable()
-export class Settings {
-  private clientSettings: IClientSettings = {
+export function getDefaultSettings(): IClientSettings {
+  return {
     elmFormatPath: "",
     elmPath: "",
     elmTestPath: "",
@@ -29,6 +28,10 @@ export class Settings {
     skipInstallPackageConfirmation: false,
     onlyUpdateDiagnosticsOnSave: false,
   };
+}
+@injectable()
+export class Settings {
+  private clientSettings: IClientSettings = getDefaultSettings();
   private connection: Connection;
 
   private initDone = false;


### PR DESCRIPTION
Refactor the compiler api so that it can be used as a standalone application by other projects.

Usage would look like 
```ts
import { Program } from '@elm-tooling/elm-language-server';

const program = new Program('path-root-root-uri');
await program.init(); // Init dependencies, initial parsing, etc

const checker = program.getTypeChecker();
const sourceFile = program.getSourceFile('some-file-uri');

sourceFile.tree.rootNode.children.forEach((node) => {
	if (node.type === 'value_declaration') {
		const type = checker.findType(node);
	}
});
```