### PR TITLE
Show types in completion label details

### DIFF
--- a/src/common/providers/completionProvider.ts
+++ b/src/common/providers/completionProvider.ts
@@ -29,6 +29,7 @@ import escapeStringRegexp from "escape-string-regexp";
 import { TRecord } from "../../compiler/typeInference.js";
 import { ICompletionParams } from "./paramsExtensions.js";
 import { Utils } from "../util/utils.js";
+import { Settings } from "../util/settings.js";
 
 export type CompletionResult =
   CompletionItem[] | CompletionList | null | undefined;
@@ -50,10 +51,12 @@ export class CompletionProvider {
   private qidRegex = /[_\d\p{L}.]+/u;
   private connection: Connection;
   private diagnostics: DiagnosticsProvider;
+  private settings: Settings;
 
   constructor() {
     this.connection = container.resolve<Connection>("Connection");
     this.diagnostics = container.resolve(DiagnosticsProvider);
+    this.settings = container.resolve<Settings>("Settings");
     this.connection.onCompletion(
       this.diagnostics.interruptDiagnostics(() =>
         new ElmWorkspaceMatcher((params: CompletionParams) =>
@@ -481,6 +484,7 @@ export class CompletionProvider {
     const moduleName = importClause
       ? TreeUtils.getModuleNameNodeFromImportClause(importClause)?.text
       : undefined;
+    const checker = program.getTypeChecker();
 
     if (moduleName) {
       const sortPrefix = "c";
@@ -532,6 +536,11 @@ export class CompletionProvider {
                   label: a.name,
                   range,
                   sortPrefix,
+                  labelDetail: this.getTypeLabelDetail(
+                    checker,
+                    a.node,
+                    sourceFile,
+                  ),
                 }),
               ];
           }
@@ -609,6 +618,11 @@ export class CompletionProvider {
               sortPrefix,
               filterText,
               labelDescription,
+              labelDetail: this.getTypeLabelDetail(
+                checker,
+                element.node,
+                sourceFile,
+              ),
             }),
           );
           break;
@@ -620,6 +634,11 @@ export class CompletionProvider {
               sortPrefix,
               filterText,
               labelDescription,
+              labelDetail: this.getTypeLabelDetail(
+                checker,
+                element.node,
+                sourceFile,
+              ),
             }),
           );
           break;
@@ -696,6 +715,11 @@ export class CompletionProvider {
               label: symbol.name,
               range,
               sortPrefix,
+              labelDetail: this.getTypeLabelDetail(
+                checker,
+                symbol.node,
+                sourceFile,
+              ),
             }),
           );
         }
@@ -727,6 +751,11 @@ export class CompletionProvider {
                 label: unionVariant.name,
                 range,
                 sortPrefix,
+                labelDetail: this.getTypeLabelDetail(
+                  checker,
+                  unionVariant.node,
+                  sourceFile,
+                ),
               }),
             );
           });
@@ -803,7 +832,12 @@ export class CompletionProvider {
           );
 
           result.push(
-            this.createFieldOrParameterCompletion(hint, field, range),
+            this.createFieldOrParameterCompletion(
+              hint,
+              field,
+              range,
+              checker.typeToString(recordType.baseType.fields[field]),
+            ),
           );
         }
       }
@@ -814,7 +848,14 @@ export class CompletionProvider {
           recordType.alias?.name ?? "",
         );
 
-        result.push(this.createFieldOrParameterCompletion(hint, field, range));
+        result.push(
+          this.createFieldOrParameterCompletion(
+            hint,
+            field,
+            range,
+            checker.typeToString(recordType.fields[field]),
+          ),
+        );
       }
     }
 
@@ -831,7 +872,12 @@ export class CompletionProvider {
           typeName,
         );
         result.push(
-          this.createFieldOrParameterCompletion(hint, element.field, range),
+          this.createFieldOrParameterCompletion(
+            hint,
+            element.field,
+            range,
+            element.type,
+          ),
         );
       });
     }
@@ -856,7 +902,12 @@ export class CompletionProvider {
         );
 
         result.push(
-          this.createFieldOrParameterCompletion(hint, field, replaceRange),
+          this.createFieldOrParameterCompletion(
+            hint,
+            field,
+            replaceRange,
+            checker.typeToString(foundType.fields[field]),
+          ),
         );
       }
     }
