### PR TITLE
Integrate with elm-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This server contributes the following settings:
 
 - `elmLS.trace.server`: Enable/disable trace logging of client and server communication
 - `elmLS.elmPath`: The path to your `elm` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
+- `elmLS.elmReviewPath`: The path to your `elm-review` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmFormatPath`: The path to your `elm-format` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmTestPath`: The path to your `elm-test` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.disableElmLSDiagnostics`: Enable/Disable linting diagnostics from the language server.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ This server contributes the following settings:
 - `elmLS.trace.server`: Enable/disable trace logging of client and server communication
 - `elmLS.elmPath`: The path to your `elm` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmReviewPath`: The path to your `elm-review` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
+- `elmLS.disableElmReviewDiagnostics`: Enable/Disable linting diagnostics from elm-review.
 - `elmLS.elmFormatPath`: The path to your `elm-format` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmTestPath`: The path to your `elm-test` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.disableElmLSDiagnostics`: Enable/Disable linting diagnostics from the language server.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This server contributes the following settings:
 - `elmLS.trace.server`: Enable/disable trace logging of client and server communication
 - `elmLS.elmPath`: The path to your `elm` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmReviewPath`: The path to your `elm-review` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
-- `elmLS.disableElmReviewDiagnostics`: Enable/Disable linting diagnostics from elm-review.
+- `elmLS.elmReviewDiagnostics`: Configure linting diagnostics from elm-review. Possible values: `off`, `warning`, `error`.
 - `elmLS.elmFormatPath`: The path to your `elm-format` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.elmTestPath`: The path to your `elm-test` executable. Should be empty by default, in that case it will assume the name and try to first get it from a local npm installation or a global one. If you set it manually it will not try to load from the npm folder.
 - `elmLS.disableElmLSDiagnostics`: Enable/Disable linting diagnostics from the language server.

--- a/src/providers/codeAction/elmReviewFixAction.ts
+++ b/src/providers/codeAction/elmReviewFixAction.ts
@@ -1,43 +1,20 @@
 import { TextEdit } from "vscode-languageserver";
-import { Utils } from "../../util/utils";
 import { CodeActionProvider } from "../codeActionProvider";
-import { IElmReviewDiagnostic } from "../diagnostics/elmReviewDiagnostics";
+import { hasElmReviewFixes } from "../diagnostics/elmReviewDiagnostics";
 
-const errorCodes = ["elm_review"];
-const fixId = "elm_review_fix";
 CodeActionProvider.registerCodeAction({
-  errorCodes,
-  fixId,
+  errorCodes: ["elm_review"],
+  fixId: "elm_review_fix",
   getCodeActions: (params) => {
-    return (<IElmReviewDiagnostic[]>params.context.diagnostics)
-      .map((diagnostic) => {
-        const { title, edits } = getEditsForDiagnostic(diagnostic);
-
-        if (title) {
-          return CodeActionProvider.getCodeAction(params, title, edits);
-        }
-      })
-      .filter(Utils.notUndefined);
+    return params.context.diagnostics
+      .filter(hasElmReviewFixes)
+      .map(({ data: { fixes } }) =>
+        CodeActionProvider.getCodeAction(
+          params,
+          "Apply elm-review fix",
+          fixes.map(({ range, string }) => TextEdit.replace(range, string)),
+        ),
+      );
   },
-  getFixAllCodeAction: () => {
-    return undefined;
-  },
+  getFixAllCodeAction: () => undefined,
 });
-
-function getEditsForDiagnostic(
-  diagnostic: IElmReviewDiagnostic,
-): { title?: string; edits: TextEdit[] } {
-  if (
-    diagnostic.data.code !== "elm_review" ||
-    diagnostic.data.fixes === undefined
-  ) {
-    return { edits: [] };
-  }
-
-  return {
-    title: "Apply elm-review fix",
-    edits: diagnostic.data.fixes.map((fix) =>
-      TextEdit.replace(fix.range, fix.string),
-    ),
-  };
-}

