### PR TITLE
Modernize filesystem dependencies

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,9 +15,15 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+      - name: Verify release version
+        run: |
+          package_version=$(node -p "require('./package.json').version")
+          test "$package_version" = "$GITHUB_REF_NAME"
       - run: npm ci
+      - run: npm run check
       - run: npm run compile
       - run: npm test
+      - run: npm pack --dry-run
 
   publish-npm:
     needs: build

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,5 +1,6 @@
-- Update the changelog in `CHANGELOG.md`
-- Run `npm run version-patch`, `npm run version-minor` or `npm run version-major`
-- Push the code to github and wait for the CI
-- Create a new release on github
-- Update Nix upstream ([instructions](https://github.com/turboMaCk/nixpkgs/blob/98997bb48997b27287a2995460d2fb6e1db88de7/pkgs/development/compilers/elm/packages/README.md#upgrades))
+1. Update the changelog in `CHANGELOG.md`.
+2. Run `npm run version-patch`, `npm run version-minor`, or `npm run version-major`.
+3. Run `npm run check`, `npm run compile`, `npm test`, and `npm pack --dry-run`.
+4. Push the code to GitHub and wait for CI to pass.
+5. Create a GitHub release whose tag exactly matches the version in `package.json` (for example, `2.9.0`).
+6. Update Nix upstream ([instructions](https://github.com/turboMaCk/nixpkgs/blob/98997bb48997b27287a2995460d2fb6e1db88de7/pkgs/development/compilers/elm/packages/README.md#upgrades)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^3.6.0",
+        "chokidar": "^4.0.3",
         "escape-string-regexp": "^4.0.0",
         "execa": "^5.1.1",
         "fast-diff": "^1.3.0",
-        "globby": "^11.0.4",
         "pjson": "1.0.9",
         "reflect-metadata": "^0.2.2",
         "request-light": "^0.8.0",
@@ -34,7 +33,6 @@
         "@types/node": "^22.20.1",
         "@typescript-eslint/eslint-plugin": "^8.66.0",
         "@typescript-eslint/parser": "^8.66.0",
-        "copyfiles": "^2.4.1",
         "doctoc": "^2.5.0",
         "elm-format": "^0.8.8",
         "eslint": "^10.8.1",
@@ -50,7 +48,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.17.0"
       }
     },
     "node_modules/@avh4/elm-format-darwin-arm64": {
@@ -1589,41 +1587,6 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2576,6 +2539,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2600,15 +2564,6 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/babel-jest": {
@@ -2744,18 +2699,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/boundary": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
@@ -2774,18 +2717,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -2965,27 +2896,18 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -3020,18 +2942,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
     },
     "node_modules/co": {
       "version": "4.6.0",
@@ -3082,64 +2992,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/copyfiles": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
-      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.0.5",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^1.0.4",
-        "noms": "0.0.0",
-        "through2": "^2.0.1",
-        "untildify": "^4.0.0",
-        "yargs": "^16.1.0"
-      },
-      "bin": {
-        "copyfiles": "copyfiles",
-        "copyup": "copyfiles"
-      }
-    },
-    "node_modules/copyfiles/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/copyfiles/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/copyfiles/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3232,18 +3084,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/doctoc": {
@@ -3751,22 +3591,6 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "license": "Apache-2.0"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3780,15 +3604,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fault": {
       "version": "1.0.4",
@@ -3825,18 +3640,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -3927,6 +3730,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4001,18 +3805,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4042,35 +3834,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/graceful-fs": {
@@ -4240,18 +4003,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -4291,6 +4042,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4320,6 +4072,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4337,15 +4090,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -4369,13 +4113,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5654,15 +5391,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromark": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
@@ -5798,19 +5526,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5867,19 +5582,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -6019,17 +5721,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/noms": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
-      }
-    },
     "node_modules/nopt": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
@@ -6050,6 +5741,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6250,15 +5942,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6270,6 +5953,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6428,13 +6112,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6462,26 +6139,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -6498,29 +6155,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reflect-metadata": {
@@ -6644,46 +6289,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -6728,6 +6333,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6783,13 +6389,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -7021,50 +6620,6 @@
         "node": "*"
       }
     },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7119,18 +6674,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/tree-sitter-cli": {
       "version": "0.20.8",
