### PR TITLE
Fix incorrect linkedEditingRange triggers

### DIFF
--- a/src/common/util/utils.ts
+++ b/src/common/util/utils.ts
@@ -1,4 +1,5 @@
-import { Range, TextEdit } from "vscode-languageserver";
+import { Position, Range, TextEdit } from "vscode-languageserver";
+import { SyntaxNode } from "web-tree-sitter";
 
 export type NonEmptyArray<T> = [T, ...T[]];
 
@@ -77,6 +78,13 @@ export class Utils {
     }
 
     return [startIndex, endIndex];
+  }
+
+  public static rangeFromNode(node: SyntaxNode): Range {
+    return Range.create(
+      Position.create(node.startPosition.row, node.startPosition.column),
+      Position.create(node.endPosition.row, node.endPosition.column),
+    );
   }
 
   public static rotateArray<T>(array: T[], newStartIndex: number): T[] {


### PR DESCRIPTION
This fixes #1311.

1. Changes to either (1) the line before the type annotation or (2) the line between the type annotation and value declaration no longer trigger incorrect actions.
2. The new implementation also works for multiline type annotations.

The only problem I've encountered so far is that when I type a bit faster, the two lines go out of sync. I'm assuming this is a limitation of the LSP, but I might be mistaken.

P.S. I believe there is a way to make linked editing even better. Instead of just linking the type annotation and the value declaration, we could use references to modify all the instances of the identifier in the document at once. This might be slow, though. WDYT?