### PR TITLE
Fix Add missing case branches action adding missing branches outside of parenthesis

### DIFF
--- a/src/common/providers/codeAction/addMissingCaseBranchesCodeAction.ts
+++ b/src/common/providers/codeAction/addMissingCaseBranchesCodeAction.ts
@@ -65,11 +65,16 @@ function getEdits(params: ICodeActionParams, range: Range): TextEdit[] {
       "",
     );
 
+    // case_of_expr might be wrapped in parenthesis, those are included in the case_of_expr's endPosition
+    // So we try to get the last case_of_branch's endPosition if it exists
+    // Otherwise we just fallback to taking the case_of_expr's end position
+    const insertPosition =
+      nodeAtPosition.children.filter((x) => x.type == "case_of_branch").at(-1)
+        ?.endPosition ?? nodeAtPosition.endPosition;
+
     return [
       TextEdit.insert(
-        PositionUtil.FROM_TS_POSITION(
-          nodeAtPosition.endPosition,
-        ).toVSPosition(),
+        PositionUtil.FROM_TS_POSITION(insertPosition).toVSPosition(),
         edit,
       ),
     ];

--- a/test/codeActionTests/addMissingCaseBranches.test.ts
+++ b/test/codeActionTests/addMissingCaseBranches.test.ts
@@ -92,4 +92,40 @@ func a b =
       expectedSource,
     );
   });
+
+  it("should add missing cases inside of ()", async () => {
+    const source = `
+    --@ Test.elm
+module Test exposing (..)
+
+func a =
+    (case a of
+    --^
+        1 ->
+            ""
+    )
+        |> Debug.log "test"
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+func a =
+    (case a of
+        1 ->
+            ""
+
+        _ ->
+            Debug.todo "branch '_' not implemented"
+    )
+        |> Debug.log "test"
+`;
+
+    await testCodeAction(
+      source,
+      [{ title: "Add missing case branches" }],
+      expectedSource,
+    );
+  });
 });


### PR DESCRIPTION
Currently if you have the following:
```elm
func a =
    (case a of
        1 ->
            ""
        
    )
        |> Debug.log "test"
```

And then use the `Add missing case branches` action, the result is:

```elm
func a =
    (case a of
        1 ->
            ""
        
    )

        _ ->
            Debug.todo "branch '_' not implemented"
        |> Debug.log "test"
```

The following changes fixes that by since the case_of_expr's endPosition includes the ending ) we instead try to find the last case_of_branch, and take its position as the insert position.