@@ -7494,16 +7037,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
-    "node_modules/untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
@@ -7544,13 +7077,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -7774,16 +7300,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7801,25 +7317,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yargs": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
-      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -7828,16 +7325,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,17 @@
     "out"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.17.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/elm-tooling/elm-language-server"
   },
   "dependencies": {
-    "chokidar": "^3.6.0",
+    "chokidar": "^4.0.3",
     "escape-string-regexp": "^4.0.0",
     "execa": "^5.1.1",
     "fast-diff": "^1.3.0",
-    "globby": "^11.0.4",
     "pjson": "1.0.9",
     "reflect-metadata": "^0.2.2",
     "request-light": "^0.8.0",
@@ -38,7 +37,6 @@
     "@types/node": "^22.20.1",
     "@typescript-eslint/eslint-plugin": "^8.66.0",
     "@typescript-eslint/parser": "^8.66.0",
-    "copyfiles": "^2.4.1",
     "doctoc": "^2.5.0",
     "elm-format": "^0.8.8",
     "eslint": "^10.8.1",
@@ -58,7 +56,7 @@
     "version-minor": "npm --no-git-tag-version version minor",
     "version-major": "npm --no-git-tag-version version major",
     "version": "npm i && npm run compile",
-    "copy-wasm": "copyfiles ./tree-sitter-elm.wasm out",
+    "copy-wasm": "node -e \"const fs=require('node:fs');fs.mkdirSync('out',{recursive:true});fs.copyFileSync('tree-sitter-elm.wasm','out/tree-sitter-elm.wasm')\"",
     "compile": "npm run copy-wasm && tsc -p ./",
     "watch": "npm run copy-wasm && tsc -watch -p ./",
     "typecheck": "tsc --build tsconfig.node.json tsconfig.browser.json --pretty false",

--- a/src/common/providers/codeActionProvider.ts
+++ b/src/common/providers/codeActionProvider.ts
@@ -78,6 +78,24 @@ export interface IRefactorRegistration {
   ): IRefactorEdit;
 }
 
