### PR TITLE
Fix type inference of non-rigid number vars

### DIFF
--- a/src/compiler/typeInference.ts
+++ b/src/compiler/typeInference.ts
@@ -2475,7 +2475,10 @@ export class InferenceScope {
           TMutableRecord(Object.assign({}, type2.fields), type2.baseType),
         );
       } else {
-        assign(type1, type2);
+        const typeClass1 = getTypeclassName(type1);
+        if (type1.rigid || !typeClass1) {
+          assign(type1, type2);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #697. This is also a bug in intelij-elm. I am not fully confident with this fix, mostly because the compiler behavior here is a little confusing, but it passes all tests so I think it should be fine.