### PR TITLE
Fix the issue with the missing diagnostic.data

### DIFF
--- a/src/common/providers/codeActionProvider.ts
+++ b/src/common/providers/codeActionProvider.ts
@@ -293,6 +293,12 @@ export class CodeActionProvider {
     // and the fix all code action for that error if there are other diagnostics with
     // the same error code
     (<IDiagnostic[]>params.context.diagnostics).forEach((diagnostic) => {
+      // We have type casted diagnostic to `IDiagnostic`, however the original
+      // type is `Diagnostic`, the `.data` property may be missing in some cases
+      if (!diagnostic.data) {
+        return;
+      }
+
       const registrations =
         CodeActionProvider.errorCodeToRegistrationMap.getAll(
           diagnostic.data.code,


### PR DESCRIPTION
When integrating with Zed, I noticed the following error coming from elm-language-server:

```
[2024-01-25T20:47:42Z ERROR util] crates/editor/src/editor.rs:3506: Request textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'code')
```

I narrowed it down to the code where we get `registrations` by `diagnostic.data.code`. Somehow, there is a diagnostic, that doesn't have the `data` property. It is of the following shape: `{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"severity":1,"message":""}`.

Expecting and handing the missing `data`, similar to how we do it in [hasElmReviewFixes](https://github.com/elm-tooling/elm-language-server/blob/main/src/common/providers/diagnostics/elmReviewDiagnostics.ts#L28) made the error go away.

cc @absynce