--- a/src/providers/codeAction/elmReviewFixAction.ts
+++ b/src/providers/codeAction/elmReviewFixAction.ts
@@ -1,0 +1,44 @@
+import { TextEdit } from "vscode-languageserver";
+import { Utils } from "../../util/utils";
+import { CodeActionProvider } from "../codeActionProvider";
+import { IDiagnostic } from "../diagnostics/diagnosticsProvider";
+
+const errorCodes = ["elm_review"];
+const fixId = "elm_review_fix";
+CodeActionProvider.registerCodeAction({
+  errorCodes,
+  fixId,
+  getCodeActions: (params) => {
+    return (<IDiagnostic[]>params.context.diagnostics)
+      .map((diagnostic) => {
+        const { title, edits } = getEditsForDiagnostic(diagnostic);
+
+        if (title) {
+          return CodeActionProvider.getCodeAction(params, title, edits);
+        }
+      })
+      .filter(Utils.notUndefined);
+  },
+  getFixAllCodeAction: () => {
+    return undefined;
+  },
+});
+
+function getEditsForDiagnostic(
+  diagnostic: IDiagnostic,
+): { title?: string; edits: TextEdit[] } {
+
+  if (
+    diagnostic.data.code !== "elm_review" ||
+    diagnostic.data.fixes === undefined
+  ) {
+    return { edits: [] };
+  }
+
+  return {
+    title: "Apply elm-review fix",
+    edits: diagnostic.data.fixes.map((fix) =>
+      TextEdit.replace(fix.range, fix.string),
+    ),
+  };
+}

--- a/src/providers/codeAction/elmReviewFixAction.ts
+++ b/src/providers/codeAction/elmReviewFixAction.ts
@@ -1,7 +1,7 @@
 import { TextEdit } from "vscode-languageserver";
 import { Utils } from "../../util/utils";
 import { CodeActionProvider } from "../codeActionProvider";
-import { IDiagnostic } from "../diagnostics/diagnosticsProvider";
+import { IElmReviewDiagnostic } from "../diagnostics/elmReviewDiagnostics";
 
 const errorCodes = ["elm_review"];
 const fixId = "elm_review_fix";
