### PR TITLE
Find tests

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -179,7 +179,7 @@ export function bindTreeContainer(sourceFile: ISourceFile): void {
             };
           }
         })
-        .filter(Utils.notUndefined.bind(bindExposing)) ?? [];
+        .filter(Utils.notUndefined) ?? [];
 
     // Union variants get bound to the parent container
     unionVariants.forEach((variant) => {

--- a/src/compiler/patternMatches.ts
+++ b/src/compiler/patternMatches.ts
@@ -150,7 +150,7 @@ export class PatternMatches {
           return this.isExhaustive(
             matrix
               .map(this.specializeRowByAnything.bind(this))
-              .filter(Utils.notUndefined.bind(this)),
+              .filter(Utils.notUndefined),
             n - 1,
           ).map((result) => [Anything, ...result]);
         } else {
@@ -159,11 +159,11 @@ export class PatternMatches {
           if (numSeen < alts.numAlts) {
             const missing: Pattern[] = alts.alts
               .map((alt) => isMissing(alts, ctors, alt))
-              .filter(Utils.notUndefined.bind(this));
+              .filter(Utils.notUndefined);
             return this.isExhaustive(
               matrix
                 .map(this.specializeRowByAnything.bind(this))
-                .filter(Utils.notUndefined.bind(this)),
+                .filter(Utils.notUndefined),
               n - 1,
             ).flatMap((ex) => missing.map((m) => [m, ...ex]));
           } else {
@@ -173,7 +173,7 @@ export class PatternMatches {
                   .map((row) =>
                     this.specializeRowByCtor(ctor.name, ctor.arity, row),
                   )
-                  .filter(Utils.notUndefined.bind(this)),
+                  .filter(Utils.notUndefined),
                 ctor.arity + n - 1,
               ).map((patterns) =>
                 recoverCtor(alts, ctor.name, ctor.arity, patterns),
@@ -234,7 +234,7 @@ export class PatternMatches {
             return this.isUseful(
               matrix
                 .map((row) => this.specializeRowByCtor(name, args.length, row))
-                .filter(Utils.notUndefined.bind(this)),
+                .filter(Utils.notUndefined),
               [...args, ...patterns],
             );
           }
@@ -246,7 +246,7 @@ export class PatternMatches {
               return this.isUseful(
                 matrix
                   .map(this.specializeRowByAnything.bind(this))
-                  .filter(Utils.notUndefined.bind(this)),
+                  .filter(Utils.notUndefined),
                 patterns,
               );
             } else {
@@ -256,7 +256,7 @@ export class PatternMatches {
                     .map((row) =>
                       this.specializeRowByCtor(alt.name, alt.arity, row),
                     )
-                    .filter(Utils.notUndefined.bind(this)),
+                    .filter(Utils.notUndefined),
                   [...replicate(Anything, alt.arity), ...patterns],
                 );
               });
@@ -268,7 +268,7 @@ export class PatternMatches {
             return this.isUseful(
               matrix
                 .map((row) => this.specializeRowByLiteral(literal, row))
-                .filter(Utils.notUndefined.bind(this)),
+                .filter(Utils.notUndefined),
               patterns,
             );
           }

--- a/src/compiler/references.ts
+++ b/src/compiler/references.ts
@@ -799,7 +799,7 @@ export class References {
       .map((field) =>
         TreeUtils.findFirstNamedChildOfType("lower_case_identifier", field),
       )
-      .filter(Utils.notUndefinedOrNull.bind(this))
+      .filter(Utils.notUndefinedOrNull)
       .filter((field) => field.text === fieldName);
   }
 

--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -886,7 +886,7 @@ export function createTypeChecker(program: IProgram): TypeChecker {
         ?.getAll(moduleNameOrAlias)
         ?.filter((s) => s.type === "Import")
         .map((s) => s.node.childForFieldName("moduleName"))
-        .filter(Utils.notUndefinedOrNull.bind(createTypeChecker)) ?? []
+        .filter(Utils.notUndefinedOrNull) ?? []
     );
   }
 

--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -622,7 +622,7 @@ export function createTypeChecker(program: IProgram): TypeChecker {
               (s) => s.node.type !== "infix_declaration",
             ),
         )
-        .find(Utils.notUndefined.bind(findDefinition));
+        .find(Utils.notUndefined);
 
       if (localBinding) {
         return {

--- a/src/compiler/typeExpression.ts
+++ b/src/compiler/typeExpression.ts
@@ -404,7 +404,7 @@ export class TypeExpression {
         typeRef,
       )
         ?.map(mapSyntaxNodeToExpression)
-        .filter(Utils.notUndefined.bind(this))
+        .filter(Utils.notUndefined)
         .map((arg) => this.typeSignatureSegmentType(arg)) ?? [];
 
     const definition = findDefinition(

--- a/src/compiler/typeInference.ts
+++ b/src/compiler/typeInference.ts
@@ -539,7 +539,7 @@ export class InferenceScope {
   private getBinding(e: Expression): Type | undefined {
     return this.ancestors
       .map((a) => a.bindings.get(e))
-      .find(Utils.notUndefined.bind(this));
+      .find(Utils.notUndefined);
   }
 
   public static valueDeclarationInference(
@@ -910,7 +910,7 @@ export class InferenceScope {
         const patterns = pattern
           .descendantsOfType("lower_pattern")
           ?.map(mapSyntaxNodeToExpression)
-          .filter(Utils.notUndefined.bind(this));
+          .filter(Utils.notUndefined);
 
         patterns?.forEach((pat) => {
           const patType = result.expressionTypes.get(pat);
@@ -2242,7 +2242,7 @@ export class InferenceScope {
 
             return undefined;
           })
-          .filter(Utils.notUndefined.bind(this)),
+          .filter(Utils.notUndefined),
       ),
     );
   }

--- a/src/compiler/utils/expressionTree.ts
+++ b/src/compiler/utils/expressionTree.ts
@@ -299,7 +299,7 @@ export function mapSyntaxNodeToExpression(
           binOpExpr.nodeType = "BinOpExpr";
           binOpExpr.parts = node.children
             .map(mapSyntaxNodeToExpression)
-            .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+            .filter(Utils.notUndefined);
           return binOpExpr;
         }
       }
@@ -357,7 +357,7 @@ export function mapSyntaxNodeToExpression(
         typeExpression.nodeType = "TypeExpression";
         typeExpression.segments = node.children
           .map(mapSyntaxNodeToExpression)
-          .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+          .filter(Utils.notUndefined);
         return typeExpression;
       }
 
@@ -398,9 +398,7 @@ export function mapSyntaxNodeToExpression(
         functionDeclarationLeft.params = node.namedChildren
           .filter((n) => n.type.includes("pattern") || n.type === "unit_expr")
           ?.map(mapSyntaxNodeToExpression)
-          .filter(
-            Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-          ) as Pattern[];
+          .filter(Utils.notUndefined) as Pattern[];
         return functionDeclarationLeft;
       }
 
@@ -436,7 +434,7 @@ export function mapSyntaxNodeToExpression(
         unionVariant.params = node.children
           .slice(1)
           .map(mapSyntaxNodeToExpression)
-          .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+          .filter(Utils.notUndefined);
         return unionVariant;
       }
 
@@ -445,7 +443,7 @@ export function mapSyntaxNodeToExpression(
         ifElseExpr.nodeType = "IfElseExpr";
         ifElseExpr.exprList = node.namedChildren
           .map((n) => mapSyntaxNodeToExpression(n))
-          .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+          .filter(Utils.notUndefined);
         return ifElseExpr;
       }
 
@@ -471,9 +469,7 @@ export function mapSyntaxNodeToExpression(
         caseOfExpr.branches = node.namedChildren
           .slice(3)
           .map(mapSyntaxNodeToExpression)
-          .filter(
-            Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-          ) as ECaseOfBranch[];
+          .filter(Utils.notUndefined) as ECaseOfBranch[];
         return caseOfExpr;
       }
 
@@ -515,7 +511,7 @@ export function mapSyntaxNodeToExpression(
         tupleExpr.nodeType = "TupleExpr";
         tupleExpr.exprList = node.namedChildren
           .map(mapSyntaxNodeToExpression)
-          .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+          .filter(Utils.notUndefined);
         return tupleExpr;
       }
 
@@ -533,9 +529,7 @@ export function mapSyntaxNodeToExpression(
           node,
         )
           ?.map(mapSyntaxNodeToExpression)
-          .filter(
-            Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-          ) as EPattern[];
+          .filter(Utils.notUndefined) as EPattern[];
         return tuplePattern;
       }
 
@@ -547,9 +541,7 @@ export function mapSyntaxNodeToExpression(
           node,
         )
           ?.map(mapSyntaxNodeToExpression)
-          .filter(
-            Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-          ) as ETypeExpression[];
+          .filter(Utils.notUndefined) as ETypeExpression[];
         tupleType.unitExpr = mapSyntaxNodeToExpression(
           node.childForFieldName("unitExpr"),
         ) as EUnitExpr;
@@ -571,7 +563,7 @@ export function mapSyntaxNodeToExpression(
         listPattern.parts = node.namedChildren
           .filter((n) => n.type.includes("pattern"))
           .map(mapSyntaxNodeToExpression)
-          .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+          .filter(Utils.notUndefined);
         return listPattern;
       }
 
@@ -582,7 +574,7 @@ export function mapSyntaxNodeToExpression(
         unionPattern.namedParams = node
           .descendantsOfType("lower_pattern")
           .map(mapSyntaxNodeToExpression)
-          .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression));
+          .filter(Utils.notUndefined);
         unionPattern.argPatterns = node.namedChildren
           .slice(1)
           .filter(
@@ -603,7 +595,7 @@ export function mapSyntaxNodeToExpression(
           parts: node.namedChildren
             .filter((n) => n.type.includes("pattern"))
             .map(mapSyntaxNodeToExpression)
-            .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression)),
+            .filter(Utils.notUndefined),
         } as EConsPattern);
 
       case "record_type": {
@@ -617,9 +609,7 @@ export function mapSyntaxNodeToExpression(
           node,
         )
           ?.map(mapSyntaxNodeToExpression)
-          .filter(
-            Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-          ) as EFieldType[];
+          .filter(Utils.notUndefined) as EFieldType[];
         return recordType;
       }
 
@@ -674,9 +664,7 @@ export function mapSyntaxNodeToExpression(
           node,
         )
           ?.map(mapSyntaxNodeToExpression)
-          .filter(
-            Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-          ) as ELowerPattern[];
+          .filter(Utils.notUndefined) as ELowerPattern[];
         return recordPattern;
       }
 
@@ -689,9 +677,7 @@ export function mapSyntaxNodeToExpression(
         recordExpr.fields =
           (TreeUtils.findAllNamedChildrenOfType("field", node)
             ?.map(mapSyntaxNodeToExpression)
-            .filter(
-              Utils.notUndefined.bind(mapSyntaxNodeToExpression),
-            ) as EField[]) ?? [];
+            .filter(Utils.notUndefined) as EField[]) ?? [];
         return recordExpr;
       }
 