@@ -882,12 +933,14 @@ export class CompletionProvider {
     markdownDocumentation: string | undefined,
     label: string,
     range: Range,
+    type?: string,
   ): CompletionItem {
     return this.createPreselectedCompletion(
       markdownDocumentation,
       CompletionItemKind.Field,
       label,
       range,
+      type && type !== "unknown" ? ` : ${type}` : undefined,
     );
   }
 
@@ -922,6 +975,33 @@ export class CompletionProvider {
     return this.createCompletion(options);
   }
 
+  private getTypeLabelDetail(
+    checker: TypeChecker,
+    node: SyntaxNode,
+    sourceFile: ISourceFile,
+  ): string | undefined {
+    const definitionNode =
+      node.type === "function_declaration_left" && node.parent
+        ? node.parent
+        : node;
+    const type = checker.findType(definitionNode);
+
+    if (type.nodeType !== "Unknown") {
+      const renderedType = checker.typeToString(type, sourceFile);
+      if (!renderedType.includes("unknown")) {
+        return ` : ${renderedType}`;
+      }
+    }
+
+    const typeExpression =
+      definitionNode.type === "port_annotation"
+        ? definitionNode.childForFieldName("typeExpression")
+        : TreeUtils.getTypeAnnotation(definitionNode)?.childForFieldName(
+            "typeExpression",
+          );
+    return typeExpression ? ` : ${typeExpression.text}` : undefined;
+  }
+
   private createCompletion(options: ICompletionOptions): CompletionItem {
     return {
       documentation: options.markdownDocumentation
@@ -937,10 +1017,10 @@ export class CompletionProvider {
       detail: options.detail,
       additionalTextEdits: options.additionalTextEdits,
       filterText: options.filterText,
-      labelDetails: {
-        description: options.labelDescription,
-        detail: options.labelDetail,
-      },
+      labelDetails: this.createLabelDetails(
+        options.labelDescription,
+        options.labelDetail,
+      ),
     };
   }
 
@@ -949,6 +1029,7 @@ export class CompletionProvider {
     kind: CompletionItemKind,
     label: string,
     range: Range,
+    labelDetail?: string,
   ): CompletionItem {
     return {
       documentation: markdownDocumentation
@@ -961,6 +1042,24 @@ export class CompletionProvider {
       label,
       preselect: true,
       textEdit: TextEdit.replace(range, label),
+      labelDetails: this.createLabelDetails(undefined, labelDetail),
+    };
+  }
+
+  private createLabelDetails(
+    description?: string,
+    detail?: string,
+  ): CompletionItem["labelDetails"] {
+    if (
+      !this.settings.isCompletionLabelDetailsSupported() ||
+      (!description && !detail)
+    ) {
+      return undefined;
+    }
+
+    return {
+      ...(description ? { description } : {}),
+      ...(detail ? { detail } : {}),
     };
   }
 
@@ -987,6 +1086,11 @@ export class CompletionProvider {
               label: symbol.name,
               range,
               sortPrefix: sortPrefix,
+              labelDetail: this.getTypeLabelDetail(
+                checker,
+                symbol.node,
+                sourceFile,
+              ),
             }),
           );
         }
@@ -1001,6 +1105,11 @@ export class CompletionProvider {
             label: symbol.name,
             range,
             sortPrefix,
+            labelDetail: this.getTypeLabelDetail(
+              checker,
+              symbol.node,
+              sourceFile,
+            ),
           }),
         );
       }
@@ -1017,6 +1126,11 @@ export class CompletionProvider {
             label: symbol.name,
             range,
             sortPrefix,
+            labelDetail: this.getTypeLabelDetail(
+              checker,
+              symbol.node,
+              sourceFile,
+            ),
           }),
         );
 
@@ -1035,6 +1149,7 @@ export class CompletionProvider {
                 hint,
                 `${symbol.name}.${field}`,
                 range,
+                checker.typeToString(parameterType.fields[field]),
               ),
             );
           }
