### PR TITLE
Fix a bug with extract function parameter calculation

### DIFF
--- a/test/codeActionTests/codeActionTestBase.ts
+++ b/test/codeActionTests/codeActionTestBase.ts
@@ -113,12 +113,11 @@ export async function testCodeAction(
     .resolve(DiagnosticsProvider)
     .forceElmLsDiagnosticsUpdate(sourceFile, program);
 
-  const range = { start: result.position, end: result.position };
   const codeActions =
     codeActionProvider.handleCodeAction({
       program,
       sourceFile,
-      range,
+      range: result.range,
       textDocument: { uri: testUri },
       context: {
         diagnostics: [
@@ -129,7 +128,7 @@ export async function testCodeAction(
             .createDiagnostics(sourceFile, program)
             .map(convertToCompilerDiagnostic),
         ]
-          .filter((diag) => Utils.rangeOverlaps(diag.range, range))
+          .filter((diag) => Utils.rangeOverlaps(diag.range, result.range))
           .map(convertFromCompilerDiagnostic),
       },
     }) ?? [];
@@ -165,7 +164,9 @@ export async function testCodeAction(
       const edits = changesToApply[URI.file(path.join(srcUri, uri)).toString()];
       if (edits) {
         expect(
-          applyEditsToSource(stripCommentLines(result.sources[uri]), edits),
+          trimTrailingWhitespace(
+            applyEditsToSource(stripCommentLines(result.sources[uri]), edits),
+          ),
         ).toEqual(source);
       }
     });

--- a/test/codeActionTests/extractFunctionCodeAction.test.ts
+++ b/test/codeActionTests/extractFunctionCodeAction.test.ts
@@ -18,8 +18,8 @@ foo val str =
                     prop1 + prop2 + val + field2
 
                 Nothing ->
-                               --^
                     field2 + val2
+                               --^
 
         Nothing ->
             str + val2
@@ -72,8 +72,8 @@ foo val str =
             (\\{ prop1, prop2 } ->
           --^
                 prop1 + prop2 + val + field2)
-                --^
             field1
+                --^
 
         Nothing ->
             str + val2
@@ -127,8 +127,8 @@ foo val str =
             (\\{ prop1, prop2 } ->
           --^
                 prop1 + prop2 + val + field2)
-                --^
             field1
+                --^
 
         Nothing ->
             str + val2
@@ -185,8 +185,8 @@ foo val =
     val 
   --^
         + val2 
-                --^
         + Foo.val2
+                --^
   
 `;
 
@@ -236,8 +236,8 @@ foo val str =
                     prop1 + prop2 + val + field2 + field4
 
                 Nothing ->
-                               --^
                     field2 + val2
+                               --^
 
         Nothing ->
             str + val2
@@ -300,8 +300,8 @@ foo val str =
                     prop1 + prop2 + val + field2 + field4
 
                 Nothing ->
-                               --^
                     field2 + val2
+                               --^
 
         Nothing ->
             str + val2

--- a/test/codeActionTests/extractFunctionCodeAction.test.ts
+++ b/test/codeActionTests/extractFunctionCodeAction.test.ts
@@ -1,0 +1,345 @@
+import { testCodeAction } from "./codeActionTestBase";
+
+describe("extract function code action", () => {
+  it("should extract function and compute parameters", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            case field1 of
+          --^
+                Just { prop1, prop2 } ->
+                    prop1 + prop2 + val + field2
+
+                Nothing ->
+                               --^
+                    field2 + val2
+
+        Nothing ->
+            str + val2
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            newFunction field1 val field2
+
+        Nothing ->
+            str + val2
+
+
+newFunction : Maybe { a | prop1 : number, prop2 : number } -> Maybe { b | field1 : Maybe { a | prop1 : number, prop2 : number }, field2 : unknown, field3 : c } -> unknown -> unknown
+newFunction field1 val field2 =
+    case field1 of
+        Just { prop1, prop2 } ->
+            prop1 + prop2 + val + field2
+
+        Nothing ->
+            field2 + val2
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Extract function to top level" }],
+      expectedSource,
+    );
+  });
+
+  it("should extract function - without inner destructured parameters", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            (\\{ prop1, prop2 } ->
+          --^
+                prop1 + prop2 + val + field2)
+                --^
+            field1
+
+        Nothing ->
+            str + val2
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            newFunction val field2 field1
+
+        Nothing ->
+            str + val2
+
+
+newFunction : Maybe { a | field1 : { b | prop1 : number, prop2 : number }, field2 : unknown, field3 : c } -> unknown -> { b | prop1 : number, prop2 : number } -> unknown
+newFunction val field2 field1 =
+    (\\{ prop1, prop2 } ->
+        prop1 + prop2 + val + field2)
+    field1
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Extract function to top level" }],
+      expectedSource,
+    );
+  });
+
+  it("should extract function - without external record field parameters", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+type alias Field1 =
+    { prop1: Int, prop2: Int }
+
+foo : Maybe { field1: Field1, field2: Int, field3: Int } -> Int -> Int
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            (\\{ prop1, prop2 } ->
+          --^
+                prop1 + prop2 + val + field2)
+                --^
+            field1
+
+        Nothing ->
+            str + val2
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+type alias Field1 =
+    { prop1: Int, prop2: Int }
+
+foo : Maybe { field1: Field1, field2: Int, field3: Int } -> Int -> Int
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            newFunction val field2 field1
+
+        Nothing ->
+            str + val2
+
+
+newFunction : Maybe { field1 : Field1, field2 : Int, field3 : Int } -> Int -> Field1 -> unknown
+newFunction val field2 field1 =
+    (\\{ prop1, prop2 } ->
+        prop1 + prop2 + val + field2)
+    field1
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Extract function to top level" }],
+      expectedSource,
+    );
+  });
+
+  it("should extract function - without parameter from another file", async () => {
+    const source = `
+--@ Foo.elm
+module Foo exposing (..)
+
+val2 = 
+    0
+
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (..)
+
+foo val =
+    val 
+  --^
+        + val2 
+                --^
+        + Foo.val2
+  
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+import Foo exposing (..)
+
+foo val =
+    newFunction val
+
+
+newFunction : number -> number
+newFunction val =
+    val 
+        + val2 
+        + Foo.val2
+
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Extract function to top level" }],
+      expectedSource,
+    );
+  });
+
+  it("should extract function to enclosing let - no parameters", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            let
+                field4 = 
+                    0
+            in
+            case field1 of
+          --^
+                Just { prop1, prop2 } ->
+                    prop1 + prop2 + val + field2 + field4
+
+                Nothing ->
+                               --^
+                    field2 + val2
+
+        Nothing ->
+            str + val2
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    case val of
+        Just { field1, field2, field3 } ->
+            let
+                field4 = 
+                    0
+
+
+                newFunction = 
+                    case field1 of
+                        Just { prop1, prop2 } ->
+                            prop1 + prop2 + val + field2 + field4
+
+                        Nothing ->
+                            field2 + val2
+            in
+            newFunction
+
+        Nothing ->
+            str + val2
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Extract function to enclosing let" }],
+      expectedSource,
+    );
+  });
+
+  it("should extract function to enclosing let - some parameters", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    let
+        field4 = 
+            0
+    in
+    case val of
+        Just { field1, field2, field3 } ->
+            case field1 of
+          --^
+                Just { prop1, prop2 } ->
+                    prop1 + prop2 + val + field2 + field4
+
+                Nothing ->
+                               --^
+                    field2 + val2
+
+        Nothing ->
+            str + val2
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+val2 = 
+    0
+
+foo val str =
+    let
+        field4 = 
+            0
+
+
+        newFunction field1 field2 = 
+            case field1 of
+                Just { prop1, prop2 } ->
+                    prop1 + prop2 + val + field2 + field4
+
+                Nothing ->
+                    field2 + val2
+    in
+    case val of
+        Just { field1, field2, field3 } ->
+            newFunction field1 field2
+
+        Nothing ->
+            str + val2
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Extract function to enclosing let" }],
+      expectedSource,
+    );
+  });
+});

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -127,11 +127,11 @@ describe("test elm diagnostics", () => {
 
     let nodeAtPosition: SyntaxNode = undefined!;
 
-    if ("position" in result) {
+    if ("range" in result) {
       const rootNode = program.getSourceFile(testUri)!.tree.rootNode;
       nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
         rootNode,
-        result.position,
+        result.range.start,
       );
     }
 

--- a/test/renameProvider.test.ts
+++ b/test/renameProvider.test.ts
@@ -58,7 +58,7 @@ describe("renameProvider", () => {
     const renameRange = renameProvider.onPrepareRenameRequest({
       program,
       sourceFile,
-      position: result.position,
+      position: result.range.start,
       textDocument: { uri: testUri },
     });
 
@@ -90,7 +90,7 @@ describe("renameProvider", () => {
     const renameEdit = renameProvider.onRenameRequest({
       program,
       sourceFile,
-      position: result.position,
+      position: result.range.start,
       textDocument: { uri: testUri },
       newName,
     });

--- a/test/typeInference.test.ts
+++ b/test/typeInference.test.ts
@@ -67,7 +67,7 @@ describe("test type inference", () => {
 
     const nodeAtPosition = TreeUtils.getNamedDescendantForPosition(
       sourceFile.tree.rootNode,
-      result.position,
+      result.range.start,
     );
 
     const declaration = TreeUtils.findParentOfType(

--- a/test/utils/sourceParser.ts
+++ b/test/utils/sourceParser.ts
@@ -1,8 +1,6 @@
-import { Position } from "vscode-languageserver";
+import { Position, Range } from "vscode-languageserver";
 
-export function getCaretPositionFromSource(
-  source: string,
-): {
+export function getCaretPositionFromSource(source: string): {
   position: Position;
   newSources: { [K: string]: string };
   fileWithCaret: string;
@@ -159,27 +157,35 @@ export function getInvokeAndTargetPositionFromSource(source: string): TestType {
 
 export function getTargetPositionFromSource(
   source: string,
-): { position: Position; sources: { [K: string]: string } } | undefined {
+): { range: Range; sources: { [K: string]: string } } | undefined {
   const sources = getSourceFiles(source);
 
-  let position: Position | undefined;
+  let startPosition: Position | undefined;
+  let endPosition: Position | undefined;
 
   for (const fileName in sources) {
     sources[fileName].split("\n").forEach((s, line) => {
       const invokeCharacter = s.search(/--(\^)/);
 
       if (invokeCharacter >= 0) {
-        position = {
-          line: line - 1,
-          character: invokeCharacter + 2,
-        };
+        if (!startPosition) {
+          startPosition = {
+            line: line - 1,
+            character: invokeCharacter + 2,
+          };
+        } else if (!endPosition) {
+          endPosition = {
+            line: line - 1,
+            character: invokeCharacter + 2,
+          };
+        }
       }
     });
   }
 
-  if (position) {
+  if (startPosition) {
     return {
-      position,
+      range: { start: startPosition, end: endPosition ?? startPosition },
       sources,
     };
   }

--- a/test/utils/sourceParser.ts
+++ b/test/utils/sourceParser.ts
@@ -175,7 +175,7 @@ export function getTargetPositionFromSource(
           };
         } else if (!endPosition) {
           endPosition = {
-            line: line - 1,
+            line: line - 2,
             character: invokeCharacter + 2,
           };
         }


### PR DESCRIPTION
This fixes a case where the extract function code action would incorrectly add parameters for inner destructured record fields. Also adds tests for other cases. 