### PR TITLE
Preserve aliases during record unification

### DIFF
--- a/src/compiler/typeInference.ts
+++ b/src/compiler/typeInference.ts
@@ -2266,8 +2266,11 @@ export class InferenceScope {
       type1.fieldReferences = sharedFieldReferences;
       type2.fieldReferences = sharedFieldReferences;
 
-      const sharedAlias = type1.alias ?? type2.alias;
-      type1.alias = type2.alias = sharedAlias;
+      if (!type1.alias) {
+        type1.alias = type2.alias;
+      } else if (!type2.alias) {
+        type2.alias = type1.alias;
+      }
     }
 
     return result;

--- a/test/diagnosticTests/elmDiagnostics.test.ts
+++ b/test/diagnosticTests/elmDiagnostics.test.ts
@@ -140,6 +140,32 @@ concat comparators a b =
     await testTypeInference(basicsSources + source, []);
   });
 
+  test("fully applied type alias used through another alias", async () => {
+    const source = `
+--@ Test.elm
+module Test exposing (..)
+
+type alias A a =
+    { val : a }
+
+createA : a -> A a
+createA a =
+    { val = a }
+
+type alias C =
+    A Int
+
+createC : Int -> C
+createC a =
+    createA a
+
+useC : C -> ()
+useC _ =
+    ()
+`;
+    await testTypeInference(basicsSources + source, []);
+  });
+
   test("missing import", async () => {
     const source = `
 --@ Test.elm


### PR DESCRIPTION
Keep distinct named aliases from overwriting each other when their record types unify. This prevents cached aliases from acquiring the wrong type-argument count.

Refs elm-tooling/elm-language-client-vscode#922