### PR TITLE
Include type alias field line comment in hover info

### DIFF
--- a/src/common/util/hintHelper.ts
+++ b/src/common/util/hintHelper.ts
@@ -101,16 +101,24 @@ export class HintHelper {
       node,
     );
 
-    return this.formatHint(
-      node.text,
-      `Field${
-        typeAlias
-          ? ` on the type alias \`${
-              typeAlias?.childForFieldName("name")?.text ?? ""
-            }\``
-          : ""
-      }`,
-    );
+    const commentText =
+      node.nextSibling?.type === "line_comment"
+        ? this.stripComment(node.nextSibling.text)
+        : null;
+
+    const typeAliasHintText = `Field${
+      typeAlias
+        ? ` on the type alias \`${
+            typeAlias?.childForFieldName("name")?.text ?? ""
+          }\``
+        : ""
+    }`;
+
+    const lines = [];
+    if (commentText) lines.push(commentText);
+    lines.push(typeAliasHintText);
+
+    return this.formatHint(node.text, lines.join("\n\n"));
   }
 
   public static createHintFromDefinitionInCaseBranch(): string | undefined {
@@ -236,6 +244,9 @@ export class HintHelper {
     }
     if (newComment.endsWith("-}")) {
       newComment = newComment.slice(0, -2);
+    }
+    if (newComment.startsWith("-- ")) {
+      newComment = newComment.slice(3);
     }
 
     return newComment.trim();

--- a/test/hoverProvider.test.ts
+++ b/test/hoverProvider.test.ts
@@ -141,4 +141,53 @@ bar = foo
 
     await testHover(source, "foo : AnotherAlias.Foo");
   });
+
+  it("should include type alias field line comment in hover info", async () => {
+    // IMPORTING MODULE
+    const source = `
+--@ Another.elm
+module Another exposing (..)
+
+type alias Foo =
+    { bar: Int -- This is a comment explaining bar
+    , biz: String -- This is a comment explaining biz
+    }
+
+--@ Test.elm
+module Test exposing (..)
+
+import Another exposing (Foo)
+
+
+foo : Foo
+foo = 
+  { bar = 10
+  , biz = "Hello World"
+   --^
+  }
+    `;
+
+    await testHover(
+      source,
+      "\n```elm\nbiz: String\n```\n\n\n---\n\nThis is a comment explaining biz\n\nField on the type alias `Foo`",
+    );
+
+    // IN SAME FILE
+    const source2 = `
+--@ Another.elm
+module Another exposing (..)
+
+type alias Foo =
+    { bar: Int -- This is a comment explaining bar
+     --^
+    , biz: String -- This is a comment explaining biz
+    }
+     
+    `;
+
+    await testHover(
+      source2,
+      "\n```elm\nbar: Int\n```\n\n\n---\n\nThis is a comment explaining bar\n\nField on the type alias `Foo`",
+    );
+  });
 });


### PR DESCRIPTION
Currently when hovering on a type alias field this is what's shown
![image](https://github.com/elm-tooling/elm-language-server/assets/3757388/40f7768b-2dea-4266-9d68-a69624c2e8c6)

The line comment is not included in the hover text.

The following changes makes it so if a line comment is present for a given type alias field, it is included in the hover info as follows:

![image](https://github.com/elm-tooling/elm-language-server/assets/3757388/464a94ac-5c55-467b-b811-acc6b3300f4f)