### PR TITLE
Fix major performance issue with getting possible imports

### DIFF
--- a/src/util/importUtils.ts
+++ b/src/util/importUtils.ts
@@ -77,11 +77,8 @@ export class ImportUtils {
         });
 
         exposed.constructors?.forEach((exp) => {
-          if (exp.node.parent) {
-            const value = TreeUtils.findFirstNamedChildOfType(
-              "upper_case_identifier",
-              exp.node.parent,
-            )?.text;
+          if (exp.node.parent && exp.type === "UnionConstructor") {
+            const value = exp.node.parent.childForFieldName("name")?.text;
 
             if (value) {
               exposedValues.push({


### PR DESCRIPTION
When `exp.node` was a `type_alias_declaration`, we were calling `findFirstNamedChildOfType` on the `file` many times, causing a big performance hit.