### PR TITLE
Indent four spaces after `of` (#676)

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1369,7 +1369,7 @@ export class CompletionProvider {
     return [
       this.createSnippet(
         "of",
-        ["of", "   $0"],
+        ["of", "    $0"],
         "The of keyword",
         CompletionItemKind.Keyword,
       ),


### PR DESCRIPTION
Fixes #676 by adding the missing fourth space in the completionProvider snippet.