### PR TITLE
Improve workspace symbol search

### DIFF
--- a/src/common/providers/workspaceSymbolProvider.ts
+++ b/src/common/providers/workspaceSymbolProvider.ts
@@ -9,15 +9,15 @@ import { IProgram } from "../../compiler/program";
 import { SymbolInformationTranslator } from "../util/symbolTranslator";
 
 type SymbolMatch = {
-  position: number,
-  lengthDifference: number,
-  casingDifference: number,
-}
+  position: number;
+  lengthDifference: number;
+  casingDifference: number;
+};
 
 type MatchingSymbol = {
-  match: SymbolMatch,
-  info: SymbolInformation
-}
+  match: SymbolMatch;
+  info: SymbolInformation;
+};
 
 export class WorkspaceSymbolProvider {
   private readonly connection: Connection;
@@ -51,14 +51,17 @@ export class WorkspaceSymbolProvider {
               sourceFile.uri,
               node,
             );
-          
+
           if (symbolInformation) {
-            const symbolMatch = this.matchInSymbol(param.query, symbolInformation.name);
+            const symbolMatch = this.matchInSymbol(
+              param.query,
+              symbolInformation.name,
+            );
             if (symbolMatch !== null) {
               const current = symbolInformationMap.get(sourceFile.uri) || [];
               symbolInformationMap.set(sourceFile.uri, [
                 ...current,
-                {match: symbolMatch, info: symbolInformation},
+                { match: symbolMatch, info: symbolInformation },
               ]);
             }
           }
@@ -75,13 +78,19 @@ export class WorkspaceSymbolProvider {
       });
     });
 
-    return Array.from(symbolInformationMap.values()).flat().sort(this.symbolMatchSorter).map(sm => sm.info);
+    return Array.from(symbolInformationMap.values())
+      .flat()
+      .sort(this.symbolMatchSorter)
+      .map((ms) => ms.info);
   };
 
   // Determines if typed string matches a symbol
   // name. Characters must appear in order.
   // Returns a SymbolMatch on success and null on failure.
-  private matchInSymbol(typedValue: string, symbolName: string): SymbolMatch | null {
+  private matchInSymbol(
+    typedValue: string,
+    symbolName: string,
+  ): SymbolMatch | null {
     const typedLower = typedValue.toLocaleLowerCase();
     const symbolLower = symbolName.toLocaleLowerCase();
     const typedLength = typedLower.length;
@@ -101,21 +110,22 @@ export class WorkspaceSymbolProvider {
     return {
       position: matchPosition,
       lengthDifference: symbolLength - typedLength,
-      casingDifference: symbolName.substring(matchPosition, typedLength) === typedValue ? 0 : 1
-    }
+      casingDifference:
+        symbolName.substring(matchPosition, typedLength) === typedValue ? 0 : 1,
+    };
   }
 
   // Sorter for two matching symbols:
-  // - matches that occured earlier in the target are prioritized
+  // - matches that occurred earlier in the target are prioritized
   // - target strings closer in length to the query go before
   // - if both of these are the same, a case-sensitive match goes first
   private symbolMatchSorter(a: MatchingSymbol, b: MatchingSymbol): number {
     const posDistance = a.match.position - b.match.position;
     if (posDistance !== 0) return posDistance;
-    
+
     const lengthDistance = a.match.lengthDifference - b.match.lengthDifference;
     if (lengthDistance !== 0) return lengthDistance;
-    
+
     return a.match.casingDifference - b.match.casingDifference;
   }
 }


### PR DESCRIPTION
This PR fixes #1335 

The issues I had with the previous implementation:
* It searched `node.text` for the query, this resulted in many irrelevant matches in my experience.
* The resulting array was unsorted, meaning using the workspace symbol picker was rather annoying.

The fixes I did here:
* Switched to first translating the `SyntaxNode` into a `SymbolInformation` and only doing the matching on the `name` inside.
* Traverse `SyntaxNode.namedChildren` instead of `.children`, while I don't know much about TreeSitter, I assume only named children can result in a named match, so it seems to make more sense to restrict traversal to those in this case.
* Instead of returning a boolean on match, an object with data on the quality of the match is returned (`SymbolMatch` type) and it is added to the results.
* At the end, the returned array is sorted using this data.

The sorting isn't very complex:
* If the match occurs early it is sorted early
* If the match is closer to the full length it is sorted earlier
* If all the same, a match that was case-sensitive goes first (so you can have a type `SomeType` and a function `someType` and have the intended match if you use correct casing while querying).