### PR TITLE
Fix not renaming all references

### DIFF
--- a/src/compiler/references.ts
+++ b/src/compiler/references.ts
@@ -1,6 +1,6 @@
 import { IProgram } from "./program";
 import { ISourceFile } from "./forest";
-import { SyntaxNode, Tree } from "web-tree-sitter";
+import { SyntaxNode } from "web-tree-sitter";
 import { TreeUtils } from "../common/util/treeUtils";
 import { Utils } from "../common/util/utils";
 import { Imports } from "./imports";
@@ -809,8 +809,11 @@ export class References {
     return TreeUtils.descendantsOfType(node, "record_base_identifier");
   }
 
-  private static findFieldUsages(tree: Tree, fieldName: string): SyntaxNode[] {
-    return tree.rootNode
+  private static findFieldUsages(
+    sourceFile: ISourceFile,
+    fieldName: string,
+  ): SyntaxNode[] {
+    return sourceFile.tree.rootNode
       .descendantsOfType([
         "field",
         "field_accessor_function_expr",
@@ -825,13 +828,22 @@ export class References {
           );
 
           if (lowerPattern) {
-            const declaration = TreeUtils.findParentOfType(
-              "value_declaration",
-              lowerPattern,
-            );
+            let scope: SyntaxNode | undefined = lowerPattern;
+            while (scope) {
+              const scopeSymbols = sourceFile.symbolLinks?.get(scope);
+              if (
+                scopeSymbols
+                  ?.getAll(fieldName)
+                  ?.some((symbol) => symbol.node.id === lowerPattern.id)
+              ) {
+                break;
+              }
+
+              scope = scope.parent ?? undefined;
+            }
 
             const patternRefs =
-              declaration
+              scope
                 ?.descendantsOfType("value_qid")
                 .filter((ref) => ref.text === fieldName) ?? [];
 
@@ -856,7 +868,7 @@ export class References {
   ): { node: SyntaxNode; uri: string }[] {
     const references: { node: SyntaxNode; uri: string }[] = [];
 
-    const fieldUsages = References.findFieldUsages(sourceFile.tree, fieldName);
+    const fieldUsages = References.findFieldUsages(sourceFile, fieldName);
 
     fieldUsages.forEach((field) => {
       const fieldDef = program

--- a/src/compiler/typeInference.ts
+++ b/src/compiler/typeInference.ts
@@ -1250,9 +1250,6 @@ export class InferenceScope {
     for (const part of e.parts) {
       if (part.nodeType === "Operator") {
         const [type, precedence] = this.inferOperatorAndPrecedence(part);
-        if (type.nodeType !== "Function" || type.params.length < 2) {
-          throw new Error("Could not find operator function");
-        }
 
         if (
           precedence.associativity === "NON" &&
@@ -1263,7 +1260,9 @@ export class InferenceScope {
         }
 
         operatorPrecedences.set(part, precedence);
-        operatorTypes.set(part, type);
+        if (type.nodeType === "Function" && type.params.length >= 2) {
+          operatorTypes.set(part, type);
+        }
 
         lastPrecedence = precedence;
       }
@@ -1285,7 +1284,7 @@ export class InferenceScope {
           const func = operatorTypes.get(binaryTree.operator);
 
           if (!func) {
-            throw new Error("Missing function type for operator");
+            return { start: left.start, end: right.end, type: TUnknown };
           }
 
           const leftAssignable = this.isAssignable(
@@ -2259,11 +2258,33 @@ export class InferenceScope {
         );
       }
 
-      type1.fieldReferences.addAll(type2.fieldReferences);
-      type2.fieldReferences.addAll(type1.fieldReferences);
+      const sharedFieldReferences = this.mergeRecordFieldReferences(
+        type1.fieldReferences,
+        type2.fieldReferences,
+      );
+
+      type1.fieldReferences = sharedFieldReferences;
+      type2.fieldReferences = sharedFieldReferences;
+
+      const sharedAlias = type1.alias ?? type2.alias;
+      type1.alias = type2.alias = sharedAlias;
     }
 
     return result;
+  }
+
+  private mergeRecordFieldReferences(
+    type1FieldReferences: RecordFieldReferenceTable,
+    type2FieldReferences: RecordFieldReferenceTable,
+  ): RecordFieldReferenceTable {
+    // Unified records must keep one shared table instance so later field
+    // references remain visible through every equivalent record value.
+    if (type1FieldReferences.frozen) {
+      return type1FieldReferences.plus(type2FieldReferences);
+    }
+
+    type1FieldReferences.addAll(type2FieldReferences);
+    return type1FieldReferences;
   }
 
   private calculateRecordDiff(

--- a/test/referencesProviderTests/recordFieldReferences.test.ts
+++ b/test/referencesProviderTests/recordFieldReferences.test.ts
@@ -182,6 +182,7 @@ destructure { foo } =
 
     in
     field
+    --X
 `;
     await testBase.testReferences(source);
   });

--- a/test/renameProvider.test.ts
+++ b/test/renameProvider.test.ts
@@ -104,9 +104,11 @@ describe("renameProvider", () => {
 
     Object.entries(result.sources).forEach(([uri, source]) => {
       expect(
-        applyEditsToSource(
-          stripCommentLines(source),
-          renameEdit.changes![Utils.joinPath(srcUri, uri).toString()] ?? [],
+        stripCommentLines(
+          applyEditsToSource(
+            source,
+            renameEdit.changes![Utils.joinPath(srcUri, uri).toString()] ?? [],
+          ),
         ),
       ).toEqual(expectedSources[uri]);
     });

--- a/test/renameProvider.test.ts
+++ b/test/renameProvider.test.ts
@@ -416,4 +416,129 @@ fooBarList =
     await testRename(source, "baz", expectedResult);
   });
 
+  it("Nested record field rename updates chained field access references", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo =
+  { foo : Bar
+  }
+
+
+type alias Bar =
+  { bar : Int }
+  --^
+
+
+getBar : Foo -> Int
+getBar value =
+  value.foo.bar
+
+
+incrementBar : Foo -> Int
+incrementBar value =
+  value.foo.bar + 1
+`;
+
+    const expectedResult = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo =
+  { foo : Bar
+  }
+
+
+type alias Bar =
+  { baz : Int }
+
+
+getBar : Foo -> Int
+getBar value =
+  value.foo.baz
+
+
+incrementBar : Foo -> Int
+incrementBar value =
+  value.foo.baz + 1
+`;
+
+    const renameRange = Range.create(
+      Position.create(8, 4),
+      Position.create(8, 7),
+    );
+
+    await testPrepareRename(source, renameRange);
+    await testRename(source, "baz", expectedResult);
+  });
+
+  it("Nested record field rename updates destructured references", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo =
+  { foo : Bar
+  }
+
+
+type alias Bar =
+  { bar : Int }
+  --^
+
+
+destructureBar : Foo -> Int
+destructureBar { foo } =
+  let
+    { bar } = foo
+  in
+  bar
+
+
+destructureBarAgain : Foo -> Int
+destructureBarAgain { foo } =
+  let
+    { bar } = foo
+  in
+  bar + 1
+`;
+
+    const expectedResult = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo =
+  { foo : Bar
+  }
+
+
+type alias Bar =
+  { baz : Int }
+
+
+destructureBar : Foo -> Int
+destructureBar { foo } =
+  let
+    { baz } = foo
+  in
+  baz
+
+
+destructureBarAgain : Foo -> Int
+destructureBarAgain { foo } =
+  let
+    { baz } = foo
+  in
+  baz + 1
+`;
+
+    const renameRange = Range.create(
+      Position.create(8, 4),
+      Position.create(8, 7),
+    );
+
+    await testPrepareRename(source, renameRange);
+    await testRename(source, "baz", expectedResult);
+  });
 });

--- a/test/renameProvider.test.ts
+++ b/test/renameProvider.test.ts
@@ -364,4 +364,56 @@ foo =
     await testPrepareRename(source, renameRange);
     await testRename(source, "NotOkay", expectedResult);
   });
+
+  it("Nested record field rename doesn't update all list elements", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo =
+    { foo : Bar
+    }
+
+
+type alias Bar =
+    { bar : Int }
+    --^
+
+
+fooBarList : List Foo
+fooBarList =
+    [ { foo = { bar = 0 } }
+    , { foo = { bar = 1 } }
+    ]
+`;
+
+    const expectedResult = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias Foo =
+    { foo : Bar
+    }
+
+
+type alias Bar =
+    { baz : Int }
+
+
+fooBarList : List Foo
+fooBarList =
+    [ { foo = { baz = 0 } }
+    , { foo = { baz = 1 } }
+    ]
+`;
+
+    const renameRange = Range.create(
+      Position.create(8, 6),
+      Position.create(8, 9),
+    );
+
+    await testPrepareRename(source, renameRange);
+    await testRename(source, "baz", expectedResult);
+  });
+
 });


### PR DESCRIPTION
Closes #1476 

Added the case reported in #1476 and some tests regarding nested field access as well which also failed, and a test for a let..in block which also failed.

The fix also caused a new field reference to be found in the recordFieldReferences test suite which is great, so that also verified that these changes work.