### PR TITLE
Be more lenient when resolving code actions

### DIFF
--- a/src/common/providers/codeActionProvider.ts
+++ b/src/common/providers/codeActionProvider.ts
@@ -113,11 +113,16 @@ export class CodeActionProvider {
     if (this.settings.isCodeActionResolveSupported("edit")) {
       this.connection.onRequest(
         CodeActionResolveRequest.method,
-        new ElmWorkspaceMatcher((codeAction: IRefactorCodeAction) =>
-          URI.parse(codeAction.data.uri),
-        ).handleResolve((codeAction, program, sourceFile) =>
-          this.onCodeActionResolve(codeAction, program, sourceFile),
-        ),
+        (codeAction: IRefactorCodeAction) => {
+          if (!codeAction.data.uri) {
+            return codeAction;
+          }
+          return new ElmWorkspaceMatcher((codeAction: IRefactorCodeAction) =>
+            URI.parse(codeAction.data.uri),
+          ).handleResolve((codeAction, program, sourceFile) =>
+            this.onCodeActionResolve(codeAction, program, sourceFile),
+          )(codeAction);
+        },
       );
     }
 


### PR DESCRIPTION
Return early for the ones that have no `uri` in their `data`.

-------------------

LSP spec has a set of peculiarities related to how client-server action resolve interaction is specified, which combined, makes certain editors to fail to use actions despite following the spec.

1. [`CodeActionClientCapabilities`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionClientCapabilities) on the editor side, allows to specify which `CodeAction` properties the editor might query the resolve request for:

```json5
/**
 * Whether the client supports resolving additional code action
 * properties via a separate `codeAction/resolve` request.
 *
 * @since 3.16.0
 */
resolveSupport?: {
	/**
	 * The properties that a client can resolve lazily.
	 */
	properties: string[];
};
```

2. The corresponding server capability does not provide a way to the language server to declare, what it can resolve:

```
Server Capability:

    property name (optional): codeActionProvider
    property type: boolean | CodeActionOptions where [CodeActionOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionOptions) is defined as follows:

export interface [CodeActionOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionOptions) extends [WorkDoneProgressOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgressOptions) {
	/**
	 * CodeActionKinds that this server may return.
	 *
	 * The list of kinds may be generic, such as `CodeActionKind.Refactor`,
	 * or the server may list out every specific kind they provide.
	 */
	codeActionKinds?: [CodeActionKind](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind)[];

	/**
	 * The server provides support to resolve additional
	 * information for a code action.
	 *
	 * @since 3.16.0
	 */
	resolveProvider?: boolean;
}
```

3. There's no place in the spec that defines when resolve and when not to resolve, what is an "incorrect" state to resolve, can resolves repeat after happening once, etc.
It's not even stated clear whether it's fine to resolve or not when there's no `data` field is present.

This leads to a miscommunication:

1. A client declares multiple code action fields that it can resolve (usually `edit` and `command`).
2. A server like this one does not care about the commands, edits only, but cannot return that knowledge back; neither it does ever send the `command` property back.
3. A client gets the action with `data` field (which LSP spec forbids it to introspect), no `command` field and a filled `edit` field.

What to do next on the client?

* A spec allows both fields to be present, according to 
```json5
/**
 * A command this code action executes. If a code action
 * provides an edit and a command, first the edit is
 * executed and then the command.
 */
command?: [Command](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#command);

```

* So, maybe the client did not send the `command` back because it did not resolve? We cannot know, so we might want to send another request, just in case, esp. given that `data` field, used only for resolution, is not `null`.

But then, https://github.com/zed-industries/zed/issues/19834 happens for Zed editor, and similarly, Helix editor fill follow the same road:
https://github.com/helix-editor/helix/blob/ab97585b69f11b159a447c85dfd528cc241cf1e3/helix-term/src/commands/lsp.rs#L782-L784

where both try to resolve the action, but get the error back, as `data.uri` is `undefined`.

That `data` seems to be important as extracted into the type:

https://github.com/elm-tooling/elm-language-server/blob/813789f2cb6c537d4bdbfc72d31e6908f51be772/src/common/providers/codeActionProvider.ts#L51-L57

so I did not dare to adjust that and somehow override the request serialization logic to exclude that out of the data sent.
Instead, I have adjusted the the resolve handler so, that it does not error but rather returns the same action back on invalid resolve data.