### PR TITLE
fix: use the correct path to tree-sitter-elm.wasm

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -20,6 +20,7 @@ import { Settings } from "./util/settings";
 import { TextDocumentEvents } from "./util/textDocumentEvents";
 import { IFileSystemHost, InitializationOptions } from "./types";
 import { URI, Utils } from "vscode-uri";
+import { outDir } from "../directories";
 
 export function startCommonServer(
   connection: Connection,
@@ -59,10 +60,7 @@ export function startCommonServer(
       await Parser.init(options);
       const pathToWasm =
         initializationOptions.treeSitterElmWasmUri ??
-        Path.relative(
-          process.cwd(),
-          Path.join(__dirname, "tree-sitter-elm.wasm"),
-        );
+        Path.relative(process.cwd(), Path.join(outDir, "tree-sitter-elm.wasm"));
       connection.console.info(
         `Loading Elm tree-sitter syntax from ${pathToWasm}`,
       );

--- a/src/directories.ts
+++ b/src/directories.ts
@@ -1,0 +1,1 @@
+export const outDir = __dirname;

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "lib": ["es6", "ES2020", "WebWorker"]
   },
-  "include": ["src/common", "src/compiler", "src/browser"]
+  "include": ["src/common", "src/compiler", "src/browser", "src/directories.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["src/common", "src/compiler", "src/node"]
+  "include": ["src/common", "src/compiler", "src/node", "src/directories.ts"]
 }


### PR DESCRIPTION
## Description

* This fix is intended to solve #1052 
* The cause of the issue may be related to a recent refactor where the logic for building the file path to the `tree-sitter-elm.wasm` file had silently changed.
* There could be other solutions for this issue, but this PR attempts to simply correct the issue, but perhaps there's a better way for sharing the path to the `out` directory.