### PR TITLE
Improve hover and completion type strings when there is a module prefix that uses an alias

### DIFF
--- a/src/compiler/imports.ts
+++ b/src/compiler/imports.ts
@@ -21,6 +21,7 @@ type FromModule = {
 
 export interface IImport extends ISymbol {
   fromModule: FromModule;
+  importNode?: SyntaxNode;
 }
 
 function importModuleEqual(a: IImport, b: IImport): boolean {
@@ -118,6 +119,7 @@ export class Imports {
               node: foundModuleNode,
               type: "Module",
               fromModule,
+              importNode,
             });
 
             const exposedFromRemoteModule = foundModule.exposing;

--- a/src/compiler/references.ts
+++ b/src/compiler/references.ts
@@ -442,38 +442,22 @@ export class References {
                   continue;
                 }
 
-                const moduleNameToLookFor =
-                  TreeUtils.findImportAliasOfModule(
-                    moduleNameNode.text,
-                    sourceFileToCheck.tree,
-                  ) ?? moduleNameNode.text;
-
-                // Check if it is imported
-                const imported = sourceFileToCheck.symbolLinks
-                  ?.get(sourceFileToCheck.tree.rootNode)
-                  ?.get(
-                    moduleNameToLookFor,
-                    (symbol) => symbol.type === "Import",
-                  );
+                const imported = checker
+                  .getAllImports(sourceFileToCheck)
+                  .getModule(moduleNameNode.text)
+                  ?.importNode?.childForFieldName("moduleName");
 
                 if (imported) {
-                  const importNameNode = checker.findImportModuleNameNodes(
-                    moduleNameToLookFor,
-                    sourceFileToCheck,
-                  )[0];
-
-                  if (importNameNode) {
-                    references.push({ node: importNameNode, uri });
-                  }
+                  references.push({ node: imported, uri });
                 }
 
-                // If it is not imported as an alias, find all references in file
-                if (imported && moduleNameToLookFor === moduleNameNode.text) {
+                // Find all references in file
+                if (imported) {
                   sourceFileToCheck.tree.rootNode
                     .descendantsOfType("value_expr")
                     .forEach((valueNode) => {
                       if (
-                        RegExp(`${moduleNameToLookFor}.[a-z].*`).exec(
+                        RegExp(`${moduleNameNode.text}.[a-z].*`).exec(
                           valueNode.text,
                         )
                       ) {

--- a/src/compiler/typeRenderer.ts
+++ b/src/compiler/typeRenderer.ts
@@ -38,7 +38,7 @@ export class TypeRenderer {
           )
           .join(" -> ")}`;
       case "Tuple":
-        return `(${t.types.map(this.render.bind(this)).join(", ")})`;
+        return `( ${t.types.map(this.render.bind(this)).join(", ")} )`;
       case "Union":
         return this.renderUnion(t);
       case "Record":

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -573,10 +573,9 @@ export class CompletionProvider {
       const dotIndex = label.lastIndexOf(".");
       const valuePart = label.slice(dotIndex + 1);
 
-      const importNode = checker.findImportModuleNameNodes(
-        element.fromModule.name,
-        sourceFile,
-      )[0]?.parent;
+      const importNode = checker
+        .getAllImports(sourceFile)
+        .getModule(element.fromModule.name)?.importNode;
 
       // Check if a value is already imported for this module using the exposing list
       // In this case, we want to prefex the unqualified value since they are using the import exposing list
@@ -1094,14 +1093,12 @@ export class CompletionProvider {
             } else if (!aMatches && bMatches) {
               return 1;
             } else {
-              const aModuleImported = !!checker.findImportModuleNameNodes(
-                a.module,
-                sourceFile,
-              )[0];
-              const bModuleImported = !!checker.findImportModuleNameNodes(
-                b.module,
-                sourceFile,
-              )[0];
+              const aModuleImported = !!checker
+                .getAllImports(sourceFile)
+                .getModule(a.module);
+              const bModuleImported = !!checker
+                .getAllImports(sourceFile)
+                .getModule(b.module);
 
               if (aModuleImported && !bModuleImported) {
                 return -1;
@@ -1242,7 +1239,13 @@ export class CompletionProvider {
     matchedSourceFiles
       .flatMap(ImportUtils.getPossibleImportsOfTree.bind(this))
       .forEach((value) => {
-        const markdownDocumentation = HintHelper.createHint(value.node);
+        const type = checker.findType(value.node);
+        const typeString = checker.typeToString(type, sourceFile);
+
+        const markdownDocumentation = HintHelper.createHint(
+          value.node,
+          typeString,
+        );
         let additionalTextEdits: TextEdit[] | undefined;
         let detail: string | undefined;
 

--- a/src/providers/findTestsProvider.ts
+++ b/src/providers/findTestsProvider.ts
@@ -131,18 +131,16 @@ function isTestSuite(
   const funName = findExpr("ValueExpr", call.target)?.name;
   const dot = funName?.lastIndexOf(".") ?? -1;
   const prefix = dot > -1 ? funName?.substring(0, dot) : undefined;
-  const qualifier: string =
+  const qualifier =
     prefix !== undefined
-      ? typeChecker.getQualifierForName(sourceFile, prefix, "describe") ?? ""
+      ? typeChecker.getQualifierForName(sourceFile, "Test", "describe")
       : "";
-  const moduleName =
-    prefix !== undefined
-      ? typeChecker.findImportModuleNameNodes(prefix, sourceFile)[0]?.text
-      : "Test";
   return (
-    qualifier !== undefined &&
     funName === `${qualifier}describe` &&
-    moduleName === "Test"
+    (!prefix ||
+      typeChecker
+        .findImportModuleNameNodes(prefix, sourceFile)
+        .some((n) => n.text === "Test"))
   );
 }
 

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -14,7 +14,7 @@ import { HintHelper } from "../util/hintHelper";
 import { TreeUtils } from "../util/treeUtils";
 import { ITextDocumentPositionParams } from "./paramsExtensions";
 
-type HoverResult = Hover | null | undefined;
+export type HoverResult = Hover | null | undefined;
 
 export class HoverProvider {
   private connection: Connection;

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -70,7 +70,7 @@ describe("CompletionProvider", () => {
       const completions =
         completionProvider.handleCompletion({
           textDocument: { uri: testUri },
-          position: position!,
+          position,
           context,
           program,
           sourceFile,

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -1541,7 +1541,7 @@ foo asInt myNumber =
     ]);
   });
 
-  it.only("operators from different files should not have an errors", async () => {
+  it("operators from different files should not have an errors", async () => {
     const source = `
 --@ Other.elm
 module Other exposing (foo)

--- a/test/hoverProvider.test.ts
+++ b/test/hoverProvider.test.ts
@@ -1,0 +1,143 @@
+import path from "path";
+import { MarkupContent } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import { HoverProvider, HoverResult } from "../src/providers";
+import { ITextDocumentPositionParams } from "../src/providers/paramsExtensions";
+import { getInvokePositionFromSource } from "./utils/sourceParser";
+import { baseUri, SourceTreeParser, srcUri } from "./utils/sourceTreeParser";
+
+class MockHoverProvider extends HoverProvider {
+  handleHover = (params: ITextDocumentPositionParams): HoverResult => {
+    return this.handleHoverRequest(params);
+  };
+}
+
+describe("HoverProvider", () => {
+  const treeParser = new SourceTreeParser();
+
+  async function testHover(source: string, expectContains: string) {
+    await treeParser.init();
+    const hoverProvider = new MockHoverProvider();
+
+    const { invokePosition, invokeFile, sources } =
+      getInvokePositionFromSource(source);
+
+    if (!invokePosition) {
+      throw new Error("Getting position failed");
+    }
+
+    const testUri = URI.file(
+      path.join(invokeFile.startsWith("tests") ? baseUri : srcUri, invokeFile),
+    ).toString();
+
+    const program = await treeParser.getProgram(sources);
+    const sourceFile = program.getSourceFile(testUri);
+
+    if (!sourceFile) throw new Error("Getting source file failed");
+
+    const hover = hoverProvider.handleHover({
+      textDocument: { uri: testUri },
+      position: invokePosition,
+      program,
+      sourceFile,
+    });
+
+    if (!hover) {
+      expect(hover).toBeTruthy();
+      return;
+    }
+
+    if (MarkupContent.is(hover.contents)) {
+      expect(hover.contents.value).toContain(expectContains);
+    } else {
+      expect(MarkupContent.is(hover.contents)).toBeTruthy();
+    }
+  }
+
+  it("type should not have module prefix if it from the current module", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo = 
+		String
+
+foo : Foo
+foo = ""
+
+bar = foo
+     --^
+    `;
+
+    await testHover(source, "foo : Foo");
+  });
+
+  it("should have module prefix if it is from the another module and the current module doesn't have one", async () => {
+    const source = `
+--@ Another.elm
+module Another exposing (..)
+
+type alias Foo = 
+		String
+
+foo : Foo
+foo = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+import Another exposing (foo)
+
+bar = foo
+     --^
+    `;
+
+    await testHover(source, "foo : Another.Foo");
+  });
+
+  it("should have module prefix if it is from the another module and the current module has one already", async () => {
+    const source = `
+--@ Another.elm
+module Another exposing (..)
+
+type alias Foo = 
+		String
+
+foo : Foo
+foo = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+import Another exposing (foo)
+
+bar = foo
+     --^
+    `;
+
+    await testHover(source, "foo : Another.Foo");
+  });
+
+  it("should have aliases module prefix if it from the another module", async () => {
+    const source = `
+--@ Another.elm
+module Another exposing (..)
+
+type alias Foo = 
+		String
+
+foo : Foo
+foo = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+import Another as AnotherAlias exposing (foo)
+
+bar = foo
+     --^
+    `;
+
+    await testHover(source, "foo : AnotherAlias.Foo");
+  });
+});

--- a/test/typeInference.test.ts
+++ b/test/typeInference.test.ts
@@ -386,7 +386,7 @@ func a b =
 `;
     await testTypeInference(
       basicsSources + source,
-      "number -> number -> (List number, ())",
+      "number -> number -> ( List number, () )",
     );
   });
 
@@ -489,7 +489,7 @@ func a =
 `;
     await testTypeInference(
       basicsSources + source,
-      "({ a | d : (), e : b }, c) -> number",
+      "( { a | d : (), e : b }, c ) -> number",
     );
   });
 
@@ -693,7 +693,7 @@ bug =
 `;
     await testTypeInference(
       basicsSources + source,
-      "a -> b -> (c -> (d -> (e -> (f -> (g -> (h -> (i -> (j -> (k -> (l -> (m -> (n -> (o -> (p -> (q -> (r -> (s -> (t -> (u -> (v -> (w -> (x -> (y -> (z -> (a1 -> (b1 -> (a, b1), a1), z), y), x), w), v), u), t), s), r), q), p), o), n), m), l), k), j), i), h), g), f), e), d), c), b)",
+      "a -> b -> ( c -> ( d -> ( e -> ( f -> ( g -> ( h -> ( i -> ( j -> ( k -> ( l -> ( m -> ( n -> ( o -> ( p -> ( q -> ( r -> ( s -> ( t -> ( u -> ( v -> ( w -> ( x -> ( y -> ( z -> ( a1 -> ( b1 -> ( a, b1 ), a1 ), z ), y ), x ), w ), v ), u ), t ), s ), r ), q ), p ), o ), n ), m ), l ), k ), j ), i ), h ), g ), f ), e ), d ), c ), b )",
     );
   });
 

--- a/test/utils/sourceParser.ts
+++ b/test/utils/sourceParser.ts
@@ -1,3 +1,4 @@
+import { fail } from "assert";
 import { Position, Range } from "vscode-languageserver";
 
 export function getCaretPositionFromSource(source: string): {
@@ -153,6 +154,36 @@ export function getInvokeAndTargetPositionFromSource(source: string): TestType {
       invokeFile,
     };
   }
+}
+
+export function getInvokePositionFromSource(source: string): IInvokeTest {
+  const sources = getSourceFiles(source);
+
+  let invokePosition;
+  let invokeFile = "";
+
+  for (const fileName in sources) {
+    sources[fileName].split("\n").forEach((s, line) => {
+      const invokeCharacter = s.search(/--(\^)/);
+
+      if (invokeCharacter >= 0) {
+        invokePosition = {
+          line: line - 1,
+          character: invokeCharacter + 2,
+        };
+        invokeFile = fileName;
+      }
+    });
+  }
+
+  if (!invokePosition) {
+    fail();
+  }
+  return {
+    invokePosition,
+    sources,
+    invokeFile,
+  };
 }
 
 export function getTargetPositionFromSource(


### PR DESCRIPTION
This fixes some cases of the module prefix being missing in a hover or completion type string when a module alias was used.