### PR TITLE
Offer inferred annotations without lint diagnostics

### DIFF
--- a/src/common/providers/codeAction/addTypeAnnotationCodeAction.ts
+++ b/src/common/providers/codeAction/addTypeAnnotationCodeAction.ts
@@ -67,12 +67,17 @@ CodeActionProvider.registerRefactorAction(refactorName, {
       params.sourceFile.tree.rootNode,
       params.range.start,
     );
+    const hasMissingTypeAnnotationDiagnostic = params.context.diagnostics.some(
+      (diagnostic) =>
+        (diagnostic.data as { code?: string } | undefined)?.code ===
+        Diagnostics.MissingTypeAnnotation.code,
+    );
 
     if (
       nodeAtPosition.parent?.type === "function_declaration_left" &&
-      TreeUtils.findParentOfType("let_in_expr", nodeAtPosition) &&
       nodeAtPosition.parent.parent &&
-      !TreeUtils.getTypeAnnotation(nodeAtPosition.parent.parent)
+      !TreeUtils.getTypeAnnotation(nodeAtPosition.parent.parent) &&
+      !hasMissingTypeAnnotationDiagnostic
     ) {
       return [
         {

--- a/test/codeActionTests/addTypeAnnotationCodeAction.test.ts
+++ b/test/codeActionTests/addTypeAnnotationCodeAction.test.ts
@@ -1,4 +1,5 @@
 import { testCodeAction } from "./codeActionTestBase.js";
+import { CodeActionKind } from "vscode-languageserver";
 
 describe("add type annotation code action", () => {
   it("should annotate a type of functions", async () => {
@@ -35,5 +36,59 @@ hello =
       [{ title: "Add inferred annotation" }],
       expectedSource,
     );
+  });
+
+  it("offers a refactor for top-level functions", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+hello =
+--^
+    "hello"
+`;
+
+    const expectedSource = `
+--@ Test.elm
+module Test exposing (..)
+
+hello : String
+hello =
+    "hello"
+`;
+
+    await testCodeAction(
+      source,
+      [
+        {
+          title: "Add inferred annotation",
+          kind: CodeActionKind.RefactorExtract,
+        },
+      ],
+      expectedSource,
+      { includeDiagnostics: false },
+    );
+  });
+
+  it("does not duplicate the action when the diagnostic is enabled", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+hello =
+--^
+    "hello"
+`;
+
+    const actions = await testCodeAction(source, [
+      {
+        title: "Add inferred annotation",
+        kind: CodeActionKind.QuickFix,
+      },
+    ]);
+
+    expect(
+      actions.filter(({ title }) => title === "Add inferred annotation"),
+    ).toHaveLength(1);
   });
 });

--- a/test/codeActionTests/codeActionTestBase.ts
+++ b/test/codeActionTests/codeActionTestBase.ts
@@ -27,7 +27,7 @@ import { diff } from "jest-diff";
 import { expect } from "@jest/globals";
 
 function codeActionEquals(a: CodeAction, b: CodeAction): boolean {
-  return a.title === b.title;
+  return a.title === b.title && (a.kind === undefined || a.kind === b.kind);
 }
 
 const basicsSources = `
@@ -79,8 +79,11 @@ export async function testCodeAction(
   source: string,
   expectedCodeActions: CodeAction[],
   expectedResultAfterEdits?: string,
-  testFixAll = false,
-): Promise<void> {
+  {
+    testFixAll = false,
+    includeDiagnostics = true,
+  }: { testFixAll?: boolean; includeDiagnostics?: boolean } = {},
+): Promise<CodeAction[]> {
   const treeParser = new SourceTreeParser();
   await treeParser.init();
   const codeActionProvider = new MockCodeActionsProvider();
@@ -125,16 +128,18 @@ export async function testCodeAction(
       range: result.range,
       textDocument: { uri: testUri },
       context: {
-        diagnostics: [
-          ...program.getSyntacticDiagnostics(sourceFile),
-          ...program.getSemanticDiagnostics(sourceFile),
-          ...program.getSuggestionDiagnostics(sourceFile),
-          ...new ElmLsDiagnostics()
-            .createDiagnostics(sourceFile, program)
-            .map(convertToCompilerDiagnostic),
-        ]
-          .filter((diag) => Utils.rangeOverlaps(diag.range, result.range))
-          .map(convertFromCompilerDiagnostic),
+        diagnostics: includeDiagnostics
+          ? [
+              ...program.getSyntacticDiagnostics(sourceFile),
+              ...program.getSemanticDiagnostics(sourceFile),
+              ...program.getSuggestionDiagnostics(sourceFile),
+              ...new ElmLsDiagnostics()
+                .createDiagnostics(sourceFile, program)
+                .map(convertToCompilerDiagnostic),
+            ]
+              .filter((diag) => Utils.rangeOverlaps(diag.range, result.range))
+              .map(convertFromCompilerDiagnostic)
+          : [],
       },
     }) ?? [];
 
@@ -154,7 +159,7 @@ export async function testCodeAction(
     );
 
     const filteredCodeActions = codeActions.filter((codeAction) =>
-      expectedCodeActions.find((c) => codeActionEquals(codeAction, c)),
+      expectedCodeActions.find((c) => codeActionEquals(c, codeAction)),
     );
 
     if (filteredCodeActions.length === 0) {
@@ -176,4 +181,6 @@ export async function testCodeAction(
       }
     });
   }
+
+  return codeActions;
 }


### PR DESCRIPTION
Expose the existing annotation refactor for top-level functions when the MissingTypeAnnotation diagnostic is disabled, while avoiding duplicate actions when the quick fix is available.

Closes #827