### PR TITLE
Don't try to get code actions when there is a top level parsing error

### DIFF
--- a/src/providers/codeActionProvider.ts
+++ b/src/providers/codeActionProvider.ts
@@ -280,6 +280,14 @@ export class CodeActionProvider {
 
   protected onCodeAction(params: ICodeActionParams): CodeAction[] | undefined {
     this.connection.console.info("A code action was requested");
+
+    // Don't try to get them if there is a top level parse error
+    // It can create many diagnostics which cause a huge performance hit
+    // Code actions aren't useful in this case anyways
+    if (params.sourceFile.tree.rootNode.type === "ERROR") {
+      return [];
+    }
+
     const make = this.elmMake.onCodeAction(params);
 
     const results: (ICodeAction | IRefactorCodeAction)[] = [];


### PR DESCRIPTION
During a top level parsing error (like an unclosed if else statement), sometimes many hundreds of incorrect diagnostics would be created, due to invalid tree syntax state. The language server would get stuck trying to calculate "fix all" code actions, since it has to loop through each diagnostic. Eventually I would have to restart the language server. This change should allow it to recover during this case. I also way to explore cancellation of code action requests to see if that would provide any benefit. We should also look if we can have the parser handle an unclosed if else statement better.