### PR TITLE
Improve error handling for broken package cache

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -395,9 +395,9 @@ export class Program implements IProgram {
         }
 
         this.connection.window.showInformationMessage(
-          "The package cache is probably broken. Try a restart after removing '~/.elm' or '%APPDATA%\elm'."
-          + "If the error still occurs, try running 'elm init' in a different folder."
-          + "If the error appears again, check your PATH for multiple elm installations and verify your installed version",
+          "The package cache is probably broken. Try a restart after removing '~/.elm' or '%APPDATA%\\elm'." +
+            "If the error still occurs, try running 'elm init' in a different folder." +
+            "If the error appears again, check your PATH for multiple elm installations and verify your installed version",
         );
 
         throw error;
@@ -447,8 +447,8 @@ export class Program implements IProgram {
 
     if (this.forest === null) {
       this.connection.window.showWarningMessage(
-        `Extension will not work at all: workspace initialization failed for ${pathToElmJson}`
-        + "For more information, check the console output (F1 > Output, dropdown on the right, 'Elm (project name)')"
+        `Extension will not work at all: workspace initialization failed for ${pathToElmJson}` +
+          "For more information, check the console output (F1 > Output, dropdown on the right, 'Elm (project name)')",
       );
     }
   }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -385,7 +385,24 @@ export class Program implements IProgram {
         // On application projects, this will give a NO INPUT error message, but will still download the dependencies
       }
 
-      this.elmPackageCache = new ElmPackageCache(this.loadElmJson.bind(this));
+      try {
+        this.elmPackageCache = new ElmPackageCache(this.loadElmJson.bind(this));
+      } catch (error) {
+        if (error instanceof Error && error.stack) {
+          this.connection.window.showErrorMessage(
+            `Failed constructing ElmPackageCache for ${pathToElmJson}:\n${error.stack}`,
+          );
+        }
+
+        this.connection.window.showInformationMessage(
+          "The package cache is probably broken. Try a restart after removing '~/.elm' or '%APPDATA%\elm'."
+          + "If the error still occurs, try running 'elm init' in a different folder."
+          + "If the error appears again, check your PATH for multiple elm installations and verify your installed version",
+        );
+
+        throw error;
+      }
+
       this.rootProject = await this.loadRootProject(pathToElmJson);
       this.forest = new Forest(this.rootProject);
 
@@ -426,6 +443,13 @@ export class Program implements IProgram {
           `Error parsing files for ${pathToElmJson}:\n${error.stack}`,
         );
       }
+    }
+
+    if (this.forest === null) {
+      this.connection.window.showWarningMessage(
+        `Extension will not work at all: workspace initialization failed for ${pathToElmJson}`
+        + "For more information, check the console output (F1 > Output, dropdown on the right, 'Elm (project name)')"
+      );
     }
   }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -448,7 +448,7 @@ export class Program implements IProgram {
     if (this.forest === null) {
       this.connection.window.showWarningMessage(
         `Extension will not work at all: workspace initialization failed for ${pathToElmJson}` +
-          "For more information, check the console output (F1 > Output, dropdown on the right, 'Elm (project name)')",
+          "For more information, check your extension logs (VSCode: F1 > Output, dropdown on the right, 'Elm (project name)')",
       );
     }
   }


### PR DESCRIPTION
The current error handling for the workspace initialization silently fails, providing no visible error indication. This leaves extensions in an unusable state, just reporting `TypeError: Cannot read property 'getTree' of undefined` in the console because `this.forest` was never assigned https://github.com/elm-tooling/elm-language-server/blob/b22398b3398b20640cbdd9cc6d6b70a14826b800/src/compiler/program.ts#L388-L390

The main cause for this failure is a broken package cache, most likely caused by incompatible or multiple elm installations.

Similar things happened to multiple users, #518 #646 #687 and elm-tooling/elm-language-client-vscode#233. #640 is also most likely caused by this.

The final warning might need adjustments, as the LS is used in multipled IDEs.

The information message for the package cache is already very long, but users should also verify that the mentioned path actually does not exist and that there is no other location inside the cache providing that package.