+function isRefactorCodeAction(
+  codeAction: CodeAction,
+): codeAction is IRefactorCodeAction {
+  const data: unknown = codeAction.data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "uri" in data &&
+    typeof data.uri === "string" &&
+    "refactorName" in data &&
+    typeof data.refactorName === "string" &&
+    "actionName" in data &&
+    typeof data.actionName === "string" &&
+    "range" in data &&
+    Range.is(data.range)
+  );
+}
+
 export class CodeActionProvider {
   private connection: Connection;
   private settings: Settings;
@@ -114,8 +132,8 @@ export class CodeActionProvider {
     if (this.settings.isCodeActionResolveSupported("edit")) {
       this.connection.onRequest(
         CodeActionResolveRequest.method,
-        (codeAction: IRefactorCodeAction) => {
-          if (!codeAction.data.uri) {
+        (codeAction: CodeAction): CodeAction | Promise<CodeAction> => {
+          if (!isRefactorCodeAction(codeAction)) {
             return codeAction;
           }
           return new ElmWorkspaceMatcher((codeAction: IRefactorCodeAction) =>

--- a/src/node/fileSystem.ts
+++ b/src/node/fileSystem.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import globby from "globby";
 import util from "util";
 import chokidar from "chokidar";
 import {
@@ -64,21 +63,26 @@ export function createNodeFileSystemHost(
       }
 
       if (realUri.scheme === "file") {
-        const result =
-          depth === 1
-            ? await readDir(realUri.fsPath)
-            : await globby(
-                // Cleanup the path on windows, as globby does not like backslashes
-                Utils.joinPath(realUri, include ?? "**").fsPath.replace(
-                  /\\/g,
-                  "/",
-                ),
-                {
-                  suppressErrors: true,
-                },
-              );
+        if (depth === 1) {
+          return (await readDir(realUri.fsPath)).map((path) => URI.file(path));
+        }
 
-        return result.map((path) => URI.file(path));
+        try {
+          const result: URI[] = [];
+          for await (const entry of fs.promises.glob(include ?? "**", {
+            cwd: realUri.fsPath,
+            withFileTypes: true,
+          })) {
+            if (entry.isFile()) {
+              result.push(
+                Utils.joinPath(URI.file(entry.parentPath), entry.name),
+              );
+            }
+          }
+          return result;
+        } catch {
+          return [];
+        }
       } else {
         const result = await connection.sendRequest(
           ReadDirectoryRequest,
@@ -88,25 +92,24 @@ export function createNodeFileSystemHost(
       }
     },
     readDirectorySync: (uri, include, exclude, depth): URI[] => {
-      const result =
-        depth === 1
-          ? fs.readdirSync(uri.fsPath)
-          : globby.sync(
-              // Cleanup the path on windows, as globby does not like backslashes
-              [
-                ...(include?.map((path) =>
-                  Utils.joinPath(uri, path).fsPath.replace(/\\/g, "/"),
-                ) ?? []),
-                ...(exclude?.map(
-                  (path) =>
-                    `!${Utils.joinPath(uri, path).fsPath.replace(/\\/g, "/")}`,
-                ) ?? []),
-              ],
-              {
-                suppressErrors: true,
-              },
-            );
-      return result.map((path) => URI.file(path));
+      if (depth === 1) {
+        return fs.readdirSync(uri.fsPath).map((path) => URI.file(path));
+      }
+
+      try {
+        return fs
+          .globSync(include ?? [], {
+            cwd: uri.fsPath,
+            exclude,
+            withFileTypes: true,
+          })
+          .filter((entry) => entry.isFile())
+          .map((entry) =>
+            Utils.joinPath(URI.file(entry.parentPath), entry.name),
+          );
+      } catch {
+        return [];
+      }
     },
     fileExists: (uri): boolean =>
       uri.scheme === "file" && fs.existsSync(uri.fsPath),

--- a/test/codeActionResolve.test.ts
+++ b/test/codeActionResolve.test.ts
@@ -1,0 +1,102 @@
+import { mockDeep } from "jest-mock-extended";
+import { container } from "tsyringe";
+import {
+  CodeAction,
+  CodeActionResolveRequest,
+  CancellationTokenSource,
+  Connection,
+  RequestHandler,
+  TextEdit,
+} from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import {
+  CodeActionProvider,
+  IRefactorCodeAction,
+} from "../src/common/providers/codeActionProvider";
+import { DiagnosticsProvider } from "../src/common/providers/diagnostics/diagnosticsProvider";
+import { ElmMakeDiagnostics } from "../src/common/providers/diagnostics/elmMakeDiagnostics";
+import { Settings } from "../src/common/util/settings";
+import { ISourceFile } from "../src/compiler/forest";
+import { IProgram, IProgramHost } from "../src/compiler/program";
+
+describe("code action resolve", () => {
+  let resolveHandler: RequestHandler<CodeAction, CodeAction, void>;
+  let provider: CodeActionProvider;
+
+  beforeEach(() => {
+    const connection = mockDeep<Connection>();
+    const settings = mockDeep<Settings>();
+    settings.isCodeActionResolveSupported.mockReturnValue(true);
+
+    container.register("Connection", { useValue: connection });
+    container.register("Settings", { useValue: settings });
+    container.register(DiagnosticsProvider, {
+      useValue: mockDeep<DiagnosticsProvider>(),
+    });
+    container.register(ElmMakeDiagnostics, {
+      useValue: mockDeep<ElmMakeDiagnostics>(),
+    });
+
+    provider = new CodeActionProvider(mockDeep<IProgramHost>());
+    const registration = (
+      connection.onRequest.mock.calls as unknown as [unknown, unknown][]
+    ).find(([method]) => method === CodeActionResolveRequest.method);
+    if (!registration) {
+      throw new Error("Code action resolve handler was not registered");
+    }
+    resolveHandler = registration[1] as RequestHandler<
+      CodeAction,
+      CodeAction,
+      void
+    >;
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    container.resolve<IProgram[]>("ElmWorkspaces").splice(0);
+  });
+
+  it.each([
+    { title: "No data" },
+    { title: "Unrelated data", data: { fixId: "quick-fix" } },
+  ])("returns $title unchanged", async (codeAction) => {
+    const token = new CancellationTokenSource().token;
+    const result = await Promise.resolve().then(() =>
+      resolveHandler(codeAction, token),
+    );
+    expect(result).toBe(codeAction);
+  });
+
+  it("resolves edits for an Elm refactor action", async () => {
+    const uri = URI.file("/workspace/src/Main.elm").toString();
+    const sourceFile = mockDeep<ISourceFile>({ uri });
+    const program = mockDeep<IProgram>({ isInitialized: true });
+    program.hasDocument.mockReturnValue(true);
+    program.getSourceFile.mockReturnValue(sourceFile);
+    container.resolve<IProgram[]>("ElmWorkspaces").push(program);
+
+    const edit = TextEdit.insert({ line: 0, character: 0 }, "module Main\n");
+    CodeActionProvider.registerRefactorAction("testResolve", {
+      getAvailableActions: () => [],
+      getEditsForAction: () => ({ edits: [edit] }),
+    });
+    const codeAction: IRefactorCodeAction = {
+      title: "Resolve refactor",
+      data: {
+        uri,
+        refactorName: "testResolve",
+        actionName: "apply",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+      },
+    };
+
+    const token = new CancellationTokenSource().token;
+    await expect(resolveHandler(codeAction, token)).resolves.toEqual({
+      ...codeAction,
+      edit: { changes: { [uri]: [edit] } },
+    });
+  });
+});

--- a/test/fileSystem.test.ts
+++ b/test/fileSystem.test.ts
@@ -6,6 +6,10 @@ import { Connection } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { createNodeFileSystemHost } from "../src/node/fileSystem";
 
+function toFileUris(paths: string[]): string[] {
+  return paths.map((filePath) => URI.file(filePath).toString()).sort();
+}
+
 describe("node file system", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "elm-language-server-"));
   const nested = path.join(root, "nested");
@@ -31,8 +35,8 @@ describe("node file system", () => {
   it("recursively reads matching files as absolute file URIs", async () => {
     const result = await host.readDirectory(URI.file(root), "**/*.elm");
 
-    expect(result.map((uri) => uri.fsPath).sort()).toEqual(
-      [ignoredElm, nestedElm, rootElm].sort(),
+    expect(result.map((uri) => uri.toString()).sort()).toEqual(
+      toFileUris([ignoredElm, nestedElm, rootElm]),
     );
     expect(result.every((uri) => uri.scheme === "file")).toBe(true);
   });
@@ -48,8 +52,8 @@ describe("node file system", () => {
       ["ignored/**"],
     );
 
-    expect(result.map((uri) => uri.fsPath).sort()).toEqual(
-      [nestedElm, rootElm].sort(),
+    expect(result.map((uri) => uri.toString()).sort()).toEqual(
+      toFileUris([nestedElm, rootElm]),
     );
   });
 

--- a/test/fileSystem.test.ts
+++ b/test/fileSystem.test.ts
@@ -1,0 +1,62 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { mockDeep } from "jest-mock-extended";
+import { Connection } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import { createNodeFileSystemHost } from "../src/node/fileSystem";
+
+describe("node file system", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "elm-language-server-"));
+  const nested = path.join(root, "nested");
+  const ignored = path.join(root, "ignored");
+  const rootElm = path.join(root, "Root.elm");
+  const nestedElm = path.join(nested, "Nested.elm");
+  const ignoredElm = path.join(ignored, "Ignored.elm");
+  const host = createNodeFileSystemHost(mockDeep<Connection>());
+
+  beforeAll(() => {
+    fs.mkdirSync(nested);
+    fs.mkdirSync(ignored);
+    fs.writeFileSync(rootElm, "module Root exposing (..)");
+    fs.writeFileSync(nestedElm, "module Nested exposing (..)");
+    fs.writeFileSync(ignoredElm, "module Ignored exposing (..)");
+    fs.writeFileSync(path.join(nested, "notes.txt"), "not Elm");
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("recursively reads matching files as absolute file URIs", async () => {
+    const result = await host.readDirectory(URI.file(root), "**/*.elm");
+
+    expect(result.map((uri) => uri.fsPath).sort()).toEqual(
+      [ignoredElm, nestedElm, rootElm].sort(),
+    );
+    expect(result.every((uri) => uri.scheme === "file")).toBe(true);
+  });
+
+  it("applies include and exclude patterns to synchronous reads", () => {
+    if (!host.readDirectorySync) {
+      throw new Error("The Node file system must support synchronous reads");
+    }
+
+    const result = host.readDirectorySync(
+      URI.file(root),
+      ["**/*.elm"],
+      ["ignored/**"],
+    );
+
+    expect(result.map((uri) => uri.fsPath).sort()).toEqual(
+      [nestedElm, rootElm].sort(),
+    );
+  });
+
+  it("returns no recursive matches for a missing directory", async () => {
+    const missing = URI.file(path.join(root, "missing"));
+
+    await expect(host.readDirectory(missing, "**/*.elm")).resolves.toEqual([]);
+    expect(host.readDirectorySync?.(missing, ["**/*.elm"])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Use the stable Node.js glob APIs, move Chokidar to its CommonJS-compatible 4.x line, and remove the copyfiles helper. Raise the Node floor to the release where glob is stable and preserve recursive discovery behavior with focused tests.