### PR TITLE
Fix case statement constant binding inference

### DIFF
--- a/src/compiler/typeInference.ts
+++ b/src/compiler/typeInference.ts
@@ -1793,22 +1793,22 @@ export class InferenceScope {
         this.isAssignable(pattern, ty, TUnit, undefined, true);
         break;
       case "StringConstant":
-		if (isParameter) {
-		  this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
-		}
-		this.isAssignable(pattern, ty, TString(), undefined, true);
-		break;
+        if (isParameter) {
+          this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
+        }
+        this.isAssignable(pattern, ty, TString(), undefined, true);
+        break;
       case "NumberConstant":
-		if (isParameter) {
-		  this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
-		}
-		this.isAssignable(pattern, ty, TInt(), undefined, true);
-		break;
+        if (isParameter) {
+          this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
+        }
+        this.isAssignable(pattern, ty, TInt(), undefined, true);
+        break;
       case "CharConstantExpr":
         if (isParameter) {
           this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
         }
-		this.isAssignable(pattern, ty, TChar(), undefined, true);
+        this.isAssignable(pattern, ty, TChar(), undefined, true);
         break;
       default:
         throw new Error("Unexpected pattern type: " + pattern.nodeType);

--- a/src/compiler/typeInference.ts
+++ b/src/compiler/typeInference.ts
@@ -1793,11 +1793,22 @@ export class InferenceScope {
         this.isAssignable(pattern, ty, TUnit, undefined, true);
         break;
       case "StringConstant":
+		if (isParameter) {
+		  this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
+		}
+		this.isAssignable(pattern, ty, TString(), undefined, true);
+		break;
       case "NumberConstant":
+		if (isParameter) {
+		  this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
+		}
+		this.isAssignable(pattern, ty, TInt(), undefined, true);
+		break;
       case "CharConstantExpr":
         if (isParameter) {
           this.diagnostics.push(error(pattern, Diagnostics.PartialPattern));
         }
+		this.isAssignable(pattern, ty, TChar(), undefined, true);
         break;
       default:
         throw new Error("Unexpected pattern type: " + pattern.nodeType);

--- a/test/typeInference.test.ts
+++ b/test/typeInference.test.ts
@@ -494,7 +494,7 @@ func a =
 `;
     await testTypeInference(
       basicsSources + source,
-      "( { a | d : (), e : b }, c ) -> number",
+      "( { a | d : (), e : Char }, String ) -> number",
     );
   });
 
@@ -761,5 +761,70 @@ number i =
       basicsSources + listSources + source3,
       "Float -> List Float",
     );
+  });
+
+  test("case statement () constant binding", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func a =
+--^
+    case a of 
+		() ->
+			1
+`;
+    await testTypeInference(basicsSources + source, "() -> number");
+  });
+
+  test("case statement Char constant binding", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func a =
+--^
+    case a of 
+		'x' ->
+			1
+
+		_ -> 
+			3
+`;
+    await testTypeInference(basicsSources + source, "Char -> number");
+  });
+
+  test("case statement String constant binding", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func a =
+--^
+    case a of 
+		"x" ->
+			1
+
+		_ -> 
+			3
+`;
+    await testTypeInference(basicsSources + source, "String -> number");
+  });
+
+  test("case statement Int constant binding", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+func a =
+--^
+    case a of 
+		1 ->
+			1
+
+		_ -> 
+			3
+`;
+    await testTypeInference(basicsSources + source, "Int -> number");
   });
 });

--- a/test/typeInference.test.ts
+++ b/test/typeInference.test.ts
@@ -771,8 +771,8 @@ module Test exposing (..)
 func a =
 --^
     case a of 
-		() ->
-			1
+        () ->
+            1
 `;
     await testTypeInference(basicsSources + source, "() -> number");
   });
@@ -785,11 +785,11 @@ module Test exposing (..)
 func a =
 --^
     case a of 
-		'x' ->
-			1
+        'x' ->
+            1
 
-		_ -> 
-			3
+        _ -> 
+            3
 `;
     await testTypeInference(basicsSources + source, "Char -> number");
   });
@@ -802,11 +802,11 @@ module Test exposing (..)
 func a =
 --^
     case a of 
-		"x" ->
-			1
+        "x" ->
+            1
 
-		_ -> 
-			3
+        _ -> 
+            3
 `;
     await testTypeInference(basicsSources + source, "String -> number");
   });
@@ -819,11 +819,11 @@ module Test exposing (..)
 func a =
 --^
     case a of 
-		1 ->
-			1
+        1 ->
+            1
 
-		_ -> 
-			3
+        _ -> 
+            3
 `;
     await testTypeInference(basicsSources + source, "Int -> number");
   });


### PR DESCRIPTION
I noticed recently that `elm-language-server` would infer the wrong types for a simple case statement like the following: 

```elm
func x =
    case x of 
        "a" ->
            1
 
        _ ->
            2
```

The elm compiler infers a type of `String -> number`, but `elm-language-server` suggests `a -> number`. 

The fix seemed simple enough (I think?!?).  Making sure that the variable is assignable to the constants type did the trick.