@@ -1125,6 +1240,8 @@ export class CompletionProvider {
     filterText: string,
   ): { list: CompletionItem[]; isIncomplete: boolean } {
     const result: CompletionItem[] = [];
+    const sourceFile = program.getSourceFile(uri);
+    const checker = program.getTypeChecker();
     const possibleImports = this.getPossibleImportsFiltered(
       program,
       uri,
@@ -1157,7 +1274,18 @@ export class CompletionProvider {
         possibleImport.type === "Function" ||
         possibleImport.type === "Port"
       ) {
-        result.push(this.createFunctionCompletion(completionOptions));
+        result.push(
+          this.createFunctionCompletion({
+            ...completionOptions,
+            labelDetail: sourceFile
+              ? this.getTypeLabelDetail(
+                  checker,
+                  possibleImport.node,
+                  sourceFile,
+                )
+              : undefined,
+          }),
+        );
       } else if (possibleImport.type === "TypeAlias") {
         result.push(this.createTypeAliasCompletion(completionOptions));
       } else if (possibleImport.type === "Type") {
@@ -1171,6 +1299,13 @@ export class CompletionProvider {
             detail,
             additionalTextEdits: importTextEdit ? [importTextEdit] : undefined,
             labelDescription: possibleImport.module,
+            labelDetail: sourceFile
+              ? this.getTypeLabelDetail(
+                  checker,
+                  possibleImport.node,
+                  sourceFile,
+                )
+              : undefined,
           }),
         );
       }
@@ -1306,7 +1441,12 @@ export class CompletionProvider {
         switch (value.type) {
           case "Function":
           case "Port":
-            result.push(this.createFunctionCompletion(completionOptions));
+            result.push(
+              this.createFunctionCompletion({
+                ...completionOptions,
+                labelDetail: ` : ${typeString}`,
+              }),
+            );
             break;
           case "Type":
             result.push(this.createTypeCompletion(completionOptions));
@@ -1316,7 +1456,10 @@ export class CompletionProvider {
             break;
           case "UnionConstructor":
             result.push(
-              this.createUnionConstructorCompletion(completionOptions),
+              this.createUnionConstructorCompletion({
+                ...completionOptions,
+                labelDetail: ` : ${typeString}`,
+              }),
             );
             break;
         }

--- a/src/common/util/settings.ts
+++ b/src/common/util/settings.ts
@@ -83,4 +83,11 @@ export class Settings {
     }
     return value;
   }
+
+  public isCompletionLabelDetailsSupported(): boolean {
+    return (
+      this.clientCapabilities.textDocument?.completion?.completionItem
+        ?.labelDetailsSupport === true
+    );
+  }
 }

