### PR TITLE
Align test detection logic

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -622,11 +622,10 @@ export class Program implements IProgram {
 
       const moduleName = utils.getModuleName(matchingPath, sourceDir);
 
-      // We could track this using the separate `testDirectories`
-      // But those are just hardcoded to ./tests anyways, so this should be fine
-      const isTestDir =
-        matchingPath.includes("tests") || matchingPath.includes("Tests");
-      if (isTestDir) {
+      const isTestFile =
+        this.getSourceDirectoryOfFile(matchingPath)?.endsWith("tests") ?? false;
+
+      if (isTestFile) {
         project.testModuleToUriMap.set(
           moduleName,
           URI.file(matchingPath).toString(),
@@ -642,7 +641,7 @@ export class Program implements IProgram {
         maintainerAndPackageName,
         path: matchingPath,
         project,
-        isTestFile: isTestDir,
+        isTestFile,
       });
     });
 

--- a/test/codeActionTests/codeActionTestBase.ts
+++ b/test/codeActionTests/codeActionTestBase.ts
@@ -18,11 +18,12 @@ import {
 import {
   SourceTreeParser,
   trimTrailingWhitespace,
-  baseUri,
   applyEditsToSource,
   stripCommentLines,
+  srcUri,
 } from "../utils/sourceTreeParser";
 import diffDefault from "jest-diff";
+import path from "path";
 
 function codeActionEquals(a: CodeAction, b: CodeAction): boolean {
   return a.title === b.title;
@@ -83,7 +84,7 @@ export async function testCodeAction(
     throw new Error("Getting sources failed");
   }
 
-  const testUri = URI.file(baseUri + "Test.elm").toString();
+  const testUri = URI.file(path.join(srcUri, "Test.elm")).toString();
 
   result.sources["Test.elm"] = stripCommentLines(result.sources["Test.elm"]);
 
@@ -145,7 +146,7 @@ export async function testCodeAction(
       .edit!.changes!;
 
     Object.entries(expectedSources).forEach(([uri, source]) => {
-      const edits = changesToApply[URI.file(baseUri + uri).toString()];
+      const edits = changesToApply[URI.file(srcUri + uri).toString()];
       if (edits) {
         expect(
           applyEditsToSource(stripCommentLines(result.sources[uri]), edits),

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -152,7 +152,7 @@ describe("CompletionProvider", () => {
   it("Should complete module keyword", async () => {
     const sourceModule = `
 --@ Test.elm
-{-caret-} 
+{-caret-}
   ""
     `;
     await testCompletions(sourceModule, ["module"], "partialMatch");
@@ -171,7 +171,7 @@ m{-caret-}
 module Test exposing (..)
 
 {-caret-}
-    
+
     `;
     await testCompletions(sourceImport, ["import"], "partialMatch");
 
@@ -190,7 +190,7 @@ i{-caret-}
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -208,12 +208,12 @@ view model =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: Data
   , prop2: Int
   }
 
-type alias Data = 
+type alias Data =
   { item1: String
   , item2: Int
   }
@@ -231,7 +231,7 @@ view model =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -247,7 +247,7 @@ view =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -256,7 +256,7 @@ view : Model
 view =
   let
     testFunc : Model
-    testFunc = 
+    testFunc =
       { p{-caret-} }
 
   in
@@ -270,7 +270,7 @@ view =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -279,7 +279,7 @@ view : Model -> Model
 view model =
   let
     var : String
-    var = 
+    var =
       model.{-caret-}
         |> String.toFloat
         |> String.fromFloat
@@ -299,7 +299,7 @@ view model =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -307,7 +307,7 @@ type alias Model =
 view : Model -> Model
 view model =
   let
-    var = 
+    var =
       model.p{-caret-}
 
   in
@@ -337,7 +337,7 @@ test param =
 
   it("Function parameter should have completions in a nested expression", async () => {
     const source = `
---@ Test.elm    
+--@ Test.elm
 module Test exposing (..)
 
 test : Model -> String
@@ -353,7 +353,7 @@ test param =
 
   it("Let values should have completions", async () => {
     const source = `
---@ Test.elm    
+--@ Test.elm
 module Test exposing (..)
 
 test : Model -> String
@@ -370,7 +370,7 @@ test param =
     await testCompletions(source, ["val"]);
 
     const source2 = `
---@ Test.elm    
+--@ Test.elm
 module Test exposing (..)
 
 test : Model -> String
@@ -444,7 +444,7 @@ test param =
 --@ OtherModule.elm
 module OtherModule exposing (..)
 
-main = 
+main =
   ""
 `;
     const source = `
@@ -535,12 +535,12 @@ import OtherModule exposing (testFunction, T{-caret-})
 module Test exposing ({-caret-})
 
 testFunc : String
-testFunc = 
+testFunc =
   ""
 
 type Msg = Msg1 | Msg2
 
-type alias TestType = 
+type alias TestType =
   { prop : String }
 `;
 
@@ -555,12 +555,12 @@ type alias TestType =
 module Test exposing (t{-caret-})
 
 testFunc : String
-testFunc = 
+testFunc =
   ""
 
 type Msg = Msg1 | Msg2
 
-type alias TestType = 
+type alias TestType =
   { prop : String }
 `;
 
@@ -577,12 +577,12 @@ type alias TestType =
 module Test exposing (testFunc, Msg(..), {-caret-})
 
 testFunc : String
-testFunc = 
+testFunc =
   ""
 
 type Msg = Msg1 | Msg2
 
-type alias TestType = 
+type alias TestType =
   { prop : String }
 `;
 
@@ -598,7 +598,7 @@ type alias TestType =
 --@ Test.elm
 module Test exposing (..)
 
-{-caret-} 
+{-caret-}
 testFunc =
   ""
     `;
@@ -620,7 +620,7 @@ module Test exposing (..)
 
 count : Int
 {-caret-}
-    
+
     `;
     await testCompletions(sourceFunc, ["count"], "exactMatch");
 
@@ -629,7 +629,7 @@ count : Int
 module Test exposing (..)
 
 testFunc : String
-t{-caret-} =  
+t{-caret-} =
   ""
 `;
     await testCompletions(sourceFunc1, ["testFunc"], "exactMatch");
@@ -643,7 +643,7 @@ module Test exposing (..)
 type Msg = Msg1 String
 
 testFunc : Msg -> String
-testFunc msg = 
+testFunc msg =
   case msg of
     Msg1 str ->
       s{-caret-}
@@ -667,7 +667,7 @@ type alias TestType = {prop : String}
 module Test exposing (..)
 
 testFunc : String
-testFunc = 
+testFunc =
   {-caret-}
 `;
 
@@ -704,7 +704,7 @@ type Msg = Msg1 | Msg2
 module Test exposing (..)
 
 testFunc : String
-testFunc = 
+testFunc =
   {-caret-}
 `;
 
@@ -748,15 +748,15 @@ testFunc =
 module Data.User exposing (..)
 
 func : String
-func = 
+func =
   ""
-  
+
 --@ Test.elm
 module Test exposing (..)
 
 import Data.User
 
-test = 
+test =
   {-caret-}
 `;
 
@@ -772,17 +772,17 @@ test =
 module Data.User exposing (..)
 
 func : String
-func = 
+func =
   ""
 
 type alias TestType = { prop : String }
-  
+
 --@ Test.elm
 module Test exposing (..)
 
 import Data.User
 
-test = 
+test =
   Da{-caret-}
 `;
 
@@ -806,7 +806,7 @@ module Test exposing (..)
 
 import Page
 
-defaultPage = 
+defaultPage =
   Page.{-caret-}
 
 func = ""
@@ -830,7 +830,7 @@ module Test exposing (..)
 
 import Page
 
-defaultPage = 
+defaultPage =
   Page.{-caret-}
     `;
 
@@ -1211,7 +1211,7 @@ module Test exposing (..)
 
 import Other
 
-type alias Model = 
+type alias Model =
 { prop1: String
 , prop2: Int
 }
@@ -1309,7 +1309,7 @@ encodeScope scope =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -1349,7 +1349,7 @@ func (State state) =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: String
   , prop2: Int
   }
@@ -1371,13 +1371,13 @@ func model =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = 
+type alias Model =
   { prop1: Model2
   , prop2: Int
   }
 
-type alias Model2 = 
-  { field1: String 
+type alias Model2 =
+  { field1: String
   , field2: Int }
 
 type Maybe a = Just a | Nothing
@@ -1409,19 +1409,19 @@ func model =
     await testCompletions(source, ["prop1", "prop2"], "exactMatch");
   });
 
-  it("Test dependencies should be seperate from normal ones", async () => {
+  it("Test dependencies should not be found from normal ones", async () => {
     const source = `
---@ Test.elm
+    --@ Test.elm
 module Test exposing (..)
 
 test =
-    {-caret-}
+{-caret-}
 
 --@ tests/TestFile.elm
 module TestFile exposing (..)
 
 func =
-    ""
+""
 `;
 
     await testCompletions(
@@ -1429,7 +1429,9 @@ func =
       [{ name: "func", shouldNotExist: true }],
       "partialMatch",
     );
+  });
 
+  it("Test dependencies should find each other", async () => {
     const source2 = `
 --@ Test.elm
 module Test exposing (..)
@@ -1496,7 +1498,7 @@ func =
 module Test exposing (..)
 
 func model =
-    case model of 
+    case model of
       Just { details } ->
         d{-caret-}
 `;

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { isDeepStrictEqual } from "util";
 import {
   CompletionContext,
@@ -9,7 +10,7 @@ import { URI } from "vscode-uri";
 import { CompletionProvider, CompletionResult } from "../src/providers";
 import { ICompletionParams } from "../src/providers/paramsExtensions";
 import { getCaretPositionFromSource } from "./utils/sourceParser";
-import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+import { baseUri, SourceTreeParser, srcUri } from "./utils/sourceTreeParser";
 
 class MockCompletionProvider extends CompletionProvider {
   public handleCompletion(params: ICompletionParams): CompletionResult {
@@ -54,7 +55,13 @@ describe("CompletionProvider", () => {
       throw new Error("Getting position failed");
     }
 
-    const testUri = URI.file(baseUri + fileWithCaret).toString();
+    const testUri = URI.file(
+      path.join(
+        fileWithCaret.startsWith("tests") ? baseUri : srcUri,
+        fileWithCaret,
+      ),
+    ).toString();
+
     const program = await treeParser.getProgram(newSources);
     const sourceFile = program.getSourceFile(testUri);
 
@@ -127,7 +134,8 @@ describe("CompletionProvider", () => {
           "shouldNotExist" in completion &&
           completion.shouldNotExist
         ) {
-          result = !result;
+          expect(result).toBe(false);
+          return;
         }
 
         if (!result && debug) {
@@ -747,8 +755,8 @@ testFunc =
 --@ Data/User.elm
 module Data.User exposing (..)
 
-func : String
-func =
+testFunction : String
+testFunction =
   ""
 
 --@ Test.elm
@@ -762,7 +770,7 @@ test =
 
     await testCompletions(
       source,
-      ["Data.User.func"],
+      ["Data.User.testFunction"],
       "partialMatch",
       "triggeredByDot",
     );
@@ -771,8 +779,8 @@ test =
 --@ Data/User.elm
 module Data.User exposing (..)
 
-func : String
-func =
+testFunction : String
+testFunction =
   ""
 
 type alias TestType = { prop : String }
@@ -788,7 +796,7 @@ test =
 
     await testCompletions(
       source2,
-      ["Data.User.func", "Data.User.TestType"],
+      ["Data.User.testFunction", "Data.User.TestType"],
       "partialMatch",
       "triggeredByDot",
     );
@@ -809,7 +817,7 @@ import Page
 defaultPage =
   Page.{-caret-}
 
-func = ""
+testFunction = ""
 `;
 
     await testCompletions(
@@ -901,12 +909,12 @@ viewUser : U{-caret-}
 --@ Module/Submodule.elm
 module Module.Submodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule/AnotherSubmodule.elm
 module Module.Submodule.AnotherSubmodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Test.elm
 module Test exposing (..)
@@ -925,12 +933,12 @@ test : Module.{-caret-}
 --@ Module/Submodule.elm
 module Module.Submodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule/AnotherSubmodule.elm
 module Module.Submodule.AnotherSubmodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Test.elm
 module Test exposing (..)
@@ -940,7 +948,7 @@ test = Module.Submodule.{-caret-}
 
     await testCompletions(
       source2,
-      ["AnotherSubmodule", "func"],
+      ["AnotherSubmodule", "testFunction"],
       "exactMatch",
       "triggeredByDot",
     );
@@ -949,12 +957,12 @@ test = Module.Submodule.{-caret-}
 --@ Module/Submodule.elm
 module Module.Submodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule/AnotherSubmodule.elm
 module Module.Submodule.AnotherSubmodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Test.elm
 module Test exposing (..)
@@ -974,17 +982,17 @@ test = Module.sub{-caret-}
 --@ Module.elm
 module Module exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule.elm
 module Module.Submodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule/AnotherSubmodule.elm
 module Module.Submodule.AnotherSubmodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Test.elm
 module Test exposing (..)
@@ -1004,17 +1012,17 @@ import Module.{-caret-}
 --@ Module.elm
 module Module exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule.elm
 module Module.Submodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule/AnotherSubmodule.elm
 module Module.Submodule.AnotherSubmodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Test.elm
 module Test exposing (..)
@@ -1033,17 +1041,17 @@ import Module.Sub{-caret-}
 --@ Module.elm
 module Module exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule.elm
 module Module.Submodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Module/Submodule/AnotherSubmodule.elm
 module Module.Submodule.AnotherSubmodule exposing (..)
 
-func = ""
+testFunction = ""
 
 --@ Test.elm
 module Test exposing (..)
@@ -1318,8 +1326,8 @@ map: (a -> b) -> List a -> List b
 map func list =
   list
 
-func : List Model -> List a
-func model =
+testFunction : List Model -> List a
+testFunction model =
     map (\\m -> m.{-caret-}) model
 `;
 
@@ -1336,8 +1344,8 @@ type State
     = State { field1 : String, field2 : String }
 
 
-func : State -> a
-func (State state) =
+testFunction : State -> a
+testFunction (State state) =
     [ state.{-caret-} ]
 `;
 
@@ -1356,8 +1364,8 @@ type alias Model =
 
 type Maybe a = Just a | Nothing
 
-func : Maybe Model -> a
-func model =
+testFunction : Maybe Model -> a
+testFunction model =
     case model of
         Just m ->
             m.{-caret-}
@@ -1382,8 +1390,8 @@ type alias Model2 =
 
 type Maybe a = Just a | Nothing
 
-func : Maybe Model -> a
-func model =
+testFunction : Maybe Model -> a
+testFunction model =
     case model of
         Just { prop1, prop2 } ->
             prop1.f{-caret-}
@@ -1402,11 +1410,29 @@ module Test exposing (..)
 
 type Maybe a = Just { prop1: String, prop2: Int } | Nothing
 
-func model =
+testFunction model =
     Just { p{-caret-} }
 `;
 
     await testCompletions(source, ["prop1", "prop2"], "exactMatch");
+  });
+
+  it("Functions from other modules should be importable", async () => {
+    const source = `
+    --@ Test.elm
+module Test exposing (..)
+
+test =
+    {-caret-}
+
+--@ TestFile.elm
+module TestFile exposing (..)
+
+testFunction =
+    ""
+`;
+
+    await testCompletions(source, ["testFunction"], "partialMatch");
   });
 
   it("Test dependencies should not be found from normal ones", async () => {
@@ -1420,18 +1446,18 @@ test =
 --@ tests/TestFile.elm
 module TestFile exposing (..)
 
-func =
-""
+testFunction =
+    ""
 `;
 
     await testCompletions(
       source,
-      [{ name: "func", shouldNotExist: true }],
+      [{ name: "testFunction", shouldNotExist: true }],
       "partialMatch",
     );
   });
 
-  it("Test dependencies should find each other", async () => {
+  it("Test dependencies should find each other and normal", async () => {
     const source2 = `
 --@ Test.elm
 module Test exposing (..)
@@ -1442,17 +1468,17 @@ test =
 --@ tests/TestFile.elm
 module TestFile exposing (..)
 
-func =
+testFunction =
     ""
 
 --@ tests/TestFile2.elm
 module TestFile2 exposing (..)
 
-func2 =
+testFunction2 =
     {-caret-}
 `;
 
-    await testCompletions(source2, ["func", "test"], "partialMatch");
+    await testCompletions(source2, ["testFunction", "test"], "partialMatch");
   });
 
   it("Record completions in record patterns", async () => {
@@ -1460,8 +1486,8 @@ func2 =
 --@ Test.elm
 module Test exposing (..)
 
-func : { prop1: String, prop2: Int } -> String
-func {{-caret-}} =
+testFunction : { prop1: String, prop2: Int } -> String
+testFunction {{-caret-}} =
     ""
 `;
 
@@ -1471,8 +1497,8 @@ func {{-caret-}} =
 --@ Test.elm
 module Test exposing (..)
 
-func : { prop1: String, prop2: Int } -> String
-func {p{-caret-}} =
+testFunction : { prop1: String, prop2: Int } -> String
+testFunction {p{-caret-}} =
     ""
 `;
 
@@ -1482,7 +1508,7 @@ func {p{-caret-}} =
 --@ Test.elm
 module Test exposing (..)
 
-func =
+testFunction =
     let
       {{-caret-}} = { prop1 = "", prop2 = 2 }
     in
@@ -1497,7 +1523,7 @@ func =
 --@ Test.elm
 module Test exposing (..)
 
-func model =
+testFunction model =
     case model of
       Just { details } ->
         d{-caret-}
@@ -1520,7 +1546,7 @@ module Test exposing (..)
 
 import Module as M
 
-func =
+testFunction =
     M.f{-caret-}
 `;
 
@@ -1545,7 +1571,7 @@ module Test exposing (..)
 
 import Module as M
 
-func =
+testFunction =
     Module.f{-caret-}
 `;
 
@@ -1574,7 +1600,7 @@ module Test exposing (..)
 import Module as M
 import OtherModule as M
 
-func =
+testFunction =
     M.f{-caret-}
 `;
 
@@ -1597,7 +1623,7 @@ singleton value =
 --@ Test.elm
 module Test exposing (..)
 
-func =
+testFunction =
     List.{-caret-}
 `;
 
@@ -1618,7 +1644,7 @@ batch =
 --@ Test.elm
 module Test exposing (..)
 
-func =
+testFunction =
     Cmd.{-caret-}
 `;
 
@@ -1630,8 +1656,8 @@ func =
 --@ Test.elm
 module Test exposing (..)
 
-func : { field : Int } -> Int
-func =
+testFunction : { field : Int } -> Int
+testFunction =
     (\\param -> p{-caret-})
 `;
 
@@ -1643,8 +1669,8 @@ func =
 --@ Test.elm
 module Test exposing (..)
 
-func : { field : Int } -> Int
-func =
+testFunction : { field : Int } -> Int
+testFunction =
     (\\{ field } -> f{-caret-})
 `;
 

--- a/test/definitionProviderTests/definitionProviderTestBase.ts
+++ b/test/definitionProviderTests/definitionProviderTestBase.ts
@@ -1,10 +1,11 @@
+import path from "path";
 import { Location } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { DefinitionProvider, DefinitionResult } from "../../src/providers";
 import { ITextDocumentPositionParams } from "../../src/providers/paramsExtensions";
 import { TreeUtils } from "../../src/util/treeUtils";
 import { getInvokeAndTargetPositionFromSource } from "../utils/sourceParser";
-import { baseUri, SourceTreeParser } from "../utils/sourceTreeParser";
+import { SourceTreeParser, srcUri } from "../utils/sourceTreeParser";
 
 class MockDefinitionProvider extends DefinitionProvider {
   public handleDefinition(
@@ -27,7 +28,7 @@ export class DefinitionProviderTestBase {
 
     const determinedTestType = getInvokeAndTargetPositionFromSource(source);
     const invokeUri = URI.file(
-      baseUri + determinedTestType.invokeFile,
+      path.join(srcUri, determinedTestType.invokeFile),
     ).toString();
 
     const program = await this.treeParser.getProgram(
@@ -71,7 +72,7 @@ export class DefinitionProviderTestBase {
 
           if (determinedTestType.targetPosition) {
             const targetUri = URI.file(
-              baseUri + determinedTestType.targetFile,
+              path.join(srcUri, determinedTestType.targetFile),
             ).toString();
 
             const rootNode = program.getSourceFile(targetUri)!.tree.rootNode;

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -14,8 +14,9 @@ import {
   getSourceFiles,
   getTargetPositionFromSource,
 } from "../utils/sourceParser";
-import { baseUri, SourceTreeParser } from "../utils/sourceTreeParser";
+import { SourceTreeParser, srcUri } from "../utils/sourceTreeParser";
 import diffDefault from "jest-diff";
+import path from "path";
 
 const basicsSources = `
 --@ Basics.elm
@@ -90,7 +91,7 @@ describe("test elm diagnostics", () => {
       throw new Error("Getting sources failed");
     }
 
-    const testUri = URI.file(baseUri + "Test.elm").toString();
+    const testUri = URI.file(path.join(srcUri, "Test.elm")).toString();
 
     const program = await treeParser.getProgram(result.sources);
     const sourceFile = program.getForest().getByUri(testUri);

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -9,15 +9,16 @@ import { ElmLsDiagnostics } from "../../src/providers/diagnostics/elmLsDiagnosti
 import { diagnosticsEquals } from "../../src/providers/diagnostics/fileDiagnostics";
 import { Utils } from "../../src/util/utils";
 import { getSourceFiles } from "../utils/sourceParser";
-import { baseUri, SourceTreeParser } from "../utils/sourceTreeParser";
+import { SourceTreeParser, srcUri } from "../utils/sourceTreeParser";
 import diffDefault from "jest-diff";
+import path from "path";
 
 describe("ElmLsDiagnostics", () => {
   let elmDiagnostics: ElmLsDiagnostics;
   const treeParser = new SourceTreeParser();
 
   const debug = process.argv.find((arg) => arg === "--debug");
-  const uri = URI.file(baseUri + "Main.elm").toString();
+  const uri = URI.file(path.join(srcUri, "Main.elm")).toString();
 
   async function testDiagnostics(
     source: string,
@@ -32,7 +33,7 @@ describe("ElmLsDiagnostics", () => {
 
     let diagnostics: Array<IDiagnostic> = [];
     for (const fileName in sources) {
-      const filePath = URI.file(baseUri + fileName).toString();
+      const filePath = URI.file(path.join(srcUri, fileName)).toString();
       const sourceFile = program.getSourceFile(filePath);
 
       if (!sourceFile) {

--- a/test/fileEventsHandler.test.ts
+++ b/test/fileEventsHandler.test.ts
@@ -19,7 +19,7 @@ import { URI } from "vscode-uri";
 import { IProgram } from "../src/compiler/program";
 import { FileEventsHandler } from "../src/providers/handlers/fileEventsHandler";
 import { getSourceFiles } from "./utils/sourceParser";
-import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+import { SourceTreeParser, srcUri } from "./utils/sourceTreeParser";
 
 describe("fileEventsHandler", () => {
   const treeParser = new SourceTreeParser();
@@ -93,8 +93,8 @@ describe("fileEventsHandler", () => {
     });
   }
 
-  function uri(uri: string, base = baseUri): string {
-    return URI.file(path.join(base, uri)).toString();
+  function uri(uri: string, src = srcUri): string {
+    return URI.file(path.join(src, uri)).toString();
   }
 
   it("handles file create event", async () => {

--- a/test/findTestsProvider.test.ts
+++ b/test/findTestsProvider.test.ts
@@ -1,5 +1,5 @@
 import { getSourceFiles } from "./utils/sourceParser";
-import { SourceTreeParser, testUri } from "./utils/sourceTreeParser";
+import { SourceTreeParser, testsUri } from "./utils/sourceTreeParser";
 import { URI } from "vscode-uri";
 import {
   findAllTestSuites,
@@ -85,7 +85,7 @@ int = F 13
 describe("FindTestsProvider", () => {
   const treeParser = new SourceTreeParser();
 
-  const testModuleUri = URI.file(testUri + "/MyModule.elm").toString();
+  const testModuleUri = URI.file(testsUri + "/MyModule.elm").toString();
 
   async function testFindTests(source: string, expected: TestSuite[]) {
     await treeParser.init();

--- a/test/referencesProviderTests/referencesProviderTestBase.ts
+++ b/test/referencesProviderTests/referencesProviderTestBase.ts
@@ -1,9 +1,10 @@
+import path from "path";
 import { URI } from "vscode-uri";
 import { ReferenceResult, ReferencesProvider } from "../../src/providers";
 import { IReferenceParams } from "../../src/providers/paramsExtensions";
 import { TreeUtils } from "../../src/util/treeUtils";
 import { getReferencesTestFromSource } from "../utils/sourceParser";
-import { baseUri, SourceTreeParser } from "../utils/sourceTreeParser";
+import { SourceTreeParser, srcUri } from "../utils/sourceTreeParser";
 
 class MockReferencesProvider extends ReferencesProvider {
   public handleReference(params: IReferenceParams): ReferenceResult {
@@ -28,14 +29,18 @@ export class ReferencesProviderTestBase {
       throw new Error("Getting references from source failed");
     }
 
-    const testUri = URI.file(baseUri + referenceTest.invokeFile).toString();
+    const testUri = URI.file(
+      path.join(srcUri, referenceTest.invokeFile),
+    ).toString();
 
     const program = await this.treeParser.getProgram(referenceTest.sources);
     const sourceFile = program.getForest().getByUri(testUri);
 
     if (!sourceFile) throw new Error("Getting tree failed");
 
-    const invokeUri = URI.file(baseUri + referenceTest.invokeFile).toString();
+    const invokeUri = URI.file(
+      path.join(srcUri, referenceTest.invokeFile),
+    ).toString();
 
     const references =
       this.referencesProvider.handleReference({
@@ -69,7 +74,9 @@ export class ReferencesProviderTestBase {
     expect(references.length).toEqual(referenceTest.references.length);
 
     referenceTest.references.forEach(({ referencePosition, referenceFile }) => {
-      const referenceUri = URI.file(baseUri + referenceFile).toString();
+      const referenceUri = URI.file(
+        path.join(srcUri, referenceFile),
+      ).toString();
 
       const rootNode = program.getSourceFile(referenceUri)!.tree.rootNode;
       const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(

--- a/test/renameProvider.test.ts
+++ b/test/renameProvider.test.ts
@@ -1,9 +1,5 @@
-import {
-  TextEdit,
-  WorkspaceEdit,
-  Range,
-  Position,
-} from "vscode-languageserver";
+import path from "path";
+import { WorkspaceEdit, Range, Position } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { RenameProvider } from "../src/providers";
 import {
@@ -16,8 +12,8 @@ import {
 } from "./utils/sourceParser";
 import {
   applyEditsToSource,
-  baseUri,
   SourceTreeParser,
+  srcUri,
   stripCommentLines,
   trimTrailingWhitespace,
 } from "./utils/sourceTreeParser";
@@ -44,7 +40,7 @@ describe("renameProvider", () => {
   ): Promise<void> {
     await treeParser.init();
 
-    const testUri = URI.file(baseUri + "Test.elm").toString();
+    const testUri = URI.file(path.join(srcUri, "Test.elm")).toString();
     const result = getTargetPositionFromSource(source);
 
     if (!result) {
@@ -76,7 +72,7 @@ describe("renameProvider", () => {
   ): Promise<void> {
     await treeParser.init();
 
-    const testUri = URI.file(baseUri + "Test.elm").toString();
+    const testUri = URI.file(path.join(srcUri, "Test.elm")).toString();
     const result = getTargetPositionFromSource(trimTrailingWhitespace(source));
 
     if (!result) {
@@ -111,7 +107,8 @@ describe("renameProvider", () => {
       expect(
         applyEditsToSource(
           stripCommentLines(source),
-          renameEdit.changes![URI.file(baseUri + uri).toString()] ?? [],
+          renameEdit.changes![URI.file(path.join(srcUri, uri)).toString()] ??
+            [],
         ),
       ).toEqual(expectedSources[uri]);
     });

--- a/test/typeInference.test.ts
+++ b/test/typeInference.test.ts
@@ -1,7 +1,8 @@
+import path from "path";
 import { URI } from "vscode-uri";
 import { TreeUtils } from "../src/util/treeUtils";
 import { getTargetPositionFromSource } from "./utils/sourceParser";
-import { baseUri, SourceTreeParser } from "./utils/sourceTreeParser";
+import { SourceTreeParser, srcUri } from "./utils/sourceTreeParser";
 
 const basicsSources = `
 --@ Basics.elm
@@ -51,7 +52,7 @@ describe("test type inference", () => {
       throw new Error("Getting source and target position failed");
     }
 
-    const testUri = URI.file(baseUri + "Test.elm").toString();
+    const testUri = URI.file(path.join(srcUri, "Test.elm")).toString();
 
     const program = await treeParser.getProgram(result.sources);
     const sourceFile = program.getSourceFile(testUri);
@@ -178,7 +179,7 @@ func a b c =
 --@ App.elm
 module App exposing (..)
 
-type Maybe a = Just a | Nothing 
+type Maybe a = Just a | Nothing
 
 plus : number -> number -> number
 plus a b = a + b
@@ -372,7 +373,7 @@ module Test exposing (..)
 
 func a b =
 --^
-  if a == b then 
+  if a == b then
     ([ a ], ())
   else
     ([ b, 3 ], ())
@@ -418,7 +419,7 @@ func a =
 --@ Test.elm
 module Test exposing (..)
 
-type alias Model = { 
+type alias Model = {
   field1 : number,
   field2 : number,
   field3 : number
@@ -469,7 +470,7 @@ func a =
         { d, e } ->
           case d of
             () ->
-              1 
+              1
             _ ->
               case e of
                 'a' -> 1
@@ -568,7 +569,7 @@ func =
   case foo of
     Just Nothing ->
       ""
-    
+
     _ ->
       ""
 

--- a/test/utils/sourceTreeParser.ts
+++ b/test/utils/sourceTreeParser.ts
@@ -9,8 +9,9 @@ import { Program, IProgram, IProgramHost } from "../../src/compiler/program";
 import * as path from "../../src/util/path";
 import { Utils } from "../../src/util/utils";
 
-export const baseUri = path.join(__dirname, "../sources/src/");
-export const testUri = path.join(baseUri, "tests");
+export const baseUri = path.join(__dirname, "../sources/");
+export const srcUri = path.join(baseUri, "src");
+export const testsUri = path.join(baseUri, "tests");
 
 export class SourceTreeParser {
   private parser?: Parser;
@@ -36,7 +37,7 @@ export class SourceTreeParser {
         {
           "type": "application",
           "source-directories": [
-              "."
+              "src"
           ],
           "elm-version": "0.19.1",
           "dependencies": {
@@ -52,12 +53,12 @@ export class SourceTreeParser {
       }
 
       return (
-        sources[path.relative(baseUri, uri)] ??
-        testSources[path.relative(testUri, uri)]
+        sources[path.relative(srcUri, uri)] ??
+        testSources[path.relative(testsUri, uri)]
       );
     };
 
-    // Seperate test sources
+    // Separate test sources
     const testSources: { [K: string]: string } = {};
     for (const key in sources) {
       if (key.startsWith("tests/")) {
@@ -71,10 +72,9 @@ export class SourceTreeParser {
         Promise.resolve(readFile(uri)),
       readDirectory: (uri: string): Promise<string[]> => {
         return Promise.resolve(
-          path.normalizeUri(uri) ===
-            path.normalizeUri(baseUri.substr(0, baseUri.length - 1)) // Remove trailing / from baseUri
+          path.normalizeUri(uri) === path.normalizeUri(srcUri)
             ? Object.keys(sources).map((sourceUri) => path.join(uri, sourceUri))
-            : path.normalizeUri(uri) === path.normalizeUri(testUri)
+            : path.normalizeUri(uri) === path.normalizeUri(testsUri)
             ? Object.keys(testSources).map((testUri) => path.join(uri, testUri))
             : [],
         );


### PR DESCRIPTION
Closes https://github.com/elm-tooling/elm-language-server/issues/589

This aligns the one place where we detect tests differently. We now basically only handle the `tests` folder.