### PR TITLE
Add exposing type with variants action

### DIFF
--- a/src/providers/codeAction/exposeUnexposeCodeAction.ts
+++ b/src/providers/codeAction/exposeUnexposeCodeAction.ts
@@ -87,26 +87,19 @@ CodeActionProvider.registerRefactorAction(refactorName, {
             range: params.range,
           },
         });
-      }
-    }
 
-    if (
-      nodeAtPosition.type === "upper_case_identifier" &&
-      nodeAtPosition.parent?.type === "union_variant"
-    ) {
-      const typeName = nodeAtPosition.text;
-
-      if (!TreeUtils.isExposedTypeOrTypeAlias(tree, typeName)) {
-        result.push({
-          title: `Expose Type with Variants`,
-          kind: CodeActionKind.Refactor,
-          data: {
-            actionName: "expose_type_with_variants",
-            refactorName,
-            uri: params.sourceFile.uri,
-            range: params.range,
-          },
-        });
+        if (nodeAtPosition.parent?.type === "type_declaration") {
+          result.push({
+            title: `Expose Type with Variants`,
+            kind: CodeActionKind.Refactor,
+            data: {
+              actionName: "expose_type_with_variants",
+              refactorName,
+              uri: params.sourceFile.uri,
+              range: params.range,
+            },
+          });
+        }
       }
     }
 

--- a/src/providers/codeAction/exposeUnexposeCodeAction.ts
+++ b/src/providers/codeAction/exposeUnexposeCodeAction.ts
@@ -90,6 +90,26 @@ CodeActionProvider.registerRefactorAction(refactorName, {
       }
     }
 
+    if (
+      nodeAtPosition.type === "upper_case_identifier" &&
+      nodeAtPosition.parent?.type === "union_variant"
+    ) {
+      const typeName = nodeAtPosition.text;
+
+      if (!TreeUtils.isExposedTypeOrTypeAlias(tree, typeName)) {
+        result.push({
+          title: `Expose Type with Variants`,
+          kind: CodeActionKind.Refactor,
+          data: {
+            actionName: "expose_type_with_variants",
+            refactorName,
+            uri: params.sourceFile.uri,
+            range: params.range,
+          },
+        });
+      }
+    }
+
     return result;
   },
   getEditsForAction: (
@@ -109,14 +129,17 @@ CodeActionProvider.registerRefactorAction(refactorName, {
         const edit = RefactorEditUtils.unexposedValueInModule(
           tree,
           nodeAtPosition.text,
+
         );
         return edit ? { edits: [edit] } : {};
       }
       case "expose_function":
-      case "expose_type": {
+      case "expose_type":
+      case "expose_type_with_variants": {
         const edit = RefactorEditUtils.exposeValueInModule(
           tree,
           nodeAtPosition.text,
+          actionName === "expose_type_with_variants",
         );
         return edit ? { edits: [edit] } : {};
       }

--- a/src/providers/codeAction/exposeUnexposeCodeAction.ts
+++ b/src/providers/codeAction/exposeUnexposeCodeAction.ts
@@ -129,7 +129,6 @@ CodeActionProvider.registerRefactorAction(refactorName, {
         const edit = RefactorEditUtils.unexposedValueInModule(
           tree,
           nodeAtPosition.text,
-
         );
         return edit ? { edits: [edit] } : {};
       }

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -113,7 +113,7 @@ export class RefactorEditUtils {
       const lastExposedNode = exposedNodes[exposedNodes.length - 1];
 
       if (withVariants) {
-        valueName += '(..)'
+        valueName += "(..)";
       }
 
       if (lastExposedNode) {

--- a/src/util/refactorEditUtils.ts
+++ b/src/util/refactorEditUtils.ts
@@ -105,11 +105,16 @@ export class RefactorEditUtils {
   public static exposeValueInModule(
     tree: Tree,
     valueName: string,
+    withVariants = false,
   ): TextEdit | undefined {
     const exposedNodes = TreeUtils.getModuleExposingListNodes(tree);
 
     if (exposedNodes.length > 0) {
       const lastExposedNode = exposedNodes[exposedNodes.length - 1];
+
+      if (withVariants) {
+        valueName += '(..)'
+      }
 
       if (lastExposedNode) {
         return TextEdit.insert(

--- a/test/codeActionTests/exposeUnexposeCodeAction.test.ts
+++ b/test/codeActionTests/exposeUnexposeCodeAction.test.ts
@@ -136,4 +136,37 @@ type World =
       expectedSource,
     );
   })
+
+  test("exposing a type with all variants is available", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (hello)
+
+hello : string
+hello =
+    "hello"
+
+type World =
+    World
+  --^
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (hello, World(..))
+
+hello : string
+hello =
+    "hello"
+
+type World =
+    World
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: `Expose Type with Variants` }],
+      expectedSource,
+    );
+  })
 })

--- a/test/codeActionTests/exposeUnexposeCodeAction.test.ts
+++ b/test/codeActionTests/exposeUnexposeCodeAction.test.ts
@@ -146,21 +146,23 @@ hello : string
 hello =
     "hello"
 
-type World =
-    World
-  --^
+type Hoge
+   --^
+    = Hello
+    | World
 `;
 
     const expectedSource = `
 --@ Test.elm
-module Test exposing (hello, World(..))
+module Test exposing (hello, Hoge(..))
 
 hello : string
 hello =
     "hello"
 
-type World =
-    World
+type Hoge
+    = Hello
+    | World
 `;
 
     await testCodeAction(

--- a/test/codeActionTests/exposeUnexposeCodeAction.test.ts
+++ b/test/codeActionTests/exposeUnexposeCodeAction.test.ts
@@ -70,4 +70,70 @@ world =
       expectedSource,
     );
   })
+
+  test("exposing a type is available", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (hello)
+
+hello : string
+hello =
+    "hello"
+
+type World =
+   --^
+    World
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (hello, World)
+
+hello : string
+hello =
+    "hello"
+
+type World =
+    World
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: `Expose Type` }],
+      expectedSource,
+    );
+  })
+
+  test("unexposing a type is available", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (hello, World)
+
+hello : string
+hello =
+    "hello"
+
+type World =
+   --^
+    World
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (hello)
+
+hello : string
+hello =
+    "hello"
+
+type World =
+    World
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: `Unexpose Type` }],
+      expectedSource,
+    );
+  })
 })


### PR DESCRIPTION
Currently, expose/unexpose action does not cover exposing types with variants, but I want that capability.

This PR implements it.