### PR TITLE
Fix vim-ale when `range` missing from `contentChanges`

### DIFF
--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -81,6 +81,17 @@ export class ASTProvider {
       for (const change of params.contentChanges) {
         if ("range" in change) {
           tree?.edit(this.getEditFromChange(change, tree.rootNode.text));
+        } else {
+          const currentText = tree?.rootNode.text;
+          if (currentText) {
+            const regex = new RegExp(/\r\n|\r|\n/);
+            const lines = currentText.split(regex);
+            const range = {
+              start: {line: 0, character: 0},
+              end: {line: lines.length, character: 0},
+            };
+            tree?.edit(this.getEditFromChange({text: change.text, range: range}, currentText));
+          }
         }
       }
     }

--- a/src/providers/astProvider.ts
+++ b/src/providers/astProvider.ts
@@ -87,10 +87,15 @@ export class ASTProvider {
             const regex = new RegExp(/\r\n|\r|\n/);
             const lines = currentText.split(regex);
             const range = {
-              start: {line: 0, character: 0},
-              end: {line: lines.length, character: 0},
+              start: { line: 0, character: 0 },
+              end: { line: lines.length, character: 0 },
             };
-            tree?.edit(this.getEditFromChange({text: change.text, range: range}, currentText));
+            tree?.edit(
+              this.getEditFromChange(
+                { text: change.text, range: range },
+                currentText,
+              ),
+            );
           }
         }
       }


### PR DESCRIPTION
As discussed in #635

If `contentChanges` doesn't contain a `range` property, we assume the whole file content was sent.

This follows from the details of [DidChangeTextDocument](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocument_didChange), specifically:

![133562903-46630628-c23c-47a4-b2ac-9cc6e56db3c5](https://user-images.githubusercontent.com/18142/134824656-5f2aee71-6855-4bf7-acf0-0d85130880b8.png)

It's assumed the text goes from `{line: 0, character: 0}` to `{line: textSplitInLines.length, character: 0}`. This seems to follow the [details about range](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#range) from the spec.