### PR TITLE
Fix for reference count of function in a let, with a type annotation.

### DIFF
--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -449,6 +449,21 @@ export function createTypeChecker(program: IProgram): TypeChecker {
           diagnostics: [],
         };
       }
+
+      // This is for values, with type annotation, but *inside* a let.
+      if (nodeParent.nextNamedSibling?.type === "value_declaration") {
+        // A value_declaration with a type annotation got it's type_annotation node
+        // added. So, we confirm the value_declaration does indeed follow, and return
+        // type node text with value declaration node.
+        return {
+          symbol: {
+            name: nodeText,
+            node: nodeParent.nextNamedSibling.children[0], // the function_declaration_left
+            type: "Function",
+          },
+          diagnostics: [],
+        };
+      }
     } else if (
       (nodeParentType === "exposed_type" &&
         nodeParent.parent?.parent?.type === "module_declaration") ||


### PR DESCRIPTION
This fixes a bug where values in a `let...in` have a zero reference count, if they have a type annotation.

This gif demonstrates the problem. Watch how the count changes from 2 to 0 depending on the presence of the type annotation. 
![Code_NklwL66TI0](https://user-images.githubusercontent.com/85681/167041870-8ccc8d8b-465d-4b04-b41c-ecce6a65f976.gif)
