### PR TITLE
Adopt LSP virtual document content support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Supports Elm 0.19 and up
 | workspaceSymbols | Identifies all symbols in the current workspace                                                                                                      |
 | selectionRange   | Enables navigation by selectionRange (extend selection for e.g.)                                                                                     |
 
+Virtual Elm package files use the LSP 3.18 `workspace/textDocumentContent` request when the client advertises support. Implementations include [vscode-languageclient 10](https://github.com/microsoft/vscode-languageserver-node/blob/main/client/src/common/textDocumentContent.ts), [coc.nvim](https://github.com/neoclide/coc.nvim/blob/master/src/language-client/textDocumentContent.ts), and [Sublime LSP 2.13](https://github.com/sublimelsp/LSP/blob/4070-2.13.0/docs/src/client_configuration.md). Elm clients that do not support the standard request can continue to use `elm/provideFileContents` during the migration.
+
 ## Server Settings
 
 This server contributes the following settings:

--- a/src/common/capabilityCalculator.ts
+++ b/src/common/capabilityCalculator.ts
@@ -43,6 +43,13 @@ export class CapabilityCalculator {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       workspaceSymbolProvider: true,
       workspace: {
+        ...(this.clientCapabilities.workspace?.textDocumentContent
+          ? {
+              textDocumentContent: {
+                schemes: ["elm-virtual-file"],
+              },
+            }
+          : {}),
         fileOperations: {
           didCreate: {
             filters: [

--- a/src/common/providers/virtualFileProvider.ts
+++ b/src/common/providers/virtualFileProvider.ts
@@ -3,17 +3,23 @@ import { Connection } from "vscode-languageserver";
 import { ProvideFileContentsRequest } from "../protocol.js";
 import { ElmWorkspaceMatcher } from "../util/elmWorkspaceMatcher.js";
 import { URI } from "vscode-uri";
+import { Settings } from "../util/settings.js";
 
 export class VirtualFileProvider {
   constructor() {
     const connection = container.resolve<Connection>("Connection");
-    connection.onRequest(
-      ProvideFileContentsRequest,
-      new ElmWorkspaceMatcher((params: { uri: string }) =>
-        URI.parse(params.uri),
-      ).handle(({ sourceFile }) => {
-        return sourceFile.tree.rootNode.text;
-      }),
-    );
+    const settings = container.resolve<Settings>("Settings");
+    const provideContent = new ElmWorkspaceMatcher((params: { uri: string }) =>
+      URI.parse(params.uri),
+    ).handle(({ sourceFile }) => sourceFile.tree.rootNode.text);
+
+    // TODO: Remove this custom request after Elm clients migrate to LSP 3.18.
+    connection.onRequest(ProvideFileContentsRequest, provideContent);
+
+    if (settings.isTextDocumentContentSupported()) {
+      connection.workspace.textDocumentContent.on(async (params, token) => ({
+        text: await provideContent(params, token),
+      }));
+    }
   }
 }

--- a/src/common/util/settings.ts
+++ b/src/common/util/settings.ts
@@ -90,4 +90,8 @@ export class Settings {
         ?.labelDetailsSupport === true
     );
   }
+
+  public isTextDocumentContentSupported(): boolean {
+    return this.clientCapabilities.workspace?.textDocumentContent !== undefined;
+  }
 }

--- a/test/capabilityCalculator.test.ts
+++ b/test/capabilityCalculator.test.ts
@@ -1,0 +1,19 @@
+import { CapabilityCalculator } from "../src/common/capabilityCalculator.js";
+
+describe("CapabilityCalculator", () => {
+  it("advertises virtual document content to supporting clients", () => {
+    const capabilities = new CapabilityCalculator({
+      workspace: { textDocumentContent: {} },
+    }).capabilities;
+
+    expect(capabilities.workspace?.textDocumentContent).toEqual({
+      schemes: ["elm-virtual-file"],
+    });
+  });
+
+  it("does not advertise virtual document content to other clients", () => {
+    const capabilities = new CapabilityCalculator({}).capabilities;
+
+    expect(capabilities.workspace?.textDocumentContent).toBeUndefined();
+  });
+});

--- a/test/virtualFileProvider.test.ts
+++ b/test/virtualFileProvider.test.ts
@@ -1,0 +1,73 @@
+import { mockDeep } from "jest-mock-extended";
+import { container } from "tsyringe";
+import {
+  CancellationTokenSource,
+  Connection,
+  RequestHandler,
+} from "vscode-languageserver";
+import { VirtualFileProvider } from "../src/common/providers/virtualFileProvider.js";
+import { Settings } from "../src/common/util/settings.js";
+import { ISourceFile } from "../src/compiler/forest.js";
+import { IProgram } from "../src/compiler/program.js";
+
+describe("VirtualFileProvider", () => {
+  it("serves virtual Elm source through the standard request", async () => {
+    const connection = mockDeep<Connection>();
+    const settings = mockDeep<Settings>();
+    settings.isTextDocumentContentSupported.mockReturnValue(true);
+    const uri = "elm-virtual-file://package/elm/core/1.0.0/src/Basics.elm";
+    const sourceFile = {
+      tree: { rootNode: { text: "module Basics exposing (..)" } },
+    } as ISourceFile;
+    const program = mockDeep<IProgram>({ isInitialized: true });
+    program.hasDocument.mockReturnValue(true);
+    program.getSourceFile.mockReturnValue(sourceFile);
+
+    container.register("Connection", { useValue: connection });
+    container.register("Settings", { useValue: settings });
+    container.register("ElmWorkspaces", { useValue: [program] });
+
+    new VirtualFileProvider();
+
+    const handler =
+      connection.workspace.textDocumentContent.on.mock.calls[0][0];
+    const token = new CancellationTokenSource().token;
+
+    await expect(handler({ uri }, token)).resolves.toEqual({
+      text: "module Basics exposing (..)",
+    });
+  });
+
+  it("keeps the custom request as a fallback", async () => {
+    const connection = mockDeep<Connection>();
+    const settings = mockDeep<Settings>();
+    settings.isTextDocumentContentSupported.mockReturnValue(false);
+    const uri = "elm-virtual-file://package/elm/core/1.0.0/src/Basics.elm";
+    const sourceFile = {
+      tree: { rootNode: { text: "module Basics exposing (..)" } },
+    } as ISourceFile;
+    const program = mockDeep<IProgram>({ isInitialized: true });
+    program.hasDocument.mockReturnValue(true);
+    program.getSourceFile.mockReturnValue(sourceFile);
+
+    container.register("Connection", { useValue: connection });
+    container.register("Settings", { useValue: settings });
+    container.register("ElmWorkspaces", { useValue: [program] });
+
+    new VirtualFileProvider();
+
+    expect(connection.workspace.textDocumentContent.on.mock.calls).toHaveLength(
+      0,
+    );
+    const handler = connection.onRequest.mock.calls[0][1] as RequestHandler<
+      { uri: string },
+      string,
+      void
+    >;
+    const token = new CancellationTokenSource().token;
+
+    await expect(handler({ uri }, token)).resolves.toBe(
+      "module Basics exposing (..)",
+    );
+  });
+});


### PR DESCRIPTION
Advertise and handle workspace/textDocumentContent for capable clients while retaining the Elm-specific request during migration.

Closes #1497