@@ -758,7 +744,7 @@ export function mapTypeAliasDeclaration(
       typeAliasDeclaration,
     )
       ?.map(mapSyntaxNodeToExpression)
-      .filter(Utils.notUndefined.bind(mapSyntaxNodeToExpression)) ?? [];
+      .filter(Utils.notUndefined) ?? [];
   typeAliasDeclaration.typeExpression = mapSyntaxNodeToExpression(
     typeAliasDeclaration.childForFieldName("typeExpression"),
   ) as ETypeExpression;

--- a/src/compiler/utils/expressionTree.ts
+++ b/src/compiler/utils/expressionTree.ts
@@ -129,7 +129,7 @@ export interface ENumberConstant extends SyntaxNode {
   nodeType: "NumberConstant";
   isFloat: boolean;
 }
-interface EStringConstant extends SyntaxNode {
+export interface EStringConstant extends SyntaxNode {
   nodeType: "StringConstant";
 }
 export interface ETypeExpression extends SyntaxNode {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -51,3 +51,17 @@ export const GetDiagnosticsRequest = new RequestType<
   void,
   void
 >("elm/getDiagnostics");
+
+export const FindTestsRequest = new RequestType<
+  IFindTestsParams,
+  IFindTestsResponse,
+  void
+>("elm/findTests");
+
+export interface IFindTestsParams {
+  text: string;
+}
+
+export interface IFindTestsResponse {
+  text: string;
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -68,5 +68,5 @@ export interface IFindTestsResponse {
 }
 
 export type TestSuite =
-  | { tag: "test"; label: string }
-  | { tag: "suite"; label: string; tests: TestSuite[] };
+  | { tag: "test"; label: string | string[] }
+  | { tag: "suite"; label: string | string[]; tests: TestSuite[] };

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -67,6 +67,4 @@ export interface IFindTestsResponse {
   suite?: TestSuite;
 }
 
-export type TestSuite =
-  | { tag: "test"; label: string | string[] }
-  | { tag: "suite"; label: string | string[]; tests: TestSuite[] };
+export type TestSuite = { label: string | string[]; tests?: TestSuite[] };

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,4 +1,5 @@
 import { CodeActionParams, RequestType } from "vscode-languageserver";
+import { URI } from "vscode-uri";
 import { IParams } from "./util/elmWorkspaceMatcher";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -59,9 +60,13 @@ export const FindTestsRequest = new RequestType<
 >("elm/findTests");
 
 export interface IFindTestsParams {
-  text: string;
+  workspaceRoot: URI;
 }
 
 export interface IFindTestsResponse {
-  text: string;
+  suite?: TestSuite;
 }
+
+export type TestSuite =
+  | { tag: "test"; label: string }
+  | { tag: "suite"; label: string; tests: TestSuite[] };

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -60,7 +60,7 @@ export const FindTestsRequest = new RequestType<
 >("elm/findTests");
 
 export interface IFindTestsParams {
-  workspaceRoot: URI;
+  projectFolder: URI;
 }
 
 export interface IFindTestsResponse {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -64,7 +64,12 @@ export interface IFindTestsParams {
 }
 
 export interface IFindTestsResponse {
-  suite?: TestSuite;
+  suites?: TestSuite[];
 }
 
-export type TestSuite = { label: string | string[]; tests?: TestSuite[] };
+export type TestSuite = {
+  label: string | string[];
+  tests?: TestSuite[];
+  file: string;
+  position: { line: number; character: number };
+};

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -68,7 +68,7 @@ export interface IFindTestsResponse {
 }
 
 export type TestSuite = {
-  label: string | string[];
+  label: string;
   tests?: TestSuite[];
   file: string;
   position: { line: number; character: number };

--- a/src/providers/codeAction/addMissingCaseBranchesCodeAction.ts
+++ b/src/providers/codeAction/addMissingCaseBranchesCodeAction.ts
@@ -50,7 +50,7 @@ function getEdits(params: ICodeActionParams, range: Range): TextEdit[] {
     );
     const patterns = branches
       .map((branch) => branch.childForFieldName("pattern"))
-      .filter(Utils.notUndefinedOrNull.bind(getEdits));
+      .filter(Utils.notUndefinedOrNull);
 
     const branchIndent = getSpaces(branches[0].startPosition.column);
     const branchExprIndent = getSpaces(

--- a/src/providers/codeAction/makeExternalDeclarationFromUsageCodeAction.ts
+++ b/src/providers/codeAction/makeExternalDeclarationFromUsageCodeAction.ts
@@ -26,7 +26,7 @@ CodeActionProvider.registerCodeAction({
           );
         }
       })
-      .filter(Utils.notUndefinedOrNull.bind(CodeActionProvider));
+      .filter(Utils.notUndefinedOrNull);
   },
   getFixAllCodeAction: (params: ICodeActionParams): ICodeAction | undefined => {
     return CodeActionProvider.getFixAllCodeAction(
@@ -107,7 +107,7 @@ function getEdits(
           }
         }
       })
-      .filter(Utils.notUndefinedOrNull.bind(getEdits));
+      .filter(Utils.notUndefinedOrNull);
   }
 
   return [];

--- a/src/providers/codeActionLs/removeUnusedCodeAction.ts
+++ b/src/providers/codeActionLs/removeUnusedCodeAction.ts
@@ -34,7 +34,7 @@ CodeActionProvider.registerCodeAction({
           return CodeActionProvider.getCodeAction(params, title, edits);
         }
       })
