### PR TITLE
Add completions for destructured record patterns and ports

### DIFF
--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -95,6 +95,7 @@ export interface TypeChecker {
     moduleNameOrAlias: string,
     sourceFile: ISourceFile,
   ) => SyntaxNode[];
+  getSymbolsInScope(node: SyntaxNode, sourceFile: ISourceFile): ISymbol[];
 }
 
 export function createTypeChecker(program: IProgram): TypeChecker {
@@ -124,6 +125,7 @@ export function createTypeChecker(program: IProgram): TypeChecker {
     getDiagnosticsAsync,
     getSuggestionDiagnostics,
     findImportModuleNameNodes,
+    getSymbolsInScope,
   };
 
   return typeChecker;
@@ -888,6 +890,23 @@ export function createTypeChecker(program: IProgram): TypeChecker {
         .map((s) => s.node.childForFieldName("moduleName"))
         .filter(Utils.notUndefinedOrNull) ?? []
     );
+  }
+
+  function getSymbolsInScope(
+    node: SyntaxNode,
+    sourceFile: ISourceFile,
+  ): ISymbol[] {
+    const symbols: ISymbol[] = [];
+
+    let targetScope: SyntaxNode | null = node;
+    while (targetScope != null) {
+      sourceFile.symbolLinks
+        ?.get(targetScope)
+        ?.forEach((symbol) => symbols.push(symbol));
+      targetScope = targetScope.parent;
+    }
+
+    return symbols;
   }
 
   function checkNode(node: SyntaxNode): void {

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -955,6 +955,8 @@ export class CompletionProvider {
     const result: CompletionItem[] = [];
 
     checker.getSymbolsInScope(node, sourceFile).forEach((symbol, i) => {
+      // getSymbolsInScope returns ths symbols in order of inner scope to outer scope,
+      // so we add the index to the sort order so the variables that are "closer" to the position are sorted first
       const sortPrefix = `a${i}`;
       if (symbol.type === "Function") {
         // Only get let functions here

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -953,7 +953,6 @@ export class CompletionProvider {
     range: Range,
   ): CompletionItem[] {
     const result: CompletionItem[] = [];
-    const tree = sourceFile.tree;
 
     checker.getSymbolsInScope(node, sourceFile).forEach((symbol, i) => {
       const sortPrefix = `a${i}`;

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -998,32 +998,23 @@ export class CompletionProvider {
           }),
         );
 
-        const annotationTypeNode =
-          TreeUtils.getTypeOrTypeAliasOfFunctionParameter(symbol.node);
-        if (annotationTypeNode) {
-          const typeDeclarationNode = TreeUtils.findTypeAliasDeclaration(
-            tree,
-            annotationTypeNode.text,
-          );
-          if (typeDeclarationNode) {
-            const fields =
-              TreeUtils.getAllFieldsFromTypeAlias(typeDeclarationNode);
-            if (fields) {
-              fields.forEach((element) => {
-                const hint = HintHelper.createHintForTypeAliasReference(
-                  element.type,
-                  element.field,
-                  symbol.name,
-                );
-                result.push(
-                  this.createFieldOrParameterCompletion(
-                    hint,
-                    `${symbol.name}.${element.field}`,
-                    range,
-                  ),
-                );
-              });
-            }
+        const parameterType = checker.findType(symbol.node);
+
+        if (parameterType.nodeType === "Record") {
+          for (const field in parameterType.fields) {
+            const hint = HintHelper.createHintForTypeAliasReference(
+              checker.typeToString(parameterType.fields[field]),
+              field,
+              symbol.name,
+            );
+
+            result.push(
+              this.createFieldOrParameterCompletion(
+                hint,
+                `${symbol.name}.${field}`,
+                range,
+              ),
+            );
           }
         }
       }

--- a/src/util/hintHelper.ts
+++ b/src/util/hintHelper.ts
@@ -19,7 +19,8 @@ export class HintHelper {
         return this.createHintFromFieldType(node);
       } else if (node.type === "port_annotation") {
         const name = node.childForFieldName("name");
-        if (name && typeString) {
+        const typeExpression = node.childForFieldName("typeExpression");
+        if (name && typeExpression) {
           let comment = "";
           if (
             node.previousNamedSibling &&
@@ -28,7 +29,10 @@ export class HintHelper {
             comment = node.previousNamedSibling.text;
           }
 
-          return this.formatHint(`${name.text} : ${typeString}`, comment);
+          return this.formatHint(
+            `${name.text} : ${typeExpression.text}`,
+            comment,
+          );
         }
       } else {
         return this.createHintFromDefinition(node);

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -1737,4 +1737,38 @@ testFunction =
 
     await testCompletions(source, ["field"]);
   });
+
+  it("Destructed record function parameter", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Model =
+  { prop1: String
+  , prop2: Int
+  }
+
+testFunction : Model -> a
+testFunction { prop1, prop2 } =
+    pr{-caret-}
+`;
+
+    await testCompletions(source, ["prop1", "prop2"], "partialMatch");
+  });
+
+  it("port completion", async () => {
+    const source = `
+--@ Test.elm
+port module Test exposing (..)
+
+x = 
+    f{-caret-}
+
+port foo : String -> Cmd msg
+
+port fbar : (String -> msg) -> Sub msg
+`;
+
+    await testCompletions(source, ["foo", "fbar"], "partialMatch");
+  });
 });

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -1771,4 +1771,26 @@ port fbar : (String -> msg) -> Sub msg
 
     await testCompletions(source, ["foo", "fbar"], "partialMatch");
   });
+
+  it("Completions for record fields", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Model =
+  { prop1: String
+  , prop2: Int
+  }
+
+view : Model -> String
+view model =
+    m{-caret-}
+`;
+
+    await testCompletions(
+      source,
+      ["model.prop1", "model.prop2"],
+      "partialMatch",
+    );
+  });
 });


### PR DESCRIPTION
Added some missing completions for destructed record patterns and ports. I was able to simplify the logic by using the existing symbol binder.