@@ -9,7 +9,7 @@ CodeActionProvider.registerCodeAction({
   errorCodes,
   fixId,
   getCodeActions: (params) => {
-    return (<IDiagnostic[]>params.context.diagnostics)
+    return (<IElmReviewDiagnostic[]>params.context.diagnostics)
       .map((diagnostic) => {
         const { title, edits } = getEditsForDiagnostic(diagnostic);
 
@@ -25,9 +25,8 @@ CodeActionProvider.registerCodeAction({
 });
 
 function getEditsForDiagnostic(
-  diagnostic: IDiagnostic,
+  diagnostic: IElmReviewDiagnostic,
 ): { title?: string; edits: TextEdit[] } {
-
   if (
     diagnostic.data.code !== "elm_review" ||
     diagnostic.data.fixes === undefined

--- a/src/providers/codeAction/index.ts
+++ b/src/providers/codeAction/index.ts
@@ -8,3 +8,4 @@ import "./moveFunctionCodeAction";
 import "./installPackageCodeAction";
 import "./addMissingRecordFieldCodeAction";
 import "./addMissingCaseBranchesCodeAction";
+import "./elmReviewFixAction";

--- a/src/providers/diagnostics/diagnosticSource.ts
+++ b/src/providers/diagnostics/diagnosticSource.ts
@@ -1,1 +1,1 @@
-export type DiagnosticSource = "Elm" | "ElmLS";
+export type DiagnosticSource = "Elm" | "ElmLS" | "elm-review";

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -508,7 +508,8 @@ export class DiagnosticsProvider {
       }
     });
 
-    // return true if elm make returned non empty results
+    // return true if elm make returned non empty results,
+    // it returns `new Map([[sourceFile.uri, []]])` in case of no errors
     return !(
       elmMakeDiagnostics.size === 1 &&
       elmMakeDiagnostics.get(sourceFile.uri)?.length === 0
@@ -522,20 +523,14 @@ export class DiagnosticsProvider {
       sourceFile,
     );
 
-    this.resetDiagnostics(elmReviewDiagnostics, DiagnosticKind.ElmReview);
-
-    elmReviewDiagnostics.forEach((diagnostics, diagnosticsUri) => {
-      this.updateDiagnostics(
-        diagnosticsUri,
-        DiagnosticKind.ElmReview,
-        diagnostics,
-      );
+    // remove old elm-review diagnostics
+    this.currentDiagnostics.forEach((_, uri) => {
+      this.updateDiagnostics(uri, DiagnosticKind.ElmReview, []);
     });
 
-    this.currentDiagnostics.forEach((_, uri) => {
-      if (!elmReviewDiagnostics.has(uri)) {
-        this.updateDiagnostics(uri, DiagnosticKind.ElmReview, []);
-      }
+    // add new elm-review diagnostics
+    elmReviewDiagnostics.forEach((diagnostics, uri) => {
+      this.updateDiagnostics(uri, DiagnosticKind.ElmReview, diagnostics);
     });
   }
 

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -490,8 +490,6 @@ export class DiagnosticsProvider {
     elmMakeDiagnostics.forEach((diagnostics, diagnosticsUri) => {
       this.updateDiagnostics(diagnosticsUri, DiagnosticKind.Syntactic, []);
       this.updateDiagnostics(diagnosticsUri, DiagnosticKind.Semantic, []);
-      this.connection.console.info('elm make url:' + diagnosticsUri);
-      this.connection.console.info('elm make diagnostics:' + JSON.stringify(diagnostics));
       this.updateDiagnostics(
         diagnosticsUri,
         DiagnosticKind.ElmMake,
@@ -516,8 +514,6 @@ export class DiagnosticsProvider {
     this.resetDiagnostics(elmReviewDiagnostics, DiagnosticKind.ElmReview);
 
     elmReviewDiagnostics.forEach((diagnostics, diagnosticsUri) => {
-      this.connection.console.info('elm review uri:' + diagnosticsUri);
-      this.connection.console.info('elm review value:' + JSON.stringify(diagnostics));
       this.updateDiagnostics(
         diagnosticsUri,
         DiagnosticKind.ElmReview,

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -409,6 +409,7 @@ export class DiagnosticsProvider {
 
             next.immediate(() => {
               this.updateDiagnostics(uri, DiagnosticKind.ElmMake, []);
+              this.updateDiagnostics(uri, DiagnosticKind.ElmReview, []);
               this.updateDiagnostics(
                 uri,
                 DiagnosticKind.Syntactic,

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -401,7 +401,6 @@ export class DiagnosticsProvider {
 
             next.immediate(() => {
               this.updateDiagnostics(uri, DiagnosticKind.ElmMake, []);
-              this.updateDiagnostics(uri, DiagnosticKind.ElmReview, []);
               this.updateDiagnostics(
                 uri,
                 DiagnosticKind.Syntactic,
@@ -486,8 +485,8 @@ export class DiagnosticsProvider {
     elmMakeDiagnostics.forEach((diagnostics, diagnosticsUri) => {
       this.updateDiagnostics(diagnosticsUri, DiagnosticKind.Syntactic, []);
       this.updateDiagnostics(diagnosticsUri, DiagnosticKind.Semantic, []);
-      this.connection.console.info(diagnosticsUri);
-      this.connection.console.info(JSON.stringify(diagnostics));
+      this.connection.console.info('elm make url:' + diagnosticsUri);
+      this.connection.console.info('elm make diagnostics:' + JSON.stringify(diagnostics));
       this.updateDiagnostics(
         diagnosticsUri,
         DiagnosticKind.ElmMake,
@@ -512,8 +511,8 @@ export class DiagnosticsProvider {
     this.resetDiagnostics(elmReviewDiagnostics, DiagnosticKind.ElmReview);
 
     elmReviewDiagnostics.forEach((diagnostics, diagnosticsUri) => {
-      this.connection.console.info(diagnosticsUri);
-      this.connection.console.info(JSON.stringify(diagnostics));
+      this.connection.console.info('elm review uri:' + diagnosticsUri);
+      this.connection.console.info('elm review value:' + JSON.stringify(diagnostics));
       this.updateDiagnostics(
         diagnosticsUri,
         DiagnosticKind.ElmReview,

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -483,7 +483,9 @@ export class DiagnosticsProvider {
     );
   }
 
-  private async getElmMakeDiagnostics(sourceFile: ISourceFile): Promise<boolean> {
+  private async getElmMakeDiagnostics(
+    sourceFile: ISourceFile,
+  ): Promise<boolean> {
     const elmMakeDiagnostics = await this.elmMakeDiagnostics.createDiagnostics(
       sourceFile,
     );
@@ -507,7 +509,10 @@ export class DiagnosticsProvider {
     });
 
     // return true if elm make returned non empty results
-    return !(elmMakeDiagnostics.size === 1 && elmMakeDiagnostics.get(sourceFile.uri)?.length === 0);
+    return !(
+      elmMakeDiagnostics.size === 1 &&
+      elmMakeDiagnostics.get(sourceFile.uri)?.length === 0
+    );
   }
 
   private async getElmReviewDiagnostics(

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -47,10 +47,6 @@ export interface IDiagnostic extends Omit<LspDiagnostic, "code"> {
   data: {
     uri: string;
     code: string;
-    fixes?: {
-      range: Range;
-      string: string;
-    }[]
   };
 }
 

--- a/src/providers/diagnostics/diagnosticsProvider.ts
+++ b/src/providers/diagnostics/diagnosticsProvider.ts
@@ -3,6 +3,7 @@ import {
   CancellationToken,
   Connection,
   Diagnostic as LspDiagnostic,
+  Range,
   DiagnosticSeverity,
   FileChangeType,
 } from "vscode-languageserver";
@@ -46,6 +47,10 @@ export interface IDiagnostic extends Omit<LspDiagnostic, "code"> {
   data: {
     uri: string;
     code: string;
+    fixes?: {
+      range: Range;
+      string: string;
+    }[]
   };
 }
 

--- a/src/providers/diagnostics/elmReviewDiagnostics.ts
+++ b/src/providers/diagnostics/elmReviewDiagnostics.ts
@@ -1,0 +1,157 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { container } from "tsyringe";
+import { Connection, DiagnosticSeverity } from "vscode-languageserver";
+import { URI, Utils } from "vscode-uri";
+import { ISourceFile } from "../../compiler/forest";
+import * as utils from "../../compiler/utils/elmUtils";
+import { ElmWorkspaceMatcher } from "../../util/elmWorkspaceMatcher";
+import { Settings } from "../../util/settings";
+import { IDiagnostic } from "./diagnosticsProvider";
+import execa = require("execa");
+
+interface IElmReviewError {
+  type: "review-errors";
+  errors: IFileError[];
+}
+
+interface IFileError {
+  path: string;
+  errors: IError[];
+}
+
+interface IError {
+  rule: string;
+  ruleLink: string;
+  message: string;
+  details: string[];
+  region: {
+    start: IPosition;
+    end: IPosition;
+  };
+  fix: {
+    range: {
+      start: IPosition;
+      end: IPosition;
+    };
+    string: string;
+  }[];
+}
+
+interface IPosition {
+  line: number;
+  column: number;
+}
+
+export class ElmReviewDiagnostics {
+  private elmWorkspaceMatcher: ElmWorkspaceMatcher<URI>;
+  private settings: Settings;
+  private connection: Connection;
+
+  constructor() {
+    this.settings = container.resolve("Settings");
+    this.connection = container.resolve<Connection>("Connection");
+    this.elmWorkspaceMatcher = new ElmWorkspaceMatcher((uri) => uri);
+  }
+
+  public createDiagnostics = async (
+    sourceFile: ISourceFile,
+  ): Promise<Map<string, IDiagnostic[]>> => {
+    const filePath = URI.parse(sourceFile.uri);
+    const workspaceRootPath = this.elmWorkspaceMatcher
+      .getProgramFor(filePath)
+      .getRootPath();
+    return await this.checkForErrors(workspaceRootPath.fsPath);
+  };
+
+  private hasType(error: any): error is IElmReviewError {
+    return "type" in error;
+  }
+
+  private async checkForErrors(
+    workspaceRootPath: string,
+  ): Promise<Map<string, IDiagnostic[]>> {
+    const settings = await this.settings.getClientSettings();
+
+    const args = ["--report", "json"];
+
+    const makeCommand: string = settings.elmPath;
+    const elmReviewCommand: string = settings.elmReviewPath;
+    const options = {
+      cmdArguments: args,
+      notFoundText:
+        "'elm-review' is not available. Install elm-review via 'npm install -g elm-review'.",
+    };
+
+    const fileErrors = new Map<string, IDiagnostic[]>();
+    try {
+      // Do nothing on success, but return that there were no errors
+      utils.execCmdSync(
+        elmReviewCommand,
+        "elm-review",
+        options,
+        workspaceRootPath,
+        this.connection,
+      );
+      return fileErrors;
+    } catch (error) {
+      if (typeof error === "string") {
+        return fileErrors;
+      } else {
+        const execaError = error as execa.ExecaReturnValue<string>;
+        let errorObject: unknown;
+        try {
+          this.connection.console.info(execaError.stdout);
+          errorObject = JSON.parse(execaError.stdout);
+          this.connection.console.info(JSON.stringify(errorObject));
+        } catch (error) {
+          this.connection.console.warn(
+            "Received an invalid json, skipping error.",
+          );
+        }
+
+        if (
+          errorObject &&
+          this.hasType(errorObject) &&
+          errorObject.type === "review-errors"
+        ) {
+          const reviewError = errorObject;
+          reviewError.errors.forEach((fileError: IFileError) => {
+            const errors: IDiagnostic[] = fileError.errors.map(
+              (error: IError) => ({
+                message: error.message,
+                source: "elm-review",
+                range: {
+                  start: {
+                    character: error.region.start.column - 1,
+                    line: error.region.start.line - 1,
+                  },
+                  end: {
+                    character: error.region.end.column - 1,
+                    line: error.region.end.line - 1,
+                  },
+                },
+                severity: DiagnosticSeverity.Warning,
+                data: {
+                  uri: Utils.joinPath(
+                    URI.parse(workspaceRootPath),
+                    fileError.path,
+                  ).toString(),
+                  code: "",
+                },
+              }),
+            );
+
+            fileErrors.set(
+              Utils.joinPath(
+                URI.parse(workspaceRootPath),
+                fileError.path,
+              ).toString(),
+              errors,
+            );
+          });
+        }
+        return fileErrors;
+      }
+    }
+  }
+}

--- a/src/providers/diagnostics/elmReviewDiagnostics.ts
+++ b/src/providers/diagnostics/elmReviewDiagnostics.ts
@@ -111,8 +111,15 @@ export class ElmReviewDiagnostics {
     }
 
     const elmReviewCommand: string = settings.elmReviewPath;
+    const cmdArguments = ["--report", "json", "--namespace", "vscode"];
+    if (settings.elmPath.trim.length > 0) {
+      cmdArguments.push("--compiler", settings.elmPath);
+    }
+    if (settings.elmFormatPath.trim.length > 0) {
+      cmdArguments.push("--elm-format-path", settings.elmFormatPath);
+    }
     const options = {
-      cmdArguments: ["--report", "json", "--namespace", "vscode"],
+      cmdArguments: cmdArguments,
       notFoundText:
         "'elm-review' is not available. Install elm-review via 'npm install -g elm-review'.",
     };

--- a/src/providers/diagnostics/fileDiagnostics.ts
+++ b/src/providers/diagnostics/fileDiagnostics.ts
@@ -8,6 +8,7 @@ export const enum DiagnosticKind {
   Syntactic,
   Semantic,
   Suggestion,
+  ElmReview,
 }
 
 export function diagnosticsEquals(a: IDiagnostic, b: IDiagnostic): boolean {
@@ -49,6 +50,7 @@ export class FileDiagnostics {
     return [
       ...this.getForKind(DiagnosticKind.ElmMake),
       ...this.getForKind(DiagnosticKind.ElmTest),
+      ...this.getForKind(DiagnosticKind.ElmReview),
       ...this.getForKind(DiagnosticKind.ElmLS),
       ...this.getForKind(DiagnosticKind.Syntactic),
       ...this.getForKind(DiagnosticKind.Semantic),

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ export * from "./completionProvider";
 export * from "./definitionProvider";
 export * from "./diagnostics/diagnosticsProvider";
 export * from "./diagnostics/elmMakeDiagnostics";
+export * from "./diagnostics/elmReviewDiagnostics";
 export * from "./documentFormatingProvider";
 export * from "./documentSymbolProvider";
 export * from "./selectionRangeProvider";

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import { FileEventsHandler } from "./providers/handlers/fileEventsHandler";
 import { Settings } from "./util/settings";
 import { TextDocumentEvents } from "./util/textDocumentEvents";
 import { FindTestsProvider } from "./providers/findTestsProvider";
+import { ElmReviewDiagnostics } from "./providers/diagnostics/elmReviewDiagnostics";
 
 export interface ILanguageServer {
   readonly capabilities: InitializeResult;
@@ -171,6 +172,10 @@ export class Server implements ILanguageServer {
 
     container.register(ElmMakeDiagnostics, {
       useValue: new ElmMakeDiagnostics(),
+    });
+
+    container.register(ElmReviewDiagnostics, {
+      useValue: new ElmReviewDiagnostics(),
     });
 
     container.register(ElmLsDiagnostics, {

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -5,6 +5,7 @@ export interface IClientSettings {
   elmFormatPath: string;
   elmPath: string;
   elmTestPath: string;
+  elmReviewPath: string;
   trace: { server: string };
   extendedCapabilities?: IExtendedCapabilites;
   disableElmLSDiagnostics: boolean;
@@ -24,6 +25,7 @@ export class Settings {
     elmFormatPath: "",
     elmPath: "",
     elmTestPath: "",
+    elmReviewPath: "",
     trace: { server: "off" },
     disableElmLSDiagnostics: false,
     skipInstallPackageConfirmation: false,

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -11,7 +11,7 @@ export interface IClientSettings {
   disableElmLSDiagnostics: boolean;
   skipInstallPackageConfirmation: boolean;
   onlyUpdateDiagnosticsOnSave: boolean;
-  disableElmReviewDiagnostics: boolean;
+  elmReviewDiagnostics: "off" | "warning" | "error";
 }
 
 export interface IExtendedCapabilites {
@@ -31,7 +31,7 @@ export class Settings {
     disableElmLSDiagnostics: false,
     skipInstallPackageConfirmation: false,
     onlyUpdateDiagnosticsOnSave: false,
-    disableElmReviewDiagnostics: false,
+    elmReviewDiagnostics: "off",
   };
   private connection: Connection;
 

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -11,6 +11,7 @@ export interface IClientSettings {
   disableElmLSDiagnostics: boolean;
   skipInstallPackageConfirmation: boolean;
   onlyUpdateDiagnosticsOnSave: boolean;
+  disableElmReviewDiagnostics: boolean;
 }
 
 export interface IExtendedCapabilites {
@@ -30,6 +31,7 @@ export class Settings {
     disableElmLSDiagnostics: false,
     skipInstallPackageConfirmation: false,
     onlyUpdateDiagnosticsOnSave: false,
+    disableElmReviewDiagnostics: false,
   };
   private connection: Connection;
 


### PR DESCRIPTION
![elm-review](https://user-images.githubusercontent.com/43472/117888355-3d760680-b2b2-11eb-996e-cbae8157d074.gif)

This is a super basic integration that supports diagnostics and code actions from `elm-review`. By default, `elm-review` is run if "review/src/ReviewConfig.elm" exists and if it is not disabled in the config.

The feedback from `elm-review` feels a little slow, we'll need to figure out how to integrate it in the watch mode, happy to try this in a separate PR.

@Razzeee thanks a lot for the initial pairing session!