### PR TITLE
Fix false positive for unnecessary list concat diagnostics

### DIFF
--- a/src/providers/diagnostics/elmLsDiagnostics.ts
+++ b/src/providers/diagnostics/elmLsDiagnostics.ts
@@ -287,7 +287,7 @@ export class ElmLsDiagnostics {
               ("," . (list_expr))*
               .
               "]"
-            )
+            ) @listExpr
           ) @functionCall
           (#eq? @target "List.concat")
         )
@@ -861,6 +861,11 @@ export class ElmLsDiagnostics {
 
     const listConcats = this.unnecessaryListConcatQuery
       .matches(tree.rootNode)
+      .filter((match) =>
+        match.captures[2].node?.namedChildren.every(
+          (c) => c.type === "list_expr",
+        ),
+      )
       .map((match) => match.captures[0].node)
       .filter(Utils.notUndefinedOrNull);
 

--- a/test/diagnosticTests/elmLsDiagnostics.test.ts
+++ b/test/diagnosticTests/elmLsDiagnostics.test.ts
@@ -1345,6 +1345,29 @@ foo =
 
       await testDiagnostics(source, "unnecessary_list_concat", []);
     });
+
+    it("could not merge 2", async () => {
+      const source = `
+module Bar exposing (foo)
+
+test =
+    let
+        aList =
+            if True then
+                [ 2, 3 ]
+
+            else
+                []
+    in
+    List.concat
+        [ [ 1 ]
+        , aList
+        , [ 4 ]
+        ]
+			`;
+
+      await testDiagnostics(source, "unnecessary_list_concat", []);
+    });
   });
 
   describe("unnecessary port module", () => {


### PR DESCRIPTION
Fixes #605. I couldn't find a way to fix it with the query, so I just added a filter. 