### PR TITLE
Fix add missing case branches not being prefixed correctly

### DIFF
--- a/src/common/providers/codeAction/addMissingCaseBranchesCodeAction.ts
+++ b/src/common/providers/codeAction/addMissingCaseBranchesCodeAction.ts
@@ -68,7 +68,9 @@ function getEdits(params: ICodeActionParams, range: Range): TextEdit[] {
 
     const edit = PatternMatches.missing(patterns, params.program).reduce(
       (edit, missing) => {
-        if (prefix) missing = `${prefix}.${missing}`;
+        if (prefix) {
+          missing = `${prefix}.${missing}`;
+        }
 
         return `${edit}\n\n${branchIndent}${missing} ->\n${branchExprIndent}Debug.todo "branch '${missing}' not implemented"`;
       },

--- a/test/codeActionTests/addMissingCaseBranches.test.ts
+++ b/test/codeActionTests/addMissingCaseBranches.test.ts
@@ -128,4 +128,58 @@ func a =
       expectedSource,
     );
   });
+
+  it("should prefix branch variant if needed", async () => {
+    const source = `
+--@ Foo.elm
+module Foo exposing (..)
+
+type Foo
+    = Bar
+    | Biz
+
+--@ Test.elm
+module Test exposing (..)
+
+import Foo
+
+test : Foo -> ()
+test response =
+    case response of
+    --^
+        Foo.Bar ->
+            ()
+
+    `;
+
+    const expectedSource = `
+--@ Foo.elm
+module Foo exposing (..)
+
+type Foo
+    = Bar
+    | Biz
+
+--@ Test.elm
+module Test exposing (..)
+
+import Foo
+
+test : Foo -> ()
+test response =
+    case response of
+        Foo.Bar ->
+            ()
+
+        Foo.Biz ->
+            Debug.todo "branch 'Foo.Biz' not implemented"
+
+    `;
+
+    await testCodeAction(
+      source,
+      [{ title: "Add missing case branches" }],
+      expectedSource,
+    );
+  });
 });


### PR DESCRIPTION
Add missing case branches does not include prefix for variant
```elm
test : Http.Response () -> ()
test response =
    case response of
        Http.GoodStatus_ _ _ ->
            ()
```

After using code action `Add missing case branches`:

```elm
test : Http.Response () -> ()
test response =
    case response of
        Http.GoodStatus_ _ _ ->
            ()

        BadUrl_ _ ->
            Debug.todo "branch 'BadUrl_ _' not implemented"

        Timeout_ ->
            Debug.todo "branch 'Timeout_' not implemented"

        NetworkError_ ->
            Debug.todo "branch 'NetworkError_' not implemented"

        BadStatus_ _ _ ->
            Debug.todo "branch 'BadStatus_ _ _' not implemented"
```
Which fails to compile since the variants without prefix are not available in the scope of the file.