### PR TITLE
Remove associated data when removing type value

### DIFF
--- a/src/common/util/refactorEditUtils.ts
+++ b/src/common/util/refactorEditUtils.ts
@@ -476,14 +476,16 @@ export class RefactorEditUtils {
       return this.removeType(unionVariants[0].parent);
     }
 
-    let startPosition = nodeAtPosition.startPosition;
-    let endPosition = nodeAtPosition.endPosition;
-
     const unionVariant = unionVariants?.find(
       (a) =>
         a.text.startsWith(`${nodeAtPosition.text} `) ||
         a.text === nodeAtPosition.text,
     );
+
+    let startPosition =
+      unionVariant?.startPosition ?? nodeAtPosition.startPosition;
+    let endPosition = unionVariant?.endPosition ?? nodeAtPosition.endPosition;
+
     if (unionVariant?.previousSibling?.type == "eq") {
       startPosition = unionVariant.previousSibling?.endPosition;
       if (unionVariant.nextSibling?.type == "|") {

--- a/test/codeActionTests/removeUnusedCodeAction.test.ts
+++ b/test/codeActionTests/removeUnusedCodeAction.test.ts
@@ -305,4 +305,95 @@ func = foo + bar
       true,
     );
   });
+
+  it("removing type with single unused value constructor removes entire type", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (func)
+
+type Foo 
+    = Bar
+     --^
+
+func = 1
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (func)
+
+
+
+func = 1
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value constructor `Bar`" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing unused value constructor", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (func)
+
+type Foo 
+    = Bar
+    | Baz
+     --^
+
+func = Bar
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (func)
+
+type Foo 
+    = Bar
+
+func = Bar
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value constructor `Baz`" }],
+      expectedSource,
+      true,
+    );
+  });
+
+  it("removing unused value constructor also removes associated data type", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (func)
+
+type Foo 
+    = Bar
+    | Baz Int
+     --^
+
+func = Bar
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (func)
+
+type Foo 
+    = Bar
+
+func = Bar
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Remove unused value constructor `Baz`" }],
+      expectedSource,
+      true,
+    );
+  });
 });


### PR DESCRIPTION
Currently when trying to remove an unused type variant with associated data using the code action `Remove unused value constructor` the result is:

Before:
```elm
type Foo
    = Bar
    | Baz Int
```

After:
```elm
type Foo
    = Bar Int
```
It removed the type variant `Baz` but not the associated data but instead moved that to the previous type constructor

The following changes fixes that and also adds tests to verify that `Remove unused value constructor` in general works as expected.