--- a/test/completionProvider.test.ts
+++ b/test/completionProvider.test.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "util";
 import {
+  ClientCapabilities,
   CompletionContext,
   CompletionItem,
   Position,
@@ -11,8 +12,10 @@ import {
   CompletionResult,
 } from "../src/common/providers/index.js";
 import { ICompletionParams } from "../src/common/providers/paramsExtensions.js";
+import { Settings } from "../src/common/util/settings.js";
 import { getCaretPositionFromSource } from "./utils/sourceParser.js";
 import { baseUri, SourceTreeParser, srcUri } from "./utils/sourceTreeParser.js";
+import { container } from "tsyringe";
 
 class MockCompletionProvider extends CompletionProvider {
   public handleCompletion(params: ICompletionParams): CompletionResult {
@@ -43,8 +46,19 @@ describe("CompletionProvider", () => {
     )[],
     testExactCompletions: exactCompletions = "partialMatch",
     testDotCompletion: dotCompletions = "normal",
+    labelDetailsSupport = true,
   ) {
     await treeParser.init();
+    const clientCapabilities: ClientCapabilities = labelDetailsSupport
+      ? {
+          textDocument: {
+            completion: { completionItem: { labelDetailsSupport: true } },
+          },
+        }
+      : {};
+    container.register("Settings", {
+      useValue: new Settings({} as never, clientCapabilities),
+    });
     const completionProvider = new MockCompletionProvider();
 
     const { newSources, position, fileWithCaret } =
@@ -130,12 +144,14 @@ describe("CompletionProvider", () => {
             return (
               c.label === completion.label &&
               c.detail === completion.detail &&
-              c.additionalTextEdits &&
-              completion.additionalTextEdits &&
-              isDeepStrictEqual(
-                c.additionalTextEdits[0],
-                completion.additionalTextEdits[0],
-              )
+              (!completion.additionalTextEdits ||
+                (c.additionalTextEdits &&
+                  isDeepStrictEqual(
+                    c.additionalTextEdits[0],
+                    completion.additionalTextEdits[0],
+                  ))) &&
+              (!("labelDetails" in completion) ||
+                isDeepStrictEqual(c.labelDetails, completion.labelDetails))
             );
           }
         });
@@ -192,7 +208,11 @@ describe("CompletionProvider", () => {
 {-caret-}
   ""
     `;
-    await testCompletions(sourceModule, ["module"], "partialMatch");
+    await testCompletions(
+      sourceModule,
+      [{ label: "module", labelDetails: undefined }],
+      "partialMatch",
+    );
 
     const sourceModule2 = `
 --@ Test.elm
@@ -422,6 +442,25 @@ test param =
     await testCompletions(source2, ["val"]);
   });
 
+  it("Local values should have type label details", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type Name = Name
+
+value : Name
+value = Name
+
+test =
+  v{-caret-}
+`;
+
+    await testCompletions(source, [
+      { label: "value", labelDetails: { detail: " : Name" } },
+    ]);
+  });
+
   it("Imported values should have completions", async () => {
     const otherSource = `
 --@ OtherModule.elm
@@ -458,7 +497,13 @@ test param =
 `;
 
     await testCompletions(otherSource + source, [
-      "testFunction",
+      {
+        label: "testFunction",
+        labelDetails: {
+          detail: " : String",
+          description: "OtherModule",
+        },
+      },
       "OtherModule.testFunction",
     ]);
 
@@ -716,6 +761,10 @@ testFunc =
       {
         label: "testFunction",
         detail: "Auto import from module 'OtherModule'",
+        labelDetails: {
+          detail: " : String",
+          description: "OtherModule",
+        },
         additionalTextEdits: [
           TextEdit.insert(
             Position.create(1, 0),
@@ -804,6 +853,36 @@ testFunc =
     ]);
   });
 
+  it("Omits label details when the client does not support them", async () => {
+    const source = `
+--@ OtherModule.elm
+module OtherModule exposing (testFunction)
+
+testFunction : String
+testFunction = ""
+
+--@ Test.elm
+module Test exposing (..)
+
+test =
+  {-caret-}
+`;
+
+    await testCompletions(
+      source,
+      [
+        {
+          label: "testFunction",
+          detail: "Auto import from module 'OtherModule'",
+          labelDetails: undefined,
+        },
+      ],
+      "partialMatch",
+      "normal",
+      false,
+    );
+  });
+
   it("Imported modules should have fully qualified completions", async () => {
     const source = `
 --@ Data/User.elm
@@ -876,7 +955,11 @@ testFunction = ""
 
     await testCompletions(
       source,
-      ["Away", "Home", "Page"],
+      [
+        { label: "Away", labelDetails: { detail: " : Page.Page" } },
+        { label: "Home", labelDetails: { detail: " : Page.Page" } },
+        "Page",
+      ],
       "exactMatch",
       "triggeredByDot",
     );
@@ -2028,19 +2111,24 @@ port fbar : (String -> msg) -> Sub msg
 --@ Test.elm
 module Test exposing (..)
 
+type Name = Name
+
 type alias Model =
-  { prop1: String
-  , prop2: Int
+  { prop1: Name
+  , prop2: Name
   }
 
-view : Model -> String
+view : Model -> Name
 view model =
     m{-caret-}
 `;
 
     await testCompletions(
       source,
-      ["model.prop1", "model.prop2"],
+      [
+        { label: "model.prop1", labelDetails: { detail: " : Name" } },
+        { label: "model.prop2", labelDetails: { detail: " : Name" } },
+      ],
       "partialMatch",
     );
   });


### PR DESCRIPTION
Populate completion label details from inferred or declared types while preserving module descriptions. Only send label details to clients that advertise support.

Closes #1499