### PR TITLE
Fix incorrect path returned by rename-function

### DIFF
--- a/src/providers/handlers/moveRefactoringHandler.ts
+++ b/src/providers/handlers/moveRefactoringHandler.ts
@@ -12,6 +12,7 @@ import { ElmWorkspaceMatcher } from "../../util/elmWorkspaceMatcher";
 import { RefactorEditUtils } from "../../util/refactorEditUtils";
 import { References } from "../../compiler/references";
 import { TreeUtils } from "../../util/treeUtils";
+import * as path from "path";
 
 export class MoveRefactoringHandler {
   private connection: Connection;
@@ -45,7 +46,7 @@ export class MoveRefactoringHandler {
         const rootPath = params.program.getRootPath().fsPath;
 
         uri = uri.slice(rootPath.length + 1);
-        const index = uri.lastIndexOf("\\");
+        const index = uri.lastIndexOf(path.sep);
 
         return {
           name: uri.slice(index + 1),


### PR DESCRIPTION
Previously the path would end with .el instead of .elm because,
the last letter was chopped off.

Ideally, the module name should be used instead of path in `name`, but this just fixes the bug.

<img width="693" alt="Screenshot 2022-11-04 at 20 13 54" src="https://user-images.githubusercontent.com/157210/200058148-ee1dbd05-2208-4db9-9aff-cd68e4871ade.png">