-      .filter(Utils.notUndefined.bind(this));
+      .filter(Utils.notUndefined);
   },
   getFixAllCodeAction: (params) => {
     const importsMap = new Map<string, Set<string>>();

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1281,7 +1281,7 @@ export class CompletionProvider {
               moduleName,
             );
           })
-          .filter(Utils.notUndefined.bind(this)),
+          .filter(Utils.notUndefined),
       );
 
       alreadyImported = true;

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -486,7 +486,7 @@ export class ElmLsDiagnostics {
 
     const moduleReferences = this.moduleReferencesQuery
       .matches(tree.rootNode)
-      .filter(Utils.notUndefined.bind(this))
+      .filter(Utils.notUndefined)
       .filter(
         (match) =>
           match.captures.length > 0 &&
@@ -529,7 +529,7 @@ export class ElmLsDiagnostics {
 
     const allUsages = this.exposedValueAndTypeUsagesQuery
       .matches(tree.rootNode)
-      .filter(Utils.notUndefined.bind(this));
+      .filter(Utils.notUndefined);
     exposedValuesAndTypes.forEach((exposedValueOrType) => {
       if (exposedValueOrType.text.endsWith("(..)")) {
         return;
@@ -565,7 +565,7 @@ export class ElmLsDiagnostics {
 
     const allAliasReferences = this.moduleAliasReferencesQuery
       .matches(tree.rootNode)
-      .filter(Utils.notUndefined.bind(this))
+      .filter(Utils.notUndefined)
       .filter((match) => match.captures.length > 0)
       .map((match) => match.captures[0].node.text);
 
@@ -602,7 +602,7 @@ export class ElmLsDiagnostics {
     const scopeCache = new SyntaxNodeMap<SyntaxNode, QueryResult[]>();
 
     patternMatches
-      .filter(Utils.notUndefined.bind(this))
+      .filter(Utils.notUndefined)
       .flatMap((match) => {
         let scope = match.captures[0].node;
         const patternMatch = match.captures[1].node;
@@ -636,7 +636,7 @@ export class ElmLsDiagnostics {
           .getOrSet(scope, () =>
             this.patternReferencesQuery
               .matches(scope)
-              .filter(Utils.notUndefined.bind(this)),
+              .filter(Utils.notUndefined),
           )
           .filter(
             (result) =>
@@ -939,7 +939,7 @@ export class ElmLsDiagnostics {
 
     const typeAliasUsages = this.typeAliasUsagesQuery
       .matches(tree.rootNode)
-      .filter(Utils.notUndefined.bind(this));
+      .filter(Utils.notUndefined);
 
     typeAliases.forEach((typeAlias) => {
       const references = typeAliasUsages.filter(
@@ -983,7 +983,7 @@ export class ElmLsDiagnostics {
 
     const unionVariantUsages = this.unionVariantUsagesQuery
       .matches(tree.rootNode)
-      .filter(Utils.notUndefined.bind(this));
+      .filter(Utils.notUndefined);
 
     unionVariants.forEach(([unionVariant, typeName]) => {
       const references = unionVariantUsages.filter(

--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -720,7 +720,7 @@ export class ElmLsDiagnostics {
     const caseExpressions = this.booleanCaseExpressionsQuery
       .matches(tree.rootNode)
       .map((match) => match.captures[0].node.parent)
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     caseExpressions.forEach((caseExpr) => {
       diagnostics.push({
@@ -741,7 +741,7 @@ export class ElmLsDiagnostics {
     const listExpressions = this.concatOfListsQuery
       .matches(tree.rootNode)
       .map((match) => [match.captures[0].node, match.captures[1].node])
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     listExpressions.forEach(([startList, endList]) => {
       diagnostics.push({
@@ -765,7 +765,7 @@ export class ElmLsDiagnostics {
     const consExpressions = this.consOfItemAndListQuery
       .matches(tree.rootNode)
       .map((match) => [match.captures[0].node, match.captures[1].node])
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     consExpressions.forEach(([itemExpr, listExpr]) => {
       diagnostics.push({
@@ -789,7 +789,7 @@ export class ElmLsDiagnostics {
     const concatExpressions = this.useConsOverConcatQuery
       .matches(tree.rootNode)
       .map((match) => [match.captures[0].node, match.captures[1].node])
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     concatExpressions.forEach(([firstPart, lastPart]) => {
       diagnostics.push({
@@ -817,7 +817,7 @@ export class ElmLsDiagnostics {
     const recordTypes = this.singleFieldRecordTypesQuery
       .matches(tree.rootNode)
       .map((match) => match.captures[0].node)
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     recordTypes.forEach((recordType) => {
       let isSingleField = true;
@@ -857,7 +857,7 @@ export class ElmLsDiagnostics {
     const listConcats = this.unnecessaryListConcatQuery
       .matches(tree.rootNode)
       .map((match) => match.captures[0].node)
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     listConcats.forEach((listConcat) => {
       diagnostics.push({
@@ -901,7 +901,7 @@ export class ElmLsDiagnostics {
     const operatorFunctions = this.operatorFunctionsQuery
       .matches(tree.rootNode)
       .map((match) => match.captures[0].node)
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     operatorFunctions.forEach((operatorFunction) => {
       diagnostics.push({
@@ -935,7 +935,7 @@ export class ElmLsDiagnostics {
     const typeAliases = this.typeAliasesQuery
       .matches(tree.rootNode)
       .map((match) => match.captures[0].node)
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     const typeAliasUsages = this.typeAliasUsagesQuery
       .matches(tree.rootNode)
@@ -979,7 +979,7 @@ export class ElmLsDiagnostics {
     const unionVariants = this.unionVariantsQuery
       .matches(tree.rootNode)
       .map((match) => [match.captures[1].node, match.captures[0].node])
-      .filter(Utils.notUndefinedOrNull.bind(this));
+      .filter(Utils.notUndefinedOrNull);
 
     const unionVariantUsages = this.unionVariantUsagesQuery
       .matches(tree.rootNode)

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -33,17 +33,17 @@ export class FindTestsProvider {
     const connection = container.resolve<Connection>("Connection");
     connection.onRequest(FindTestsRequest, (params: IFindTestsParams) => {
       connection.console.info(
-        `Finding tests is requested ${params.workspaceRoot.toString()}`,
+        `Finding tests is requested ${params.projectFolder.toString()}`,
       );
       try {
         const elmWorkspaces: Program[] = container.resolve("ElmWorkspaces");
         const program = elmWorkspaces.find(
           (program) =>
-            program.getRootPath().toString() == params.workspaceRoot.toString(),
+            program.getRootPath().toString() == params.projectFolder.toString(),
         );
         if (!program) {
           // TODO dedicated error?
-          throw new NoWorkspaceContainsError(params.workspaceRoot);
+          throw new NoWorkspaceContainsError(params.projectFolder);
         }
         const typeChecker = program.getTypeChecker();
         const suites: TestSuite[] = Array.from(
@@ -84,7 +84,7 @@ export class FindTestsProvider {
         connection.console.info(
           `Found ${
             suites.length
-          } top test suites in ${params.workspaceRoot.toString()}`,
+          } top test suites in ${params.projectFolder.toString()}`,
         );
         return <IFindTestsResponse>{ suites };
       } catch (err) {

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -1,6 +1,9 @@
 import { container } from "tsyringe";
-import { Connection } from "vscode-languageserver";
+import { Connection, ResponseError } from "vscode-languageserver";
 import { SyntaxNode } from "web-tree-sitter";
+import { Program } from "../compiler/program";
+import { createTypeChecker, TypeChecker } from "../compiler/typeChecker";
+import { TFunction, TUnion, Type } from "../compiler/typeInference";
 import {
   EFunctionCallExpr,
   EValueExpr,
@@ -13,7 +16,9 @@ import {
   FindTestsRequest,
   IFindTestsParams,
   IFindTestsResponse,
+  TestSuite,
 } from "../protocol";
+import { NoWorkspaceContainsError } from "../util/noWorkspaceContainsError";
 import { TreeUtils } from "../util/treeUtils";
 
 export class FindTestsProvider {
@@ -24,41 +29,111 @@ export class FindTestsProvider {
   private register(): void {
     const connection = container.resolve<Connection>("Connection");
     connection.onRequest(FindTestsRequest, (params: IFindTestsParams) => {
-      connection.console.info(`Finding tests is requested`);
-      connection.window.showInformationMessage("hello there " + params.text);
-      connection.console.log("hello there " + params.text);
-      // connection.sendNotification(NotificationType, {});
-      return <IFindTestsResponse>{ text: "echo " + params.text };
+      connection.console.info(
+        `Finding tests is requested ${params.workspaceRoot}`,
+      );
+      try {
+        const elmWorkspaces: Program[] = container.resolve("ElmWorkspaces");
+        const program = elmWorkspaces.find(
+          (program) =>
+            program.getRootPath().toString() == params.workspaceRoot.toString(),
+        );
+        if (!program) {
+          // TODO dedicated error?
+          throw new NoWorkspaceContainsError(params.workspaceRoot);
+        }
+        const typeChecker = program.getTypeChecker();
+        const tests = Array.from(program.getForest().treeMap.values())
+          .filter((sourceFile) => sourceFile.isTestFile)
+          .flatMap((sourceFile) => {
+            connection.console.info(`Finding tests is in ${sourceFile.uri}`);
+            return TreeUtils.findAllTopLevelFunctionDeclarations(
+              sourceFile.tree,
+            );
+          })
+          .map((top) => {
+            connection.console.info(`Finding tests is in top ${top?.id}`);
+            return (
+              top &&
+              findTestSuite(findTestFunctionCall(top, typeChecker), typeChecker)
+            );
+          })
+          .flatMap((s) => (s ? [s] : []));
+        const suite: TestSuite = {
+          tag: "suite",
+          label: program.getRootPath().path,
+          tests,
+        };
+        connection.console.info(
+          `Found ${tests.length} tests in ${params.workspaceRoot}`,
+        );
+        return <IFindTestsResponse>{ suite };
+      } catch (err) {
+        console.log("FW", err);
+        connection.console.error(`Error finding tests`);
+        return new ResponseError(13, "boom");
+      }
     });
   }
 }
 
 // export for testing
-export type TestSuite =
-  | { tag: "test"; label: string }
-  | { tag: "suite"; label: string; tests: TestSuite[] };
-
-// export for testing
 export function findTestFunctionCall(
   node: SyntaxNode,
+  typeChecker: TypeChecker,
 ): EFunctionCallExpr | undefined {
-  return findExpr("FunctionCallExpr", node);
+  const call = findExpr("FunctionCallExpr", node);
+  if (!call) {
+    return undefined;
+  }
+  const t: Type = typeChecker.findType(call);
+  // TODO why are there two cases here?
+  if (t.nodeType === "Function") {
+    if (
+      t.return.nodeType === "Union" &&
+      // TODO adjust test fixture!
+      (t.return.module === "Test" || t.return.module === "Test.Internal") &&
+      t.return.name === "Test"
+    ) {
+      return call;
+    }
+  }
+  if (
+    t.nodeType === "Union" &&
+    // TODO adjust test fixture!
+    (t.module === "Test" || t.module === "Test.Internal") &&
+    t.name === "Test"
+  ) {
+    return call;
+  }
+  console.log("FW", t);
+  return undefined;
+}
+
+function isTestSuite(
+  call: EFunctionCallExpr,
+  typeChecker: TypeChecker,
+): boolean {
+  const funName = findExpr("ValueExpr", call.target)?.name;
+  // const t: Type = typeChecker.findType(call);
+  // console.log("FW", t);
+  return funName === "describe";
 }
 
 // export for testing
 export function findTestSuite(
   call: EFunctionCallExpr | undefined,
+  typeChecker: TypeChecker,
 ): TestSuite | undefined {
   if (!call) {
     return undefined;
   }
-  const funName = findExpr("ValueExpr", call.target)?.name;
   const label = findExpr("StringConstant", call.args[0])?.text;
-  if (label && funName === "describe") {
+  if (label && isTestSuite(call, typeChecker)) {
     const testExprs = findExpr("ListExpr", call.args[1])?.exprList;
     const tests = testExprs
-      ?.map((e) => findTestFunctionCall(e))
-      .map((call) => findTestSuite(call));
+      ?.map((e) => findTestFunctionCall(e, typeChecker))
+      .map((call) => findTestSuite(call, typeChecker));
     return tests && <TestSuite>{ tag: "suite", label, tests };
   }
   return label ? <TestSuite>{ tag: "test", label } : undefined;

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -64,7 +64,6 @@ export class FindTestsProvider {
           })
           .flatMap((s) => (s ? [s] : []));
         const suite: TestSuite = {
-          tag: "suite",
           label: program.getRootPath().path,
           tests,
         };
@@ -153,9 +152,9 @@ export function findTestSuite(
     const tests = testExprs
       ?.map((e) => findTestFunctionCall(e, typeChecker))
       .map((call) => findTestSuite(call, sourceFile, typeChecker));
-    return tests && <TestSuite>{ tag: "suite", label, tests };
+    return tests && <TestSuite>{ label, tests };
   }
-  return label ? <TestSuite>{ tag: "test", label } : undefined;
+  return label ? <TestSuite>{ label } : undefined;
 }
 
 type ExpressionNodeTypes = {

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -1,6 +1,5 @@
 import { container } from "tsyringe";
 import { Connection, ResponseError } from "vscode-languageserver";
-import { URI } from "vscode-uri";
 import { SyntaxNode } from "web-tree-sitter";
 import { ISourceFile } from "../compiler/forest";
 import { Program } from "../compiler/program";
@@ -81,11 +80,15 @@ export function findTestFunctionCall(
   node: SyntaxNode,
   typeChecker: TypeChecker,
 ): EFunctionCallExpr | undefined {
-  // console.log("FW0", typeChecker.typeToString(typeChecker.findType(node)));
   const call = findExpr("FunctionCallExpr", node);
   if (!call) {
     return undefined;
   }
+  // console.log(
+  //   "FW0",
+  //   findExpr("ValueExpr", call?.target)?.name,
+  //   typeChecker.typeToString(typeChecker.findType(node)),
+  // );
   const t: Type = typeChecker.findType(call);
   // TODO why are there two cases here?
   if (t.nodeType === "Function") {
@@ -105,7 +108,7 @@ export function findTestFunctionCall(
   ) {
     return call;
   }
-  console.log("FW", t);
+  // console.log("FW", findExpr("ValueExpr", call.target)?.name, t);
   return undefined;
 }
 
@@ -161,7 +164,7 @@ export function findTestSuite(
     line: call.startPosition.row,
     character: call.startPosition.column,
   };
-  // TODO relative to workspace
+  // TODO relative to workspace?
   const file = sourceFile.uri.toString();
   const label = labelParts?.length === 1 ? labelParts[0] : labelParts;
   if (label && isTestSuite(call, sourceFile, typeChecker)) {

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -85,7 +85,10 @@ export function findTestFunctionCall(
   typeChecker: TypeChecker,
 ): EFunctionCallExpr | undefined {
   const letIn = findExpr("LetInExpr", node);
-  const call = findExpr("FunctionCallExpr", letIn?.body ?? node);
+  if (letIn) {
+    return findTestFunctionCall(letIn.body, typeChecker);
+  }
+  const call = findExpr("FunctionCallExpr", node);
   if (!call) {
     return undefined;
   }

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -149,7 +149,7 @@ function isTestSuite(
       : "";
   const moduleName =
     prefix !== undefined
-      ? typeChecker.findImportModuleNameNode(prefix, sourceFile)?.text
+      ? typeChecker.findImportModuleNameNodes(prefix, sourceFile)[0]?.text
       : "Test";
   return (
     qualifier !== undefined &&

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -91,8 +91,7 @@ export function findTestFunctionCall(
   if (t.nodeType === "Function") {
     if (
       t.return.nodeType === "Union" &&
-      // TODO adjust test fixture!
-      (t.return.module === "Test" || t.return.module === "Test.Internal") &&
+      t.return.module === "Test.Internal" &&
       t.return.name === "Test"
     ) {
       return call;
@@ -100,8 +99,7 @@ export function findTestFunctionCall(
   }
   if (
     t.nodeType === "Union" &&
-    // TODO adjust test fixture!
-    (t.module === "Test" || t.module === "Test.Internal") &&
+    t.module === "Test.Internal" &&
     t.name === "Test"
   ) {
     return call;

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -2,8 +2,8 @@ import { container } from "tsyringe";
 import { Connection, ResponseError } from "vscode-languageserver";
 import { SyntaxNode } from "web-tree-sitter";
 import { Program } from "../compiler/program";
-import { createTypeChecker, TypeChecker } from "../compiler/typeChecker";
-import { TFunction, TUnion, Type } from "../compiler/typeInference";
+import { TypeChecker } from "../compiler/typeChecker";
+import { Type } from "../compiler/typeInference";
 import {
   EFunctionCallExpr,
   EValueExpr,
@@ -113,9 +113,10 @@ function isTestSuite(
   typeChecker: TypeChecker,
 ): boolean {
   const funName = findExpr("ValueExpr", call.target)?.name;
+  const t: Type = typeChecker.findType(call.target);
   // const t: Type = typeChecker.findType(call);
-  // console.log("FW", t);
-  return funName === "describe";
+  // console.log("FW1", funName, t);
+  return funName === "describe" || funName === "Test.describe";
 }
 
 // export for testing

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -12,6 +12,7 @@ import {
   EListExpr,
   mapSyntaxNodeToExpression,
   Expression,
+  ELetInExpr,
 } from "../compiler/utils/expressionTree";
 import {
   FindTestsRequest,
@@ -80,7 +81,8 @@ export function findTestFunctionCall(
   node: SyntaxNode,
   typeChecker: TypeChecker,
 ): EFunctionCallExpr | undefined {
-  const call = findExpr("FunctionCallExpr", node);
+  const letIn = findExpr("LetInExpr", node);
+  const call = findExpr("FunctionCallExpr", letIn?.body ?? node);
   if (!call) {
     return undefined;
   }
@@ -182,6 +184,7 @@ type ExpressionNodeTypes = {
   StringConstant: EStringConstant;
   ListExpr: EListExpr;
   FunctionCallExpr: EFunctionCallExpr;
+  LetInExpr: ELetInExpr;
 };
 
 type TypeExpressionNodeTypes = {
@@ -189,6 +192,7 @@ type TypeExpressionNodeTypes = {
   string_constant_expr: EStringConstant;
   list_expr: EListExpr;
   function_call_expr: EFunctionCallExpr;
+  let_in_expr: ELetInExpr;
 };
 
 const typeByNodeType: Map<
@@ -199,6 +203,7 @@ const typeByNodeType: Map<
   ["StringConstant", "string_constant_expr"],
   ["ListExpr", "list_expr"],
   ["FunctionCallExpr", "function_call_expr"],
+  ["LetInExpr", "let_in_expr"],
 ]);
 
 function findExpr<K extends keyof ExpressionNodeTypes>(

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -80,7 +80,7 @@ export function findAllTestSuites(program: IProgram): TestSuite[] {
         );
       });
     })
-    .filter(Utils.notUndefinedOrNull);
+    .filter(Utils.notUndefined);
 }
 
 // export for testing
@@ -182,7 +182,7 @@ export function findTestSuite(
     const tests: TestSuite[] | undefined = testExprs
       ?.map((e) => findTestFunctionCall(e, typeChecker))
       .map((call) => findTestSuite(call, sourceFile, typeChecker))
-      .filter(Utils.notUndefinedOrNull);
+      .filter(Utils.notUndefined);
     return tests && <TestSuite>{ label, tests, file, position };
   }
   return label ? <TestSuite>{ label, file, position } : undefined;

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -189,7 +189,7 @@ export function findTestSuite(
   };
   // TODO relative to workspace?
   const file = sourceFile.uri.toString();
-  const label = labelParts?.length === 1 ? labelParts[0] : labelParts;
+  const label = labelParts?.length === 1 ? labelParts[0] : undefined;
   if (label && isTestSuite(call, sourceFile, typeChecker)) {
     const testExprs = findExpr("ListExpr", call.args[1])?.exprList;
     const tests: TestSuite[] | undefined = testExprs

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -33,7 +33,7 @@ export class FindTestsProvider {
     const connection = container.resolve<Connection>("Connection");
     connection.onRequest(FindTestsRequest, (params: IFindTestsParams) => {
       connection.console.info(
-        `Finding tests is requested ${params.workspaceRoot}`,
+        `Finding tests is requested ${params.workspaceRoot.toString()}`,
       );
       try {
         const elmWorkspaces: Program[] = container.resolve("ElmWorkspaces");
@@ -68,7 +68,9 @@ export class FindTestsProvider {
           })
           .filter(Utils.notUndefinedOrNull.bind(this));
         connection.console.info(
-          `Found ${suites.length} test suites in ${params.workspaceRoot}`,
+          `Found ${
+            suites.length
+          } test suites in ${params.workspaceRoot.toString()}`,
         );
         return <IFindTestsResponse>{ suites };
       } catch (err) {
@@ -180,7 +182,7 @@ export function findTestSuite(
     const tests = testExprs
       ?.map((e) => findTestFunctionCall(e, typeChecker))
       .map((call) => findTestSuite(call, sourceFile, typeChecker))
-      .filter(Utils.notUndefinedOrNull);
+      .filter((s) => Utils.notUndefinedOrNull(s));
     return tests && <TestSuite>{ label, tests, file, position };
   }
   return label ? <TestSuite>{ label, file, position } : undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import { ElmLsDiagnostics } from "./providers/diagnostics/elmLsDiagnostics";
 import { FileEventsHandler } from "./providers/handlers/fileEventsHandler";
 import { Settings } from "./util/settings";
 import { TextDocumentEvents } from "./util/textDocumentEvents";
+import { FindTestsProvider } from "./providers/findTestsProvider";
 
 export interface ILanguageServer {
   readonly capabilities: InitializeResult;
@@ -190,6 +191,8 @@ export class Server implements ILanguageServer {
     new RenameProvider();
     new FileEventsHandler();
     new LinkedEditingRangesProvider();
+
+    new FindTestsProvider();
   }
 
   private getElmJsonFolder(uri: string): URI {

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -3,7 +3,7 @@ import { Range, TextEdit } from "vscode-languageserver";
 export type NonEmptyArray<T> = [T, ...T[]];
 
 export class Utils {
-  public static notUndefined<T>(x: T | undefined): x is T {
+  public static notUndefined<T>(this: void, x: T | undefined): x is T {
     return x !== undefined;
   }
 

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -7,7 +7,10 @@ export class Utils {
     return x !== undefined;
   }
 
-  public static notUndefinedOrNull<T>(x: T | undefined | null): x is T {
+  public static notUndefinedOrNull<T>(
+    this: void,
+    x: T | undefined | null,
+  ): x is T {
     return x !== undefined && x !== null;
   }
 

--- a/test/findTests.test.ts
+++ b/test/findTests.test.ts
@@ -1,0 +1,143 @@
+import { getSourceFiles } from "./utils/sourceParser";
+import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+import { URI } from "vscode-uri";
+import { TreeUtils } from "../src/util/treeUtils";
+import {
+  EFunctionCallExpr,
+  EListExpr,
+  EValueExpr,
+  EStringConstant,
+  Expression,
+  mapSyntaxNodeToExpression,
+} from "../src/compiler/utils/expressionTree";
+import { SyntaxNode } from "web-tree-sitter";
+
+const source = `
+--@ TestModule.elm
+module TestModule exposing (..)
+
+import Expect
+import Test exposing (..)
+
+topSuite : Test
+topSuite =
+    describe "top suite"
+        [ test "first" <| \_ -> Expect.equal 13 13
+        , describe "nested"
+            [ test "second" <| \_ -> Expect.equal 14 14
+            ]
+        ]
+`;
+
+describe("find tests", () => {
+  const treeParser = new SourceTreeParser();
+
+  async function testFindTests(source: string, expected: TestSuite[]) {
+    await treeParser.init();
+
+    const sources = getSourceFiles(source);
+    const testModuleUri = URI.file(baseUri + "TestModule.elm").toString();
+
+    const program = await treeParser.getProgram(sources);
+    const sourceFile = program.getSourceFile(testModuleUri);
+    expect(sourceFile).not.toBeUndefined;
+    if (!sourceFile) {
+      throw new Error("parsing failed");
+    }
+    expect(sourceFile.isTestFile).toBeTruthy;
+
+    const tops = TreeUtils.findAllTopLevelFunctionDeclarations(sourceFile.tree);
+
+    const suites = tops
+      ? tops.map((top) => findTestSuite(findExpr("FunctionCallExpr", top)))
+      : [];
+    expect(suites).toEqual(expected);
+  }
+
+  test("first", async () => {
+    await testFindTests(source, [
+      {
+        tag: "suite",
+        label: '"top suite"',
+        tests: [
+          { tag: "test", label: '"first"' },
+          {
+            tag: "suite",
+            label: '"nested"',
+            tests: [{ tag: "test", label: '"second"' }],
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+type TestSuite =
+  | { tag: "test"; label: string }
+  | { tag: "suite"; label: string; tests: TestSuite[] };
+
+function findTestSuite(
+  call: EFunctionCallExpr | undefined,
+): TestSuite | undefined {
+  if (!call) {
+    return undefined;
+  }
+  const funName = findExpr("ValueExpr", call.target)?.name;
+  const label = findExpr("StringConstant", call.args[0])?.text;
+  if (label && funName === "describe") {
+    const testExprs = findExpr("ListExpr", call.args[1])?.exprList;
+    const tests = testExprs
+      ?.map((e) => findExpr("FunctionCallExpr", e))
+      .map((call) => findTestSuite(call));
+    return tests && <TestSuite>{ tag: "suite", label, tests };
+  }
+  return label ? <TestSuite>{ tag: "test", label } : undefined;
+}
+
+type ExpressionNodeTypes = {
+  ValueExpr: EValueExpr;
+  StringConstant: EStringConstant;
+  ListExpr: EListExpr;
+  FunctionCallExpr: EFunctionCallExpr;
+};
+
+type TypeExpressionNodeTypes = {
+  value_expr: EValueExpr;
+  string_constant_expr: EStringConstant;
+  list_expr: EListExpr;
+  function_call_expr: EFunctionCallExpr;
+};
+
+const typeByNodeType: Map<
+  keyof ExpressionNodeTypes,
+  keyof TypeExpressionNodeTypes
+> = new Map([
+  ["ValueExpr", "value_expr"],
+  ["StringConstant", "string_constant_expr"],
+  ["ListExpr", "list_expr"],
+  ["FunctionCallExpr", "function_call_expr"],
+]);
+
+function findExpr<K extends keyof ExpressionNodeTypes>(
+  key: K,
+  node: SyntaxNode | undefined,
+): ExpressionNodeTypes[K] | undefined {
+  if (!node) {
+    return undefined;
+  }
+  const type = typeByNodeType.get(key);
+  if (!type) {
+    return undefined;
+  }
+  const n =
+    node.type === type ? node : TreeUtils.findFirstNamedChildOfType(type, node);
+  const e = mapSyntaxNodeToExpression(n);
+  return e && mapExpr(key, e);
+}
+
+function mapExpr<K extends keyof ExpressionNodeTypes>(
+  k: K,
+  e: Expression,
+): ExpressionNodeTypes[K] | undefined {
+  return e?.nodeType === k ? (e as ExpressionNodeTypes[K]) : undefined;
+}

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -5,8 +5,8 @@ import { TreeUtils } from "../src/util/treeUtils";
 import {
   findTestFunctionCall,
   findTestSuite,
-  TestSuite,
 } from "../src/providers/findTestsProvider";
+import { TestSuite } from "../src/protocol";
 
 const basicsSources = `
 --@ Basics.elm
@@ -30,12 +30,18 @@ apL f x =
 `;
 
 const sourceTestModule = `
+--@ TestInternal.elm
+module Test.Internal exposing (Test(..))
+
+type Test = T
+
 --@ Test.elm
 module Test exposing (Test(..), describe, test)
 
 import Expect exposing (..)
+import Test.Internal as Internal
 
-type Test = T
+type alias Test = Internal.Test
 
 describe : String -> List Test -> Test
 describe untrimmedDesc tests = T

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -133,7 +133,7 @@ topSuite =
 
     await testFindTests(source, [
       {
-        label: '"top suite"',
+        label: "top suite",
         file: testModuleUri,
         position: { line: 6, character: 4 },
         tests: [],
@@ -161,22 +161,22 @@ topSuite =
 
     await testFindTests(source, [
       {
-        label: '"top suite"',
+        label: "top suite",
         file: testModuleUri,
         position: { line: 7, character: 4 },
         tests: [
           {
-            label: '"first"',
+            label: "first",
             file: testModuleUri,
             position: { line: 8, character: 6 },
           },
           {
-            label: '"nested"',
+            label: "nested",
             file: testModuleUri,
             position: { line: 9, character: 6 },
             tests: [
               {
-                label: '"second"',
+                label: "second",
                 file: testModuleUri,
                 position: { line: 10, character: 10 },
               },
@@ -201,7 +201,7 @@ topSuite = describe "top suite" []
 
     await testFindTests(source, [
       {
-        label: '"top suite"',
+        label: "top suite",
         file: testModuleUri,
         position: { line: 6, character: 11 },
         tests: [],
@@ -231,10 +231,45 @@ topSuite =
 
     await testFindTests(source, [
       {
-        label: '"top suite"',
+        label: "top suite",
         file: testModuleUri,
         position: { line: 14, character: 4 },
         tests: [],
+      },
+    ]);
+  });
+
+  test("with deep let/in", async () => {
+    const source = `
+--@ MyModule.elm
+module MyModule exposing (..)
+
+import Test exposing (..)
+
+topSuite : Test
+topSuite =
+    describe "top suite"
+        [ let
+            a =
+                doit 13
+          in
+          describe "deeper suite" []
+        ]
+`;
+
+    await testFindTests(source, [
+      {
+        label: "top suite",
+        file: testModuleUri,
+        position: { line: 6, character: 4 },
+        tests: [
+          {
+            label: "deeper suite",
+            file: testModuleUri,
+            position: { line: 11, character: 10 },
+            tests: [],
+          },
+        ],
       },
     ]);
   });
@@ -251,7 +286,7 @@ topSuite = Test.describe "top suite" []
 
     await testFindTests(source, [
       {
-        label: '"top suite"',
+        label: "top suite",
         file: testModuleUri,
         position: { line: 4, character: 11 },
         tests: [],
@@ -271,7 +306,7 @@ topSuite = T.describe "top suite" []
 
     await testFindTests(source, [
       {
-        label: '"top suite"',
+        label: "top suite",
         file: testModuleUri,
         position: { line: 4, character: 11 },
         tests: [],
@@ -291,7 +326,7 @@ topSuite = describe ("top suite" ++ "13") []
 
     await testFindTests(source, [
       {
-        label: ['"top suite"', '"13"'],
+        label: ["top suite", "13"],
         file: testModuleUri,
         position: { line: 4, character: 11 },
         tests: [],
@@ -313,7 +348,7 @@ top = fuzz int "top fuzz" <| \_ -> Expect.equal True True
 
     await testFindTests(source, [
       {
-        label: '"top fuzz"',
+        label: "top fuzz",
         file: testModuleUri,
         position: { line: 6, character: 6 },
       },
@@ -339,7 +374,7 @@ top = myTest 13 "my top" True
 
     await testFindTests(source, [
       {
-        label: '"top fuzz"',
+        label: "top fuzz",
         file: testModuleUri,
         position: { line: 5, character: 6 },
       },

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -208,6 +208,32 @@ topSuite = describe "top suite" []
     ]);
   });
 
+  test("with let/in", async () => {
+    const source = `
+--@ MyModule.elm
+module MyModule exposing (..)
+
+import Test exposing (..)
+
+topSuite : Test
+topSuite =
+    let
+        foo =
+            doit bar
+    in
+    describe "top suite" [] 
+`;
+
+    await testFindTests(source, [
+      {
+        label: '"top suite"',
+        file: testModuleUri,
+        position: { line: 10, character: 4 },
+        tests: [],
+      },
+    ]);
+  });
+
   test("import without expose", async () => {
     const source = `
 --@ MyModule.elm

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -123,7 +123,6 @@ describe("FindTestsProvider", () => {
 --@ MyModule.elm
 module MyModule exposing (..)
 
-import Expect
 import Test exposing (..)
 
 topSuite : Test
@@ -135,7 +134,7 @@ topSuite =
       {
         label: '"top suite"',
         file: testModuleUri,
-        position: { line: 7, character: 4 },
+        position: { line: 6, character: 4 },
         tests: [],
       },
     ]);
@@ -269,15 +268,42 @@ topSuite = describe ("top suite" ++ "13") []
     ]);
   });
 
-  test("fuzz label", async () => {
+  test("fuzz", async () => {
     const source = `
 --@ MyModule.elm 
 module MyModule exposing (..)
 
+import Expect
 import Test exposing (..)
 import Fuzz exposing (..)
 
 top = fuzz int "top fuzz" <| \_ -> Expect.equal True True
+`;
+
+    await testFindTests(source, [
+      {
+        label: '"top fuzz"',
+        file: testModuleUri,
+        position: { line: 6, character: 6 },
+      },
+    ]);
+  });
+
+  // TODO improve inferred types?!
+  test.skip("any test function", async () => {
+    const source = `
+--@ MyModule.elm 
+module MyModule exposing (..)
+
+import Expect 
+import Test exposing (..)
+
+myTest : Int -> String -> Bool -> Test
+myTest i desc b =
+    describe desc []
+
+top : Test
+top = myTest 13 "my top" True  
 `;
 
     await testFindTests(source, [

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -222,6 +222,10 @@ topSuite =
         foo =
             doit bar
     in
+    let
+        foo =
+            doit bar
+    in
     describe "top suite" [] 
 `;
 
@@ -229,7 +233,7 @@ topSuite =
       {
         label: '"top suite"',
         file: testModuleUri,
-        position: { line: 10, character: 4 },
+        position: { line: 14, character: 4 },
         tests: [],
       },
     ]);

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -122,7 +122,6 @@ topSuite =
 
     await testFindTests(source, [
       {
-        tag: "suite",
         label: '"top suite"',
         tests: [],
       },
@@ -149,14 +148,12 @@ topSuite =
 
     await testFindTests(source, [
       {
-        tag: "suite",
         label: '"top suite"',
         tests: [
-          { tag: "test", label: '"first"' },
+          { label: '"first"' },
           {
-            tag: "suite",
             label: '"nested"',
-            tests: [{ tag: "test", label: '"second"' }],
+            tests: [{ label: '"second"' }],
           },
         ],
       },
@@ -177,7 +174,6 @@ topSuite = describe "top suite" []
 
     await testFindTests(source, [
       {
-        tag: "suite",
         label: '"top suite"',
         tests: [],
       },
@@ -196,7 +192,6 @@ topSuite = Test.describe "top suite" []
 
     await testFindTests(source, [
       {
-        tag: "suite",
         label: '"top suite"',
         tests: [],
       },
@@ -215,7 +210,6 @@ topSuite = T.describe "top suite" []
 
     await testFindTests(source, [
       {
-        tag: "suite",
         label: '"top suite"',
         tests: [],
       },
@@ -234,7 +228,6 @@ topSuite = describe ("top suite" ++ "13") []
 
     await testFindTests(source, [
       {
-        tag: "suite",
         label: ['"top suite"', '"13"'],
         tests: [],
       },

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -82,7 +82,11 @@ describe("FindTestsProvider", () => {
     const suites = tops
       ? tops
           .map((top) =>
-            findTestSuite(findTestFunctionCall(top, typeChecker), typeChecker),
+            findTestSuite(
+              findTestFunctionCall(top, typeChecker),
+              sourceFile,
+              typeChecker,
+            ),
           )
           .reduce((acc, s) => (s ? [...acc, s] : acc), [])
       : [];
@@ -174,6 +178,25 @@ module MyModule exposing (..)
 import Test
 
 topSuite = Test.describe "top suite" []
+`;
+
+    await testFindTests(source, [
+      {
+        tag: "suite",
+        label: '"top suite"',
+        tests: [],
+      },
+    ]);
+  });
+
+  test("import with alias", async () => {
+    const source = `
+--@ MyModule.elm
+module MyModule exposing (..)
+
+import Test as T 
+
+topSuite = T.describe "top suite" []
 `;
 
     await testFindTests(source, [

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -80,9 +80,11 @@ describe("FindTestsProvider", () => {
     const typeChecker = program.getTypeChecker();
 
     const suites = tops
-      ? tops.map((top) =>
-          findTestSuite(findTestFunctionCall(top, typeChecker), typeChecker),
-        )
+      ? tops
+          .map((top) =>
+            findTestSuite(findTestFunctionCall(top, typeChecker), typeChecker),
+          )
+          .reduce((acc, s) => (s ? [...acc, s] : acc), [])
       : [];
     expect(suites).toEqual(expected);
   }
@@ -109,7 +111,7 @@ topSuite =
     ]);
   });
 
-  test("first", async () => {
+  test("some", async () => {
     const source = `
 --@ MyModule.elm
 module MyModule exposing (..)
@@ -139,6 +141,27 @@ topSuite =
             tests: [{ tag: "test", label: '"second"' }],
           },
         ],
+      },
+    ]);
+  });
+
+  test("ignore non Test top levels", async () => {
+    const source = `
+--@ MyModule.elm
+module MyModule exposing (..)
+
+import Test exposing (..)
+
+someThingElse = True
+
+topSuite = describe "top suite" []
+`;
+
+    await testFindTests(source, [
+      {
+        tag: "suite",
+        label: '"top suite"',
+        tests: [],
       },
     ]);
   });

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -74,12 +74,12 @@ equal aa bb = E
 
 describe("FindTestsProvider", () => {
   const treeParser = new SourceTreeParser();
+  const testModuleUri = URI.file(baseUri + "MyModule.elm").toString();
 
   async function testFindTests(source: string, expected: TestSuite[]) {
     await treeParser.init();
 
     const sources = getSourceFiles(basicsSources + sourceTestModule + source);
-    const testModuleUri = URI.file(baseUri + "MyModule.elm").toString();
 
     const program = await treeParser.getProgram(sources);
     const sourceFile = program.getSourceFile(testModuleUri);
@@ -123,6 +123,8 @@ topSuite =
     await testFindTests(source, [
       {
         label: '"top suite"',
+        file: testModuleUri,
+        position: { line: 7, character: 4 },
         tests: [],
       },
     ]);
@@ -149,11 +151,25 @@ topSuite =
     await testFindTests(source, [
       {
         label: '"top suite"',
+        file: testModuleUri,
+        position: { line: 7, character: 4 },
         tests: [
-          { label: '"first"' },
+          {
+            label: '"first"',
+            file: testModuleUri,
+            position: { line: 8, character: 6 },
+          },
           {
             label: '"nested"',
-            tests: [{ label: '"second"' }],
+            file: testModuleUri,
+            position: { line: 9, character: 6 },
+            tests: [
+              {
+                label: '"second"',
+                file: testModuleUri,
+                position: { line: 10, character: 10 },
+              },
+            ],
           },
         ],
       },
@@ -175,6 +191,8 @@ topSuite = describe "top suite" []
     await testFindTests(source, [
       {
         label: '"top suite"',
+        file: testModuleUri,
+        position: { line: 6, character: 11 },
         tests: [],
       },
     ]);
@@ -193,6 +211,8 @@ topSuite = Test.describe "top suite" []
     await testFindTests(source, [
       {
         label: '"top suite"',
+        file: testModuleUri,
+        position: { line: 4, character: 11 },
         tests: [],
       },
     ]);
@@ -211,6 +231,8 @@ topSuite = T.describe "top suite" []
     await testFindTests(source, [
       {
         label: '"top suite"',
+        file: testModuleUri,
+        position: { line: 4, character: 11 },
         tests: [],
       },
     ]);
@@ -229,6 +251,8 @@ topSuite = describe ("top suite" ++ "13") []
     await testFindTests(source, [
       {
         label: ['"top suite"', '"13"'],
+        file: testModuleUri,
+        position: { line: 4, character: 11 },
         tests: [],
       },
     ]);

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -1,0 +1,69 @@
+import { getSourceFiles } from "./utils/sourceParser";
+import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+import { URI } from "vscode-uri";
+import { TreeUtils } from "../src/util/treeUtils";
+import {
+  findTestFunctionCall,
+  findTestSuite,
+  TestSuite,
+} from "../src/providers/findTestsProvider";
+
+const source = `
+--@ TestModule.elm
+module TestModule exposing (..)
+
+import Expect
+import Test exposing (..)
+
+topSuite : Test
+topSuite =
+    describe "top suite"
+        [ test "first" <| \_ -> Expect.equal 13 13
+        , describe "nested"
+            [ test "second" <| \_ -> Expect.equal 14 14
+            ]
+        ]
+`;
+
+describe("FindTestsProvider", () => {
+  const treeParser = new SourceTreeParser();
+
+  async function testFindTests(source: string, expected: TestSuite[]) {
+    await treeParser.init();
+
+    const sources = getSourceFiles(source);
+    const testModuleUri = URI.file(baseUri + "TestModule.elm").toString();
+
+    const program = await treeParser.getProgram(sources);
+    const sourceFile = program.getSourceFile(testModuleUri);
+    expect(sourceFile).not.toBeUndefined;
+    if (!sourceFile) {
+      throw new Error("parsing failed");
+    }
+    expect(sourceFile.isTestFile).toBeTruthy;
+
+    const tops = TreeUtils.findAllTopLevelFunctionDeclarations(sourceFile.tree);
+
+    const suites = tops
+      ? tops.map((top) => findTestSuite(findTestFunctionCall(top)))
+      : [];
+    expect(suites).toEqual(expected);
+  }
+
+  test("first", async () => {
+    await testFindTests(source, [
+      {
+        tag: "suite",
+        label: '"top suite"',
+        tests: [
+          { tag: "test", label: '"first"' },
+          {
+            tag: "suite",
+            label: '"nested"',
+            tests: [{ tag: "test", label: '"second"' }],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -314,7 +314,7 @@ topSuite = T.describe "top suite" []
     ]);
   });
 
-  test("dynamic label", async () => {
+  test("dynamic label is ignored", async () => {
     const source = `
 --@ MyModule.elm
 module MyModule exposing (..)
@@ -324,14 +324,7 @@ import Test exposing (..)
 topSuite = describe ("top suite" ++ "13") []
 `;
 
-    await testFindTests(source, [
-      {
-        label: undefined,
-        file: testModuleUri,
-        position: { line: 4, character: 11 },
-        tests: [],
-      },
-    ]);
+    await testFindTests(source, []);
   });
 
   test("fuzz", async () => {

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -7,6 +7,7 @@ import {
   findTestSuite,
 } from "../src/providers/findTestsProvider";
 import { TestSuite } from "../src/protocol";
+import { Utils } from "../src/util/utils";
 
 const basicsSources = `
 --@ Basics.elm
@@ -104,7 +105,7 @@ describe("FindTestsProvider", () => {
 
     const typeChecker = program.getTypeChecker();
 
-    const suites = tops
+    const suites: TestSuite[] = tops
       ? tops
           .map((top) =>
             findTestSuite(
@@ -113,7 +114,7 @@ describe("FindTestsProvider", () => {
               typeChecker,
             ),
           )
-          .reduce((acc, s) => (s ? [...acc, s] : acc), [])
+          .filter(Utils.notUndefinedOrNull)
       : [];
     expect(suites).toEqual(expected);
   }

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -165,4 +165,23 @@ topSuite = describe "top suite" []
       },
     ]);
   });
+
+  test("import without expose", async () => {
+    const source = `
+--@ MyModule.elm
+module MyModule exposing (..)
+
+import Test
+
+topSuite = Test.describe "top suite" []
+`;
+
+    await testFindTests(source, [
+      {
+        tag: "suite",
+        label: '"top suite"',
+        tests: [],
+      },
+    ]);
+  });
 });

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -10,9 +10,10 @@ import { TestSuite } from "../src/protocol";
 
 const basicsSources = `
 --@ Basics.elm
-module Basics exposing ((<|), Int, Float, Bool(..), Order(..), negate)
+module Basics exposing ((<|),(++), Int, Float, Bool(..), Order(..), negate)
 
 infix left  0 (<|) = apL
+infix right 5 (++) = append
 
 type Int = Int
 
@@ -24,9 +25,22 @@ add : number -> number -> number
 add =
   Elm.Kernel.Basics.add
 
+append : appendable -> appendable -> appendable
+append =
+  Elm.Kernel.Utils.append
+
 apL : (a -> b) -> a -> b
 apL f x =
   f x
+
+--@ String.elm
+module String exposing (String,append)
+
+type String = String
+
+append : String -> String -> String
+append =
+  Elm.Kernel.String.append 
 `;
 
 const sourceTestModule = `
@@ -203,6 +217,25 @@ topSuite = T.describe "top suite" []
       {
         tag: "suite",
         label: '"top suite"',
+        tests: [],
+      },
+    ]);
+  });
+
+  test("dynamic label", async () => {
+    const source = `
+--@ MyModule.elm
+module MyModule exposing (..)
+
+import Test exposing (..)
+
+topSuite = describe ("top suite" ++ "13") []
+`;
+
+    await testFindTests(source, [
+      {
+        tag: "suite",
+        label: ['"top suite"', '"13"'],
         tests: [],
       },
     ]);

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -326,7 +326,7 @@ topSuite = describe ("top suite" ++ "13") []
 
     await testFindTests(source, [
       {
-        label: ["top suite", "13"],
+        label: undefined,
         file: testModuleUri,
         position: { line: 4, character: 11 },
         tests: [],

--- a/test/utils/sourceTreeParser.ts
+++ b/test/utils/sourceTreeParser.ts
@@ -10,7 +10,7 @@ import * as path from "../../src/util/path";
 import { Utils } from "../../src/util/utils";
 
 export const baseUri = path.join(__dirname, "../sources/src/");
-const testUri = path.join(baseUri, "tests");
+export const testUri = path.join(baseUri, "tests");
 
 export class SourceTreeParser {
   private parser?: Parser;


### PR DESCRIPTION
Experimenting.
The goal it to leverage the ELM Language Server to detect tests.

This will allow to reduce load time for the test explorer UI.
Currently, tests need to be run to be loaded into the UI.
This approach attempts a static code analysis approach to populate the test explorer UI.

The PR unblocks integration work on the client.

There are a few open questions to be addressed
- how to make the new request available earlier for clients? Or, how to hold back client calls until the request is available?
- is this the right way to use internal LS APIs? Does it leverage type inference enough?
