### PR TITLE
Round progress percentage to match the spec

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -169,7 +169,9 @@ export class Server implements ILanguageServer {
             const avgIndexed =
               all.reduce((sum, { indexedPercent }) => sum + indexedPercent, 0) /
               all.length;
-            progress.report(avgIndexed, "Indexing");
+            // Workaround: Rounding percentage to uint as per LSP spec
+            // https://github.com/microsoft/vscode-languageserver-node/issues/1412
+            progress.report(Math.round(avgIndexed), "Indexing");
           }),
         ),
     );

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -407,7 +407,9 @@ export class Program implements IProgram {
             .then((progress) => {
               progress.begin("Restarting Elm Language Server", 0);
               this._initializeProgressCallback = (percent: number): void => {
-                progress.report(percent, `${percent.toFixed(0)}%`);
+                // Workaround: Rounding percentage to uint as per LSP spec
+                // https://github.com/microsoft/vscode-languageserver-node/issues/1412
+                progress.report(Math.round(percent), `${percent.toFixed(0)}%`);
               };
 
               this.initWorkspace()


### PR DESCRIPTION
@absynce and I are trying to integrate `elm-language-server` with [Zed](https://github.com/zed-industries/zed) and running into the following error:

```
[2024-01-25T20:44:07Z ERROR lsp] error deserializing $/progress request: Error("data did not match any variant of untagged enum ProgressParamsValue", line: 1, column: 127), message: "{\"token\":\"36abce40-63b2-4fa1-8464-030400636f26\",\"value\":{\"kind\":\"report\",\"percentage\":100.00000000000155,\"message\":\"Indexing\"}}"
```

According to [the lsp specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgress) the `percentage` should be a uinteger. However, the actual value is a float. This works just fine if the receiving end is not strict about this, but the rust lsp implementation [assumes `percentage` to be a u32](https://docs.rs/lsp-types/latest/lsp_types/struct.WorkDoneProgressReport.html).

This PR fixes that by rounding the progress.