### PR TITLE
Add elm-format as dev dependency so tests can be run locally without a global install of elm-format

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,6 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm run compile
-      - run: npm install -g elm-format
       - run: npm test
 
   publish-npm:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,6 @@ jobs:
           npm ci
           npm run compile
           npm run lint
-          npm install -g elm-format
           npm test
         env:
           CI: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@typescript-eslint/parser": "^6.4.1",
         "copyfiles": "^2.4.1",
         "doctoc": "^2.2.1",
+        "elm-format": "^0.8.7",
         "eslint": "^8.39.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -72,6 +73,71 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@avh4/elm-format-darwin-arm64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-arm64/-/elm-format-darwin-arm64-0.8.7-2.tgz",
+      "integrity": "sha512-F5JD44mJ3KX960J5GkXMfh1/dtkXuPcQpX2EToHQKjLTZUfnhZ++ytQQt0gAvrJ0bzoOvhNzjNjUHDA1ruTVbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@avh4/elm-format-darwin-x64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-x64/-/elm-format-darwin-x64-0.8.7-2.tgz",
+      "integrity": "sha512-4pfF1cl0KyTion+7Mg4XKM3yi4Yc7vP76Kt/DotLVGJOSag4ISGic1og2mt8RZZ7XArybBmHNyYkiUbe/cEiCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@avh4/elm-format-linux-arm64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-arm64/-/elm-format-linux-arm64-0.8.7-2.tgz",
+      "integrity": "sha512-WkVmuce2zU6s9dupHhqPc886Vaqpea8dZlxv2fpZ4wSzPUbiiKHoHZzoVndMIMTUL0TZukP3Ps0n/lWO5R5+FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@avh4/elm-format-linux-x64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-x64/-/elm-format-linux-x64-0.8.7-2.tgz",
+      "integrity": "sha512-kmncfJrTBjVT94JtQvMf4M5Pn2Yl0sZt3wo7AzgFiDnB/CiZ+KjJyXuWM64NeGiv4MQqzPq65tsFXUH1CIJeiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@avh4/elm-format-win32-x64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-win32-x64/-/elm-format-win32-x64-0.8.7-2.tgz",
+      "integrity": "sha512-sBdMBGq/8mD8Y5C+fIr5vlb3N50yB7S1MfgeAq2QEbvkr/sKrCZI540i43lZDH9gWsfA1w2W8wCe0penFYzsGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -2702,6 +2768,23 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.377.tgz",
       "integrity": "sha512-H3BYG6DW5Z+l0xcfXaicJGxrpA4kMlCxnN71+iNX+dBLkRMOdVJqFJiAmbNZZKA1zISpRg17JR03qGifXNsJtw==",
       "dev": true
+    },
+    "node_modules/elm-format": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.7.tgz",
+      "integrity": "sha512-sVzFXfWnb+6rzXK+q3e3Ccgr6/uS5mFbFk1VSmigC+x2XZ28QycAa7lS8owl009ALPhRQk+pZ95Eq5ANjpEZsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "elm-format": "bin/elm-format"
+      },
+      "optionalDependencies": {
+        "@avh4/elm-format-darwin-arm64": "0.8.7-2",
+        "@avh4/elm-format-darwin-x64": "0.8.7-2",
+        "@avh4/elm-format-linux-arm64": "0.8.7-2",
+        "@avh4/elm-format-linux-x64": "0.8.7-2",
+        "@avh4/elm-format-win32-x64": "0.8.7-2"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6505,6 +6588,41 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
+    "@avh4/elm-format-darwin-arm64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-arm64/-/elm-format-darwin-arm64-0.8.7-2.tgz",
+      "integrity": "sha512-F5JD44mJ3KX960J5GkXMfh1/dtkXuPcQpX2EToHQKjLTZUfnhZ++ytQQt0gAvrJ0bzoOvhNzjNjUHDA1ruTVbg==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-darwin-x64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-x64/-/elm-format-darwin-x64-0.8.7-2.tgz",
+      "integrity": "sha512-4pfF1cl0KyTion+7Mg4XKM3yi4Yc7vP76Kt/DotLVGJOSag4ISGic1og2mt8RZZ7XArybBmHNyYkiUbe/cEiCw==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-linux-arm64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-arm64/-/elm-format-linux-arm64-0.8.7-2.tgz",
+      "integrity": "sha512-WkVmuce2zU6s9dupHhqPc886Vaqpea8dZlxv2fpZ4wSzPUbiiKHoHZzoVndMIMTUL0TZukP3Ps0n/lWO5R5+FA==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-linux-x64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-linux-x64/-/elm-format-linux-x64-0.8.7-2.tgz",
+      "integrity": "sha512-kmncfJrTBjVT94JtQvMf4M5Pn2Yl0sZt3wo7AzgFiDnB/CiZ+KjJyXuWM64NeGiv4MQqzPq65tsFXUH1CIJeiQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@avh4/elm-format-win32-x64": {
+      "version": "0.8.7-2",
+      "resolved": "https://registry.npmjs.org/@avh4/elm-format-win32-x64/-/elm-format-win32-x64-0.8.7-2.tgz",
+      "integrity": "sha512-sBdMBGq/8mD8Y5C+fIr5vlb3N50yB7S1MfgeAq2QEbvkr/sKrCZI540i43lZDH9gWsfA1w2W8wCe0penFYzsGw==",
+      "dev": true,
+      "optional": true
+    },
     "@babel/code-frame": {
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
@@ -8467,6 +8585,19 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.377.tgz",
       "integrity": "sha512-H3BYG6DW5Z+l0xcfXaicJGxrpA4kMlCxnN71+iNX+dBLkRMOdVJqFJiAmbNZZKA1zISpRg17JR03qGifXNsJtw==",
       "dev": true
+    },
+    "elm-format": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.7.tgz",
+      "integrity": "sha512-sVzFXfWnb+6rzXK+q3e3Ccgr6/uS5mFbFk1VSmigC+x2XZ28QycAa7lS8owl009ALPhRQk+pZ95Eq5ANjpEZsQ==",
+      "dev": true,
+      "requires": {
+        "@avh4/elm-format-darwin-arm64": "0.8.7-2",
+        "@avh4/elm-format-darwin-x64": "0.8.7-2",
+        "@avh4/elm-format-linux-arm64": "0.8.7-2",
+        "@avh4/elm-format-linux-x64": "0.8.7-2",
+        "@avh4/elm-format-win32-x64": "0.8.7-2"
+      }
     },
     "emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/parser": "^6.4.1",
     "copyfiles": "^2.4.1",
     "doctoc": "^2.2.1",
+    "elm-format": "^0.8.7",
     "eslint": "^8.39.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",


### PR DESCRIPTION
Context: https://github.com/elm-tooling/tree-sitter-elm/pull/145#pullrequestreview-1791679811

Adds elm-format as a dev dependency to allow test suite to run successfully without the need for a global install of elm-format.

This also makes it so the version of elm-format is stable between test